### PR TITLE
Point function for casting

### DIFF
--- a/src/rect.zig
+++ b/src/rect.zig
@@ -15,6 +15,53 @@ pub fn Point(comptime Type: type) type {
         x: Type,
         y: Type,
 
+        /// Get this as a different type of point.
+        ///
+        /// ## Function Parameters
+        /// * `self`: Point to convert.
+        /// * `NewType`: New underlying type to use for values in the point.
+        ///
+        /// ## Return Value
+        /// Returns a new point with each member casted to the new type.
+        pub fn asOtherPoint(
+            self: Self,
+            comptime NewType: type,
+        ) Point(NewType) {
+            const self_int = switch (@typeInfo(Type)) {
+                .int, .comptime_int => true,
+                else => false,
+            };
+            const new_int = switch (@typeInfo(NewType)) {
+                .int, .comptime_int => true,
+                else => false,
+            };
+            if (self_int) {
+                if (new_int) {
+                    return .{
+                        .x = @as(NewType, @intCast(self.x)),
+                        .y = @as(NewType, @intCast(self.y)),
+                    };
+                } else {
+                    return .{
+                        .x = @as(NewType, @floatFromInt(self.x)),
+                        .y = @as(NewType, @floatFromInt(self.y)),
+                    };
+                }
+            } else {
+                if (new_int) {
+                    return .{
+                        .x = @as(NewType, @intFromFloat(self.x)),
+                        .y = @as(NewType, @intFromFloat(self.y)),
+                    };
+                } else {
+                    return .{
+                        .x = @as(NewType, @floatCast(self.x)),
+                        .y = @as(NewType, @floatCast(self.y)),
+                    };
+                }
+            }
+        }
+
         /// From an SDL point.
         fn fromSdlFPoint(self: C.SDL_FPoint) Self {
             return .{


### PR DESCRIPTION
I wanted to cast an IPoint to FPoint and realized there is no function to do so unlike with the rectangles.
i simply copied the Rect function and adjusted it to fit Point casting.