### PR TITLE
Build fix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -23,7 +23,11 @@ pub fn build(b: *std.Build) !void {
     });
     const sdl_dep_lib = sdl_dep.artifact("SDL3");
 
-    const sdl3 = b.addModule("sdl3", .{ .root_source_file = cfg.root_source_file });
+    const sdl3 = b.addModule("sdl3", .{
+        .root_source_file = cfg.root_source_file,
+        .target = target,
+        .optimize = optimize,
+    });
     const main_callbacks = b.option(bool, "callbacks", "Enable SDL callbacks rather than use a main function") orelse false;
     if (main_callbacks)
     {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
-    .version = "0.0.0",
+    .version = "0.0.1",
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything

--- a/template/build.zig
+++ b/template/build.zig
@@ -13,8 +13,6 @@ pub fn build(b: *std.Build) void {
 
     const sdl3 = b.dependency("sdl3", .{});
     exe.root_module.addImport("sdl3", sdl3.module("sdl3"));
-    exe.linkSystemLibrary("SDL3");
-    exe.linkLibC();
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);


### PR DESCRIPTION
Build file didn't support X-compiling. Also doesn't work on archlinux (Cuz of some issues). Additionally, this had a dependency to [castholm's SDL](https://github.com/castholm/SDL) build witch it wasn't using for the module. Which made it a bit of a ghost requirement.

Finally, this didn't work out of the  box.. Couldn't just use `exe.
```zig
   const sdl3_package = b.dependency("sdl3", .{
        .target = target,
        .optimize = optimize,
    });
    const sdl3_module = sdl3_package.module("sdl3");
    exe.addImport("sdl3", sdl3_module);
```
As it requires a link to an SDL3 package to work.

This fixes that issue by have zig-sdl3 actually use castholm's SDL library... This allows for static or dynamic linkage pased on the user's desire. 

It also allows cross compiling. And makes this package work out of the box on any system that has zig installed, without requiring the consumer to play hidden dependency wack-a-mole.