### PR TITLE
Add some window / mouse events and fix some issues

### DIFF
--- a/src/gpu.zig
+++ b/src/gpu.zig
@@ -500,7 +500,7 @@ pub const ColorTargetInfo = extern struct {
     store: StoreOperation = .store,
     /// The texture that will receive the results of a multisample resolve operation.
     /// Ignored if a `gpu.StoreOperation.resolve` for `store` is not used.
-    resolve_texture: Texture = .{ .value = undefined },
+    resolve_texture: Texture = .{ .value = null },
     /// The mip level of the resolve texture to use for the resolve operation.
     /// Ignored if a `gpu.StoreOperation.resolve` for `store` is not used.
     resolve_mip_level: u32 = 0,
@@ -1299,6 +1299,7 @@ pub const ComputePipelineCreateInfo = struct {
         return .{
             .code = self.code.ptr,
             .code_size = self.code.len,
+            .entrypoint = self.entry_point,
             .format = ShaderFormatFlags.toSdl(self.format),
             .num_samplers = self.num_samplers,
             .num_readonly_storage_textures = self.num_readonly_storage_textures,
@@ -4029,7 +4030,7 @@ pub const SwapchainComposition = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Texture = packed struct {
-    value: *C.SDL_GPUTexture,
+    value: ?*C.SDL_GPUTexture,
 };
 
 /// A structure specifying the parameters of a texture.

--- a/src/mouse.zig
+++ b/src/mouse.zig
@@ -31,6 +31,16 @@ const video = @import("video.zig");
 /// This datatype is available since SDL 3.2.6.
 pub const MotionTransformCallback = *const fn (user_data: ?*anyopaque, timestamp: u64, window: ?*C.SDL_Window, id: C.SDL_MouseID, x: ?*f32, y: ?*f32) callconv(.C) void;
 
+/// Enum identifying mouse buttons
+pub const Button = enum(c_int) {
+    left = C.SDL_BUTTON_LEFT,
+    middle = C.SDL_BUTTON_MIDDLE,
+    right = C.SDL_BUTTON_RIGHT,
+    x1 = C.SDL_BUTTON_X1,
+    x2 = C.SDL_BUTTON_X2,
+    _,
+};
+
 /// A bitmask of pressed mouse buttons, as reported by `mouse.getState()`, etc.
 ///
 /// ## Version

--- a/src/render.zig
+++ b/src/render.zig
@@ -366,7 +366,7 @@ pub const Renderer = struct {
     /// Get the drawing area for the current target.
     pub fn getViewport(
         self: Renderer,
-    ) ?rect.Rect {
+    ) !rect.IRect {
         var viewport: C.SDL_Rect = undefined;
         const ret = C.SDL_GetRenderViewport(
             self.value,
@@ -374,7 +374,7 @@ pub const Renderer = struct {
         );
         if (!ret)
             return error.SdlError;
-        return rect.Rect.fromSdl(viewport);
+        return rect.IRect.fromSdl(viewport);
     }
 
     /// Return whether an explicit rectangle was set as the viewport.


### PR DESCRIPTION
Includes changes and missing features I needed for my project, which is why everything is a single commit.
About the `resolve_texture`: The Vulkan backend still reads it, regardless of the specified store operation and expects it to be null when unused.

I've seen #64 also implements some mouse events which I didn't know existed while implementing mine, so up to you how you handle this, but I choose to still upstream since it also inlcudes other features / fixes.