### PR TITLE
Change C Calling Convention from C to c

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,47 @@
-# zig-sdl3
+zig-sdl3
+========
 
 A lightweight wrapper to zig-ify SDL3.
 
-Note: This is not production ready and currently in development!
-I'm hoping to be done soon, great progress has been made so far!
-See the [checklist](checklist.md) for more details on progress.
+> [!WARNING]
+> This is not production ready and currently in development!
+> I'm hoping to be done soon, great progress has been made so far!
+> See the [checklist](checklist.md) for more details on progress.
 
-## Documentation
+# Documentation
 [https://gota7.github.io/zig-sdl3/](https://gota7.github.io/zig-sdl3/)
 
-## About
+# About
 
 This library aims to unite the power of SDL3 with general zigisms to feel right at home alongside the zig standard library.
 SDL3 is compatible with many different platforms, making it the perfect library to pair with zig.
 Some advantages of SDL3 include windowing, audio, gamepad, keyboard, mouse, rendering, and GPU abstractions across all supported platforms.
 
-## Structure
+# Building and using
 
-### Source
-The `src` folder was originally generated via a binding generator, but manually perfecting and testing the subsystems was found to be more productive.
-Each source file must also call each function at least once in testing if possible to ensure compilation is successful.
+Download and add zig-sdl3 as a dependency by running the following command in your project root:
 
-### Examples
+```sh
+zig fetch --save git+https://github.com/Gota7/zig-sdl3#master
+```
 
-The `examples` directory has some example programs utilizing SDL3.
-All examples may be built with `zig build examples`, or a single example can be ran with `zig build run -Dexample=<example name>`.
+Then add zig-sdl3 as a dependency and import its modules and artifact in your `build.zig`:
 
-### Template
+```sh
+const sdl3 = b.dependency("sdl3", .{
+    .target = target,
+    .optimize = optimize,
+    .callbacks = false,
+    .ext_image = true,
+});
+```
+Now add the modules and artifact to your target as you would normally:
 
-The `template` directory contains a sample hello world to get started using SDL3.
-Simply copy this folder to use as your project, and have fun!
+```sh
+lib.root_module.addImport("sdl3", sdl3.module("sdl3"));
+```
 
-### Tests
-Tests for the library can be ran by running `zig build test`.
-
-## Features
-
-* SDL subsystems are divided into convenient namespaces.
-* Functions that can fail have the return wrapped with an error type and can even call a custom error callback.
-* C namespace exporting raw SDL functions in case it is ever needed.
-* Standard `init` and `deinit` functions for creating and destroying resources.
-* Skirts around C compat weirdness when possible (C pointers, anyopaque, C types).
-* Naming and conventions are more consistent with zig.
-* Functions return values rather than write to pointers.
-* Types that are intended to be nullable are now clearly annotated as such with optionals.
-* Easy conversion to/from SDL types from the wrapped types.
-* The `self.function()` notation is used where applicable.
-
-## Hello World
+# Example
 
 ```zig
 const std = @import("std");
@@ -79,3 +73,35 @@ pub fn main() !void {
     }
 }
 ```
+
+# Structure
+
+## Source
+The `src` folder was originally generated via a binding generator, but manually perfecting and testing the subsystems was found to be more productive.
+Each source file must also call each function at least once in testing if possible to ensure compilation is successful.
+
+## Examples
+
+The `examples` directory has some example programs utilizing SDL3.
+All examples may be built with `zig build examples`, or a single example can be ran with `zig build run -Dexample=<example name>`.
+
+## Template
+
+The `template` directory contains a sample hello world to get started using SDL3.
+Simply copy this folder to use as your project, and have fun!
+
+## Tests
+Tests for the library can be ran by running `zig build test`.
+
+# Features
+
+* SDL subsystems are divided into convenient namespaces.
+* Functions that can fail have the return wrapped with an error type and can even call a custom error callback.
+* C namespace exporting raw SDL functions in case it is ever needed.
+* Standard `init` and `deinit` functions for creating and destroying resources.
+* Skirts around C compat weirdness when possible (C pointers, anyopaque, C types).
+* Naming and conventions are more consistent with zig.
+* Functions return values rather than write to pointers.
+* Types that are intended to be nullable are now clearly annotated as such with optionals.
+* Easy conversion to/from SDL types from the wrapped types.
+* The `self.function()` notation is used where applicable.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A lightweight wrapper to zig-ify SDL3.
 
 > [!WARNING]
 > This is not production ready and currently in development!
+>
 > I'm hoping to be done soon, great progress has been made so far!
+>
 > See the [checklist](checklist.md) for more details on progress.
 
 # Documentation
@@ -27,7 +29,7 @@ zig fetch --save git+https://github.com/Gota7/zig-sdl3#master
 
 Then add zig-sdl3 as a dependency and import its modules and artifact in your `build.zig`:
 
-```sh
+```zig
 const sdl3 = b.dependency("sdl3", .{
     .target = target,
     .optimize = optimize,
@@ -37,7 +39,7 @@ const sdl3 = b.dependency("sdl3", .{
 ```
 Now add the modules and artifact to your target as you would normally:
 
-```sh
+```zig
 lib.root_module.addImport("sdl3", sdl3.module("sdl3"));
 ```
 

--- a/examples/dialog.zig
+++ b/examples/dialog.zig
@@ -12,7 +12,7 @@ const State = struct {
 };
 
 // Called whenever a native dialog is shown.
-fn fileCallback(user_data: ?*anyopaque, file_list: [*c]const [*c]const u8, filter: c_int) callconv(.C) void {
+fn fileCallback(user_data: ?*anyopaque, file_list: [*c]const [*c]const u8, filter: c_int) callconv(.c) void {
     const data = sdl3.dialog.sanatizeFileCallback(State, user_data, file_list, filter) catch {
         if (user_data) |val| {
             const user: *State = @alignCast(@ptrCast(val));

--- a/examples/properties.zig
+++ b/examples/properties.zig
@@ -13,13 +13,13 @@ fn printPropertyType(typ: ?sdl3.properties.Type) []const u8 {
     return "[does not exist]";
 }
 
-fn arrayCleanupCallback(user_data: ?*anyopaque, val: ?*anyopaque) callconv(.C) void {
+fn arrayCleanupCallback(user_data: ?*anyopaque, val: ?*anyopaque) callconv(.c) void {
     _ = user_data;
     const data: *std.ArrayList(u32) = @alignCast(@ptrCast(val));
     data.deinit();
 }
 
-fn printItems(user_data: ?*anyopaque, props: sdl3.c.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
+fn printItems(user_data: ?*anyopaque, props: sdl3.c.SDL_PropertiesID, name: [*c]const u8) callconv(.c) void {
     const index: *u32 = @alignCast(@ptrCast(user_data));
     const group = sdl3.properties.Group{ .value = props };
     std.io.getStdOut().writer().print("Index: {d}, Name: \"{s}\", Type: {s}\n", .{

--- a/examples/tray.zig
+++ b/examples/tray.zig
@@ -7,7 +7,7 @@ const State = struct {
     quit: bool = false,
 };
 
-fn switch_icon_color(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv(.C) void {
+fn switch_icon_color(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv(.c) void {
     const button = sdl3.tray.Entry{ .value = entry.? };
     const state: *State = @alignCast(@ptrCast(user_data));
     const color = sdl3.pixels.FColor{ .r = state.random.float(f32), .g = state.random.float(f32), .b = state.random.float(f32), .a = 1 };
@@ -15,7 +15,7 @@ fn switch_icon_color(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) call
     button.getParent().getParentTray().?.setIcon(state.surface);
 }
 
-fn toggle_button(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv(.C) void {
+fn toggle_button(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv(.c) void {
     _ = user_data;
     const checkbox = sdl3.tray.Entry{ .value = entry.? };
     const sub_menu = checkbox.getParent();
@@ -33,7 +33,7 @@ fn toggle_button(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv
     tray.setTooltip("Toggled sub-menu checkbox");
 }
 
-fn quit(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv(.C) void {
+fn quit(user_data: ?*anyopaque, entry: ?*sdl3.c.SDL_TrayEntry) callconv(.c) void {
     _ = entry;
     const state: *State = @alignCast(@ptrCast(user_data));
     state.quit = true;

--- a/gpu_examples/src/main.zig
+++ b/gpu_examples/src/main.zig
@@ -65,7 +65,7 @@ fn sdlLog(
     category: c_int,
     priority: sdl3.c.SDL_LogPriority,
     message: [*c]const u8,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = user_data;
     const category_managed = sdl3.log.Category.fromSdl(category);
     const category_str: ?[]const u8 = if (category_managed) |val| switch (val.value) {

--- a/src/assert.zig
+++ b/src/assert.zig
@@ -19,7 +19,7 @@ const std = @import("std");
 pub const Handler = *const fn (
     assert_data: [*c]const c.SDL_AssertData,
     user_data: ?*anyopaque,
-) callconv(.C) c.SDL_AssertState;
+) callconv(.c) c.SDL_AssertState;
 
 /// Possible outcomes from a triggered assertion.
 ///
@@ -190,7 +190,7 @@ const TestHandlerCallbackData = struct {
     last_data: ?*const c.SDL_AssertData = null,
 };
 
-fn testAssertCallback(assert_data: [*c]const c.SDL_AssertData, user_data: ?*anyopaque) callconv(.C) c.SDL_AssertState {
+fn testAssertCallback(assert_data: [*c]const c.SDL_AssertData, user_data: ?*anyopaque) callconv(.c) c.SDL_AssertState {
     var data: *TestHandlerCallbackData = @ptrCast(@alignCast(user_data));
     data.last_data = assert_data;
     return @intFromEnum(State.ignore);

--- a/src/assert.zig
+++ b/src/assert.zig
@@ -1,15 +1,15 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
 /// A callback that fires when an SDL assertion fails.
 ///
 /// ## Function Parameters
-/// * `assert_data`: A pointer to the `C.SDL_AssertData` structure corresponding to the current assertion.
+/// * `assert_data`: A pointer to the `c.SDL_AssertData` structure corresponding to the current assertion.
 /// * `user_data`: What was passed as userdata to `assert.setHandler()`.
 ///
 /// ## Return Value
-/// Returns a `C.SDL_AssertState` value indicating how to handle the failure.
+/// Returns a `c.SDL_AssertState` value indicating how to handle the failure.
 ///
 /// ## Thread Safety
 /// This callback may be called from any thread that triggers an assert at any time.
@@ -17,9 +17,9 @@ const std = @import("std");
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const Handler = *const fn (
-    assert_data: [*c]const C.SDL_AssertData,
+    assert_data: [*c]const c.SDL_AssertData,
     user_data: ?*anyopaque,
-) callconv(.C) C.SDL_AssertState;
+) callconv(.C) c.SDL_AssertState;
 
 /// Possible outcomes from a triggered assertion.
 ///
@@ -33,15 +33,15 @@ pub const Handler = *const fn (
 /// This enum is available since SDL 3.2.0.
 pub const State = enum(c_int) {
     /// Retry the assert immediately.
-    retry = C.SDL_ASSERTION_RETRY,
+    retry = c.SDL_ASSERTION_RETRY,
     /// Make the debugger trigger a breakpoint.
-    breakpoint = C.SDL_ASSERTION_BREAK,
+    breakpoint = c.SDL_ASSERTION_BREAK,
     /// Terminate the program.
-    abort = C.SDL_ASSERTION_ABORT,
+    abort = c.SDL_ASSERTION_ABORT,
     /// Ignore the assert.
-    ignore = C.SDL_ASSERTION_IGNORE,
+    ignore = c.SDL_ASSERTION_IGNORE,
     /// Ignore the assert from now on.
-    always_ignore = C.SDL_ASSERTION_ALWAYS_IGNORE,
+    always_ignore = c.SDL_ASSERTION_ALWAYS_IGNORE,
 };
 
 /// Get the default assertion handler.
@@ -59,7 +59,7 @@ pub const State = enum(c_int) {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getDefaultHandler() Handler {
-    return C.SDL_GetDefaultAssertionHandler().?;
+    return c.SDL_GetDefaultAssertionHandler().?;
 }
 
 /// Get the current assertion handler.
@@ -82,7 +82,7 @@ pub fn getDefaultHandler() Handler {
 /// This function is available since SDL 3.2.0.
 pub fn getHandler() struct { handler: Handler, user_data: ?*anyopaque } {
     var user_data: ?*anyopaque = undefined;
-    const handler = C.SDL_GetAssertionHandler(&user_data).?;
+    const handler = c.SDL_GetAssertionHandler(&user_data).?;
     return .{ .handler = handler, .user_data = user_data };
 }
 
@@ -113,8 +113,8 @@ pub fn getHandler() struct { handler: Handler, user_data: ?*anyopaque } {
 ///
 /// ## Version
 /// This function is available since SDL 3.2.0.
-pub fn getReport() ?*const C.SDL_AssertData {
-    return C.SDL_GetAssertionReport();
+pub fn getReport() ?*const c.SDL_AssertData {
+    return c.SDL_GetAssertionReport();
 }
 
 /// Report an assertion.
@@ -132,10 +132,10 @@ pub fn getReport() ?*const C.SDL_AssertData {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn report(
-    data: *C.SDL_AssertData,
+    data: *c.SDL_AssertData,
     location: std.builtin.SourceLocation,
 ) State {
-    return @enumFromInt(C.SDL_ReportAssertion(
+    return @enumFromInt(c.SDL_ReportAssertion(
         data,
         location.fn_name,
         location.file,
@@ -157,7 +157,7 @@ pub fn report(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn resetReport() void {
-    C.SDL_ResetAssertionReport();
+    c.SDL_ResetAssertionReport();
 }
 
 /// Set an application-defined assertion handler.
@@ -183,14 +183,14 @@ pub fn setHandler(
     handler: ?Handler,
     user_data: ?*anyopaque,
 ) void {
-    C.SDL_SetAssertionHandler(handler, user_data);
+    c.SDL_SetAssertionHandler(handler, user_data);
 }
 
 const TestHandlerCallbackData = struct {
-    last_data: ?*const C.SDL_AssertData = null,
+    last_data: ?*const c.SDL_AssertData = null,
 };
 
-fn testAssertCallback(assert_data: [*c]const C.SDL_AssertData, user_data: ?*anyopaque) callconv(.C) C.SDL_AssertState {
+fn testAssertCallback(assert_data: [*c]const c.SDL_AssertData, user_data: ?*anyopaque) callconv(.C) c.SDL_AssertState {
     var data: *TestHandlerCallbackData = @ptrCast(@alignCast(user_data));
     data.last_data = assert_data;
     return @intFromEnum(State.ignore);
@@ -209,13 +209,13 @@ test "Assert" {
 
     try std.testing.expectEqual(null, getReport());
 
-    var assert_data1 = C.SDL_AssertData{};
-    var assert_data2 = C.SDL_AssertData{};
+    var assert_data1 = c.SDL_AssertData{};
+    var assert_data2 = c.SDL_AssertData{};
     _ = report(&assert_data1, @src());
     _ = report(&assert_data2, @src());
 
-    const report2: *const C.SDL_AssertData = getReport().?;
-    const report1: *const C.SDL_AssertData = report2.next.?;
+    const report2: *const c.SDL_AssertData = getReport().?;
+    const report1: *const c.SDL_AssertData = report2.next.?;
     try std.testing.expectEqual(null, report1.next);
     try std.testing.expectEqual(214, report1.linenum);
     try std.testing.expectEqualStrings("test.Assert", std.mem.span(report1.function));

--- a/src/async_io.zig
+++ b/src/async_io.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -11,7 +11,7 @@ const std = @import("std");
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const File = struct {
-    value: *C.SDL_AsyncIO,
+    value: *c.SDL_AsyncIO,
 
     /// Use this function to create a new IO object for reading from and/or writing to a named file.
     ///
@@ -35,7 +35,7 @@ pub const File = struct {
         file: [:0]const u8,
         mode: IoMode,
     ) !File {
-        return .{ .value = try errors.wrapNull(*C.SDL_AsyncIO, C.SDL_AsyncIOFromFile(
+        return .{ .value = try errors.wrapNull(*c.SDL_AsyncIO, c.SDL_AsyncIOFromFile(
             file.ptr,
             switch (mode) {
                 .read_only => "r",
@@ -65,7 +65,7 @@ pub const File = struct {
     pub fn getSize(
         self: File,
     ) !usize {
-        return @intCast(try errors.wrapCall(i64, C.SDL_GetAsyncIOSize(self.value), -1));
+        return @intCast(try errors.wrapCall(i64, c.SDL_GetAsyncIOSize(self.value), -1));
     }
 };
 
@@ -116,7 +116,7 @@ pub const Outcome = struct {
     user_data: ?*anyopaque,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_AsyncIOOutcome) Outcome {
+    pub fn fromSdl(value: c.SDL_AsyncIOOutcome) Outcome {
         return .{
             .file = .{ .value = value.asyncio.? },
             .task_type = @enumFromInt(value.type),
@@ -129,7 +129,7 @@ pub const Outcome = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Outcome) C.SDL_AsyncIOOutcome {
+    pub fn toSdl(self: Outcome) c.SDL_AsyncIOOutcome {
         return .{
             .asyncio = self.file.value,
             .type = @intFromEnum(self.task_type),
@@ -152,7 +152,7 @@ pub const Outcome = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Queue = struct {
-    value: *C.SDL_AsyncIOQueue,
+    value: *c.SDL_AsyncIOQueue,
 
     /// Close and free any allocated resources for an async I/O object.
     ///
@@ -196,7 +196,7 @@ pub const Queue = struct {
         flush: bool,
         user_data: ?*anyopaque,
     ) !void {
-        return errors.wrapCallBool(C.SDL_CloseAsyncIO(
+        return errors.wrapCallBool(c.SDL_CloseAsyncIO(
             file.value,
             flush,
             self.value,
@@ -231,7 +231,7 @@ pub const Queue = struct {
     pub fn deinit(
         self: Queue,
     ) void {
-        C.SDL_DestroyAsyncIOQueue(self.value);
+        c.SDL_DestroyAsyncIOQueue(self.value);
     }
 
     /// Query an async I/O task queue for completed tasks.
@@ -260,8 +260,8 @@ pub const Queue = struct {
     pub fn getResult(
         self: Queue,
     ) ?Outcome {
-        var outcome: C.SDL_AsyncIOOutcome = undefined;
-        const ret = C.SDL_GetAsyncIOResult(
+        var outcome: c.SDL_AsyncIOOutcome = undefined;
+        const ret = c.SDL_GetAsyncIOResult(
             self.value,
             &outcome,
         );
@@ -285,7 +285,7 @@ pub const Queue = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn init() !Queue {
-        return .{ .value = try errors.wrapNull(*C.SDL_AsyncIOQueue, C.SDL_CreateAsyncIOQueue()) };
+        return .{ .value = try errors.wrapNull(*c.SDL_AsyncIOQueue, c.SDL_CreateAsyncIOQueue()) };
     }
 
     /// Load all the data from a file path, asynchronously.
@@ -316,7 +316,7 @@ pub const Queue = struct {
         file: [:0]const u8,
         user_data: ?*anyopaque,
     ) !void {
-        return errors.wrapCallBool(C.SDL_LoadFileAsync(
+        return errors.wrapCallBool(c.SDL_LoadFileAsync(
             file,
             self.value,
             user_data,
@@ -356,7 +356,7 @@ pub const Queue = struct {
         offset: usize,
         user_data: ?*anyopaque,
     ) !void {
-        return errors.wrapCallBool(C.SDL_ReadAsyncIO(
+        return errors.wrapCallBool(c.SDL_ReadAsyncIO(
             file.value,
             data.ptr,
             @intCast(offset),
@@ -386,7 +386,7 @@ pub const Queue = struct {
     pub fn signal(
         self: Queue,
     ) void {
-        C.SDL_SignalAsyncIOQueue(self.value);
+        c.SDL_SignalAsyncIOQueue(self.value);
     }
 
     /// Block until an async I/O task queue has a completed task.
@@ -427,8 +427,8 @@ pub const Queue = struct {
         self: Queue,
         timeout_milliseconds: ?usize,
     ) ?Outcome {
-        var outcome: C.SDL_AsyncIOOutcome = undefined;
-        const ret = C.SDL_WaitAsyncIOResult(
+        var outcome: c.SDL_AsyncIOOutcome = undefined;
+        const ret = c.SDL_WaitAsyncIOResult(
             self.value,
             &outcome,
             if (timeout_milliseconds) |val| @intCast(val) else -1,
@@ -469,7 +469,7 @@ pub const Queue = struct {
         offset: usize,
         user_data: ?*anyopaque,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteAsyncIO(
+        return errors.wrapCallBool(c.SDL_WriteAsyncIO(
             file.value,
             @constCast(data.ptr),
             @intCast(offset),
@@ -486,11 +486,11 @@ pub const Queue = struct {
 /// This enum is available since SDL 3.2.0.
 pub const Result = enum(c_uint) {
     /// Request was completed without error.
-    complete = C.SDL_ASYNCIO_COMPLETE,
+    complete = c.SDL_ASYNCIO_COMPLETE,
     /// Request failed for some reason.
-    failure = C.SDL_ASYNCIO_FAILURE,
+    failure = c.SDL_ASYNCIO_FAILURE,
     /// Request was canceled before completing.
-    canceled = C.SDL_ASYNCIO_CANCELED,
+    canceled = c.SDL_ASYNCIO_CANCELED,
 };
 
 /// Types of asynchronous I/O tasks.
@@ -499,11 +499,11 @@ pub const Result = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const TaskType = enum(c_uint) {
     /// A read operation.
-    read = C.SDL_ASYNCIO_TASK_READ,
+    read = c.SDL_ASYNCIO_TASK_READ,
     /// A write operation.
-    write = C.SDL_ASYNCIO_TASK_WRITE,
+    write = c.SDL_ASYNCIO_TASK_WRITE,
     /// A close operation.
-    close = C.SDL_ASYNCIO_TASK_CLOSE,
+    close = c.SDL_ASYNCIO_TASK_CLOSE,
 };
 
 // Test asynchronous IO.

--- a/src/audio.zig
+++ b/src/audio.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const io_stream = @import("io_stream.zig");
 const properties = @import("properties.zig");
@@ -32,7 +32,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const PostmixCallback = *const fn (user_data: ?*anyopaque, spec: [*c]const C.SDL_AudioSpec, buffer: [*c]f32, buffer_len: c_int) callconv(.C) void;
+pub const PostmixCallback = *const fn (user_data: ?*anyopaque, spec: [*c]const c.SDL_AudioSpec, buffer: [*c]f32, buffer_len: c_int) callconv(.C) void;
 
 /// A callback that fires when data passes through a `Stream`.
 ///
@@ -64,7 +64,7 @@ pub const PostmixCallback = *const fn (user_data: ?*anyopaque, spec: [*c]const C
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const StreamCallback = *const fn (user_data: ?*anyopaque, stream: ?*C.SDL_AudioStream, additional_amount: c_int, total_amount: c_int) callconv(.C) void;
+pub const StreamCallback = *const fn (user_data: ?*anyopaque, stream: ?*c.SDL_AudioStream, additional_amount: c_int, total_amount: c_int) callconv(.C) void;
 
 /// Audio format.
 ///
@@ -72,17 +72,17 @@ pub const StreamCallback = *const fn (user_data: ?*anyopaque, stream: ?*C.SDL_Au
 /// This enum is available since SDL 3.2.0.
 pub const Format = struct {
     value: c_uint,
-    pub const unsigned_8_bit = Format{ .value = C.SDL_AUDIO_U8 };
-    pub const signed_8_bit = Format{ .value = C.SDL_AUDIO_S8 };
-    pub const signed_16_bit_little_endian = Format{ .value = C.SDL_AUDIO_S16LE };
-    pub const signed_16_bit_big_endian = Format{ .value = C.SDL_AUDIO_S16BE };
-    pub const signed_32_bit_little_endian = Format{ .value = C.SDL_AUDIO_S32LE };
-    pub const signed_32_bit_big_endian = Format{ .value = C.SDL_AUDIO_S32BE };
-    pub const floating_32_bit_little_endian = Format{ .value = C.SDL_AUDIO_F32LE };
-    pub const floating_32_bit_big_endian = Format{ .value = C.SDL_AUDIO_F32BE };
-    pub const signed_16_bit = Format{ .value = C.SDL_AUDIO_S16 };
-    pub const signed_32_bit = Format{ .value = C.SDL_AUDIO_S32 };
-    pub const floating_32_bit = Format{ .value = C.SDL_AUDIO_F32 };
+    pub const unsigned_8_bit = Format{ .value = c.SDL_AUDIO_U8 };
+    pub const signed_8_bit = Format{ .value = c.SDL_AUDIO_S8 };
+    pub const signed_16_bit_little_endian = Format{ .value = c.SDL_AUDIO_S16LE };
+    pub const signed_16_bit_big_endian = Format{ .value = c.SDL_AUDIO_S16BE };
+    pub const signed_32_bit_little_endian = Format{ .value = c.SDL_AUDIO_S32LE };
+    pub const signed_32_bit_big_endian = Format{ .value = c.SDL_AUDIO_S32BE };
+    pub const floating_32_bit_little_endian = Format{ .value = c.SDL_AUDIO_F32LE };
+    pub const floating_32_bit_big_endian = Format{ .value = c.SDL_AUDIO_F32BE };
+    pub const signed_16_bit = Format{ .value = c.SDL_AUDIO_S16 };
+    pub const signed_32_bit = Format{ .value = c.SDL_AUDIO_S32 };
+    pub const floating_32_bit = Format{ .value = c.SDL_AUDIO_F32 };
 
     /// Define an audio format.
     ///
@@ -117,11 +117,11 @@ pub const Format = struct {
     ) Format {
         var ret: c_int = 0;
         if (signed)
-            ret |= C.SDL_AUDIO_MASK_SIGNED;
+            ret |= c.SDL_AUDIO_MASK_SIGNED;
         if (big_endian)
-            ret |= C.SDL_AUDIO_MASK_BIG_ENDIAN;
+            ret |= c.SDL_AUDIO_MASK_BIG_ENDIAN;
         if (float)
-            ret |= C.SDL_AUDIO_MASK_FLOAT;
+            ret |= c.SDL_AUDIO_MASK_FLOAT;
         ret |= @as(c_int, @intCast(bit_width));
         return Format{ .value = @as(c_uint, @bitCast(ret)) };
     }
@@ -145,7 +145,7 @@ pub const Format = struct {
     pub fn getBitwidth(
         self: Format,
     ) u8 {
-        const ret = C.SDL_AUDIO_BITSIZE(
+        const ret = c.SDL_AUDIO_BITSIZE(
             self.value,
         );
         return @intCast(ret);
@@ -170,7 +170,7 @@ pub const Format = struct {
     pub fn getByteSize(
         self: Format,
     ) u8 {
-        const ret = C.SDL_AUDIO_BYTESIZE(
+        const ret = c.SDL_AUDIO_BYTESIZE(
             self.value,
         );
         return @intCast(ret);
@@ -192,7 +192,7 @@ pub const Format = struct {
     pub fn getName(
         self: Format,
     ) ?[:0]const u8 {
-        const ret: [:0]const u8 = std.mem.span(C.SDL_GetAudioFormatName(self.value));
+        const ret: [:0]const u8 = std.mem.span(c.SDL_GetAudioFormatName(self.value));
         if (std.mem.eql(u8, ret, "SDL_AUDIO_UNKNOWN"))
             return null;
         return ret;
@@ -217,7 +217,7 @@ pub const Format = struct {
     pub fn getSilenceValue(
         self: Format,
     ) u8 {
-        return @intCast(C.SDL_GetSilenceValueForFormat(self.value));
+        return @intCast(c.SDL_GetSilenceValueForFormat(self.value));
     }
 
     /// If the format is big endian.
@@ -239,7 +239,7 @@ pub const Format = struct {
     pub fn isBigEndian(
         self: Format,
     ) bool {
-        const ret = C.SDL_AUDIO_ISBIGENDIAN(
+        const ret = c.SDL_AUDIO_ISBIGENDIAN(
             self.value,
         );
         return ret != 0;
@@ -264,7 +264,7 @@ pub const Format = struct {
     pub fn isFloat(
         self: Format,
     ) bool {
-        const ret = C.SDL_AUDIO_ISFLOAT(
+        const ret = c.SDL_AUDIO_ISFLOAT(
             self.value,
         );
         return ret != 0;
@@ -289,7 +289,7 @@ pub const Format = struct {
     pub fn isInt(
         self: Format,
     ) bool {
-        const ret = C.SDL_AUDIO_ISINT(
+        const ret = c.SDL_AUDIO_ISINT(
             self.value,
         );
         return ret;
@@ -314,7 +314,7 @@ pub const Format = struct {
     pub fn isLittleEndian(
         self: Format,
     ) bool {
-        const ret = C.SDL_AUDIO_ISLITTLEENDIAN(
+        const ret = c.SDL_AUDIO_ISLITTLEENDIAN(
             self.value,
         );
         return ret;
@@ -339,7 +339,7 @@ pub const Format = struct {
     pub fn isSigned(
         self: Format,
     ) bool {
-        const ret = C.SDL_AUDIO_ISSIGNED(
+        const ret = c.SDL_AUDIO_ISSIGNED(
             self.value,
         );
         return ret != 0;
@@ -364,7 +364,7 @@ pub const Format = struct {
     pub fn isUnsigned(
         self: Format,
     ) bool {
-        const ret = C.SDL_AUDIO_ISUNSIGNED(
+        const ret = c.SDL_AUDIO_ISUNSIGNED(
             self.value,
         );
         return ret;
@@ -376,15 +376,15 @@ pub const Format = struct {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const Device = packed struct {
-    value: C.SDL_AudioDeviceID,
+    value: c.SDL_AudioDeviceID,
     /// A value used to request a default playback audio device.
-    pub const default_playback = Device{ .value = C.SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK };
+    pub const default_playback = Device{ .value = c.SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK };
     /// A value used to request a default recording audio device.
-    pub const default_recording = Device{ .value = C.SDL_AUDIO_DEVICE_DEFAULT_RECORDING };
+    pub const default_recording = Device{ .value = c.SDL_AUDIO_DEVICE_DEFAULT_RECORDING };
 
     // Test sizes.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_AudioDeviceID) == @sizeOf(Device));
+        std.debug.assert(@sizeOf(c.SDL_AudioDeviceID) == @sizeOf(Device));
     }
 
     /// Bind a single audio stream to an audio device.
@@ -405,7 +405,7 @@ pub const Device = packed struct {
         self: Device,
         stream: Stream,
     ) !void {
-        const ret = C.SDL_BindAudioStream(
+        const ret = c.SDL_BindAudioStream(
             self.value,
             stream.value,
         );
@@ -442,7 +442,7 @@ pub const Device = packed struct {
         self: Device,
         streams: []Stream,
     ) !void {
-        const ret = C.SDL_BindAudioStreams(
+        const ret = c.SDL_BindAudioStreams(
             self.value,
             @ptrCast(streams.ptr),
             @intCast(streams.len),
@@ -471,7 +471,7 @@ pub const Device = packed struct {
     pub fn close(
         self: Device,
     ) void {
-        const ret = C.SDL_CloseAudioDevice(
+        const ret = c.SDL_CloseAudioDevice(
             self.value,
         );
         _ = ret;
@@ -508,9 +508,9 @@ pub const Device = packed struct {
     pub fn getFormat(
         self: Device,
     ) !struct { spec: Spec, buffer_size_frames: usize } {
-        var spec: C.SDL_AudioSpec = undefined;
+        var spec: c.SDL_AudioSpec = undefined;
         var buffer_size_frames: c_int = undefined;
-        const ret = C.SDL_GetAudioDeviceFormat(
+        const ret = c.SDL_GetAudioDeviceFormat(
             self.value,
             &spec,
             &buffer_size_frames,
@@ -543,7 +543,7 @@ pub const Device = packed struct {
         self: Device,
     ) ?[]c_int {
         var count: c_int = undefined;
-        const ret = C.SDL_GetAudioDeviceChannelMap(
+        const ret = c.SDL_GetAudioDeviceChannelMap(
             self.value,
             &count,
         );
@@ -575,7 +575,7 @@ pub const Device = packed struct {
     pub fn getGain(
         self: Device,
     ) !f32 {
-        const ret = C.SDL_GetAudioDeviceGain(
+        const ret = c.SDL_GetAudioDeviceGain(
             self.value,
         );
         return @floatCast(try errors.wrapCall(f32, ret, -1));
@@ -597,7 +597,7 @@ pub const Device = packed struct {
     pub fn getName(
         self: Device,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetAudioDeviceName(
+        const ret = c.SDL_GetAudioDeviceName(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -625,7 +625,7 @@ pub const Device = packed struct {
     pub fn getPaused(
         self: Device,
     ) bool {
-        const ret = C.SDL_AudioDevicePaused(
+        const ret = c.SDL_AudioDevicePaused(
             self.value,
         );
         return ret;
@@ -659,7 +659,7 @@ pub const Device = packed struct {
     pub fn isPhysical(
         self: Device,
     ) bool {
-        return C.SDL_IsAudioDevicePhysical(self.value);
+        return c.SDL_IsAudioDevicePhysical(self.value);
     }
 
     /// Determine if an audio device is a playback device (instead of recording).
@@ -681,7 +681,7 @@ pub const Device = packed struct {
     pub fn isPlayback(
         self: Device,
     ) bool {
-        return C.SDL_IsAudioDevicePlayback(self.value);
+        return c.SDL_IsAudioDevicePlayback(self.value);
     }
 
     /// Open a specific audio device.
@@ -741,13 +741,13 @@ pub const Device = packed struct {
         self: Device,
         spec: ?Spec,
     ) !Device {
-        const spec_sdl: C.SDL_AudioSpec = if (spec) |val| val.toSdl() else undefined;
-        const ret = C.SDL_OpenAudioDevice(
+        const spec_sdl: c.SDL_AudioSpec = if (spec) |val| val.toSdl() else undefined;
+        const ret = c.SDL_OpenAudioDevice(
             self.value,
             if (spec != null) &spec_sdl else null,
         );
         return .{
-            .value = try errors.wrapCall(C.SDL_AudioDeviceID, ret, 0),
+            .value = try errors.wrapCall(c.SDL_AudioDeviceID, ret, 0),
         };
     }
 
@@ -800,15 +800,15 @@ pub const Device = packed struct {
         callback: ?StreamCallback,
         user_data: ?*anyopaque,
     ) !Stream {
-        const spec_sdl: C.SDL_AudioSpec = if (spec) |val| val.toSdl() else undefined;
-        const ret = C.SDL_OpenAudioDeviceStream(
+        const spec_sdl: c.SDL_AudioSpec = if (spec) |val| val.toSdl() else undefined;
+        const ret = c.SDL_OpenAudioDeviceStream(
             self.value,
             if (spec != null) &spec_sdl else null,
             callback orelse null,
             user_data,
         );
         return .{
-            .value = try errors.wrapNull(*C.SDL_AudioStream, ret),
+            .value = try errors.wrapNull(*c.SDL_AudioStream, ret),
         };
     }
 
@@ -838,7 +838,7 @@ pub const Device = packed struct {
     pub fn pausePlayback(
         self: Device,
     ) !void {
-        const ret = C.SDL_PauseAudioDevice(
+        const ret = c.SDL_PauseAudioDevice(
             self.value,
         );
         return errors.wrapCallBool(ret);
@@ -866,7 +866,7 @@ pub const Device = packed struct {
     pub fn resumePlayback(
         self: Device,
     ) !void {
-        const ret = C.SDL_ResumeAudioDevice(
+        const ret = c.SDL_ResumeAudioDevice(
             self.value,
         );
         return errors.wrapCallBool(ret);
@@ -901,7 +901,7 @@ pub const Device = packed struct {
         self: Device,
         gain: f32,
     ) !void {
-        const ret = C.SDL_SetAudioDeviceGain(
+        const ret = c.SDL_SetAudioDeviceGain(
             self.value,
             gain,
         );
@@ -953,7 +953,7 @@ pub const Device = packed struct {
         callback: ?PostmixCallback,
         user_data: ?*anyopaque,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SetAudioPostmixCallback(self.value, callback orelse null, user_data));
+        return errors.wrapCallBool(c.SDL_SetAudioPostmixCallback(self.value, callback orelse null, user_data));
     }
 };
 
@@ -975,11 +975,11 @@ pub const Device = packed struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Stream = packed struct {
-    value: *C.SDL_AudioStream,
+    value: *c.SDL_AudioStream,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(*C.SDL_AudioStream) == @sizeOf(Stream));
+        std.debug.assert(@sizeOf(*c.SDL_AudioStream) == @sizeOf(Stream));
     }
 
     /// Clear any pending data in the stream.
@@ -998,7 +998,7 @@ pub const Stream = packed struct {
     pub fn clear(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_ClearAudioStream(self.value));
+        return errors.wrapCallBool(c.SDL_ClearAudioStream(self.value));
     }
 
     /// Free an audio stream.
@@ -1021,7 +1021,7 @@ pub const Stream = packed struct {
     pub fn deinit(
         self: Stream,
     ) void {
-        C.SDL_DestroyAudioStream(self.value);
+        c.SDL_DestroyAudioStream(self.value);
     }
 
     /// Tell the stream that you're done sending data, and anything being buffered should be converted/resampled and made available immediately.
@@ -1041,7 +1041,7 @@ pub const Stream = packed struct {
     pub fn flush(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_FlushAudioStream(self.value));
+        return errors.wrapCallBool(c.SDL_FlushAudioStream(self.value));
     }
 
     /// Get the number of converted/resampled bytes available.
@@ -1067,7 +1067,7 @@ pub const Stream = packed struct {
     pub fn getAvailable(
         self: Stream,
     ) usize {
-        return @intCast(C.SDL_GetAudioStreamAvailable(self.value));
+        return @intCast(c.SDL_GetAudioStreamAvailable(self.value));
     }
 
     /// Query an audio stream for its currently-bound device.
@@ -1091,7 +1091,7 @@ pub const Stream = packed struct {
     pub fn getDevice(
         self: Stream,
     ) ?Device {
-        const ret = C.SDL_GetAudioStreamDevice(
+        const ret = c.SDL_GetAudioStreamDevice(
             self.value,
         );
         if (ret == 0)
@@ -1118,7 +1118,7 @@ pub const Stream = packed struct {
     pub fn getDevicePaused(
         self: Stream,
     ) bool {
-        return C.SDL_AudioStreamDevicePaused(self.value);
+        return c.SDL_AudioStreamDevicePaused(self.value);
     }
 
     /// Query the current format of an audio stream.
@@ -1137,9 +1137,9 @@ pub const Stream = packed struct {
     pub fn getFormat(
         self: Stream,
     ) !struct { input_format: Spec, output_format: Spec } {
-        var input_format: C.SDL_AudioSpec = undefined;
-        var output_format: C.SDL_AudioSpec = undefined;
-        try errors.wrapCallBool(C.SDL_GetAudioStreamFormat(self.value, &input_format, &output_format));
+        var input_format: c.SDL_AudioSpec = undefined;
+        var output_format: c.SDL_AudioSpec = undefined;
+        try errors.wrapCallBool(c.SDL_GetAudioStreamFormat(self.value, &input_format, &output_format));
         return .{
             .input_format = Spec.fromSdl(input_format),
             .output_format = Spec.fromSdl(output_format),
@@ -1162,7 +1162,7 @@ pub const Stream = packed struct {
     pub fn getFrequencyRatio(
         self: Stream,
     ) !f32 {
-        return errors.wrapCall(f32, C.SDL_GetAudioStreamFrequencyRatio(self.value), 0);
+        return errors.wrapCall(f32, c.SDL_GetAudioStreamFrequencyRatio(self.value), 0);
     }
 
     /// Get the gain of an audio stream.
@@ -1186,7 +1186,7 @@ pub const Stream = packed struct {
     pub fn getGain(
         self: Stream,
     ) !f32 {
-        return errors.wrapCall(f32, C.SDL_GetAudioStreamGain(self.value), -1);
+        return errors.wrapCall(f32, c.SDL_GetAudioStreamGain(self.value), -1);
     }
 
     /// Get the current input channel map of an audio stream.
@@ -1212,7 +1212,7 @@ pub const Stream = packed struct {
         self: Stream,
     ) ?[]c_int {
         var count: c_int = undefined;
-        const ret = C.SDL_GetAudioStreamInputChannelMap(self.value, &count);
+        const ret = c.SDL_GetAudioStreamInputChannelMap(self.value, &count);
         if (ret == null)
             return null;
         return ret[0..@intCast(count)];
@@ -1235,7 +1235,7 @@ pub const Stream = packed struct {
         self: Stream,
     ) !properties.Group {
         return .{
-            .value = try errors.wrapCall(C.SDL_PropertiesID, C.SDL_GetAudioStreamProperties(self.value), 0),
+            .value = try errors.wrapCall(c.SDL_PropertiesID, c.SDL_GetAudioStreamProperties(self.value), 0),
         };
     }
 
@@ -1269,7 +1269,7 @@ pub const Stream = packed struct {
     pub fn getQueued(
         self: Stream,
     ) !usize {
-        return @intCast(try errors.wrapCall(c_int, C.SDL_GetAudioStreamQueued(self.value), -1));
+        return @intCast(try errors.wrapCall(c_int, c.SDL_GetAudioStreamQueued(self.value), -1));
     }
 
     /// Get the current output channel map of an audio stream.
@@ -1295,7 +1295,7 @@ pub const Stream = packed struct {
         self: Stream,
     ) ?[]c_int {
         var count: c_int = undefined;
-        const ret = C.SDL_GetAudioStreamOutputChannelMap(self.value, &count);
+        const ret = c.SDL_GetAudioStreamOutputChannelMap(self.value, &count);
         if (ret == null)
             return null;
         return ret[0..@intCast(count)];
@@ -1322,7 +1322,7 @@ pub const Stream = packed struct {
         const src_spec_sdl = src_spec.toSdl();
         const dst_spec_sdl = dst_spec.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_AudioStream, C.SDL_CreateAudioStream(&src_spec_sdl, &dst_spec_sdl)),
+            .value = try errors.wrapNull(*c.SDL_AudioStream, c.SDL_CreateAudioStream(&src_spec_sdl, &dst_spec_sdl)),
         };
     }
 
@@ -1349,7 +1349,7 @@ pub const Stream = packed struct {
     pub fn lock(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_LockAudioStream(self.value));
+        return errors.wrapCallBool(c.SDL_LockAudioStream(self.value));
     }
 
     /// Use this function to pause audio playback on the audio device associated with an audio stream.
@@ -1373,7 +1373,7 @@ pub const Stream = packed struct {
     pub fn pauseDevice(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_PauseAudioStreamDevice(self.value));
+        return errors.wrapCallBool(c.SDL_PauseAudioStreamDevice(self.value));
     }
 
     /// Add data to the stream.
@@ -1398,7 +1398,7 @@ pub const Stream = packed struct {
         self: Stream,
         data: []const u8,
     ) !void {
-        return errors.wrapCallBool(C.SDL_PutAudioStreamData(
+        return errors.wrapCallBool(c.SDL_PutAudioStreamData(
             self.value,
             data.ptr,
             @intCast(data.len),
@@ -1424,7 +1424,7 @@ pub const Stream = packed struct {
     pub fn resumeDevice(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_ResumeAudioStreamDevice(self.value));
+        return errors.wrapCallBool(c.SDL_ResumeAudioStreamDevice(self.value));
     }
 
     /// Change the input and output formats of an audio stream.
@@ -1457,9 +1457,9 @@ pub const Stream = packed struct {
         src_spec: ?Spec,
         dst_spec: ?Spec,
     ) !void {
-        const src_spec_sdl: C.SDL_AudioSpec = if (src_spec) |val| val.toSdl() else undefined;
-        const dst_spec_sdl: C.SDL_AudioSpec = if (dst_spec) |val| val.toSdl() else undefined;
-        return errors.wrapCallBool(C.SDL_SetAudioStreamFormat(
+        const src_spec_sdl: c.SDL_AudioSpec = if (src_spec) |val| val.toSdl() else undefined;
+        const dst_spec_sdl: c.SDL_AudioSpec = if (dst_spec) |val| val.toSdl() else undefined;
+        return errors.wrapCallBool(c.SDL_SetAudioStreamFormat(
             self.value,
             if (src_spec != null) &src_spec_sdl else null,
             if (dst_spec != null) &dst_spec_sdl else null,
@@ -1489,7 +1489,7 @@ pub const Stream = packed struct {
         self: Stream,
         frequency_ratio: f32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SetAudioStreamFrequencyRatio(self.value, frequency_ratio));
+        return errors.wrapCallBool(c.SDL_SetAudioStreamFrequencyRatio(self.value, frequency_ratio));
     }
 
     /// Change the gain of an audio stream.
@@ -1514,7 +1514,7 @@ pub const Stream = packed struct {
         self: Stream,
         gain: f32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SetAudioStreamGain(self.value, gain));
+        return errors.wrapCallBool(c.SDL_SetAudioStreamGain(self.value, gain));
     }
 
     /// Set a callback that runs when data is requested from an audio stream.
@@ -1554,7 +1554,7 @@ pub const Stream = packed struct {
         callback: ?StreamCallback,
         user_data: ?*anyopaque,
     ) void {
-        _ = C.SDL_SetAudioStreamGetCallback(
+        _ = c.SDL_SetAudioStreamGetCallback(
             self.value,
             if (callback) |val| val else null,
             user_data,
@@ -1602,7 +1602,7 @@ pub const Stream = packed struct {
         channel_map: ?[]const c_int,
     ) !void {
         return errors.wrapCallBool(
-            C.SDL_SetAudioStreamInputChannelMap(self.value, if (channel_map) |val| val.ptr else null, @intCast(if (channel_map) |val| val.len else 0)),
+            c.SDL_SetAudioStreamInputChannelMap(self.value, if (channel_map) |val| val.ptr else null, @intCast(if (channel_map) |val| val.len else 0)),
         );
     }
 
@@ -1646,7 +1646,7 @@ pub const Stream = packed struct {
         channel_map: ?[]const c_int,
     ) !void {
         return errors.wrapCallBool(
-            C.SDL_SetAudioStreamOutputChannelMap(self.value, if (channel_map) |val| val.ptr else null, @intCast(if (channel_map) |val| val.len else 0)),
+            c.SDL_SetAudioStreamOutputChannelMap(self.value, if (channel_map) |val| val.ptr else null, @intCast(if (channel_map) |val| val.len else 0)),
         );
     }
 
@@ -1691,7 +1691,7 @@ pub const Stream = packed struct {
         callback: ?StreamCallback,
         user_data: ?*anyopaque,
     ) void {
-        _ = C.SDL_SetAudioStreamPutCallback(
+        _ = c.SDL_SetAudioStreamPutCallback(
             self.value,
             if (callback) |val| val else null,
             user_data,
@@ -1714,7 +1714,7 @@ pub const Stream = packed struct {
     pub fn unbind(
         self: Stream,
     ) void {
-        C.SDL_UnbindAudioStream(self.value);
+        c.SDL_UnbindAudioStream(self.value);
     }
 
     /// Unlock an audio stream for serialized access.
@@ -1733,7 +1733,7 @@ pub const Stream = packed struct {
     pub fn unlock(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_UnlockAudioStream(self.value));
+        return errors.wrapCallBool(c.SDL_UnlockAudioStream(self.value));
     }
 };
 
@@ -1750,7 +1750,7 @@ pub const Spec = struct {
     sample_rate: usize,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(data: C.SDL_AudioSpec) Spec {
+    pub fn fromSdl(data: c.SDL_AudioSpec) Spec {
         return .{
             .format = Format{ .value = data.format },
             .num_channels = @intCast(data.channels),
@@ -1759,7 +1759,7 @@ pub const Spec = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Spec) C.SDL_AudioSpec {
+    pub fn toSdl(self: Spec) c.SDL_AudioSpec {
         return .{
             .format = self.format.value,
             .channels = @intCast(self.num_channels),
@@ -1801,7 +1801,7 @@ pub const Spec = struct {
         const dst_spec_sdl = dst_spec.toSdl();
         var dst_data: [*c]u8 = undefined;
         var dst_len: c_int = undefined;
-        try errors.wrapCallBool(C.SDL_ConvertAudioSamples(
+        try errors.wrapCallBool(c.SDL_ConvertAudioSamples(
             &src_spec_sdl,
             src_data.ptr,
             @intCast(src_data.len),
@@ -1837,7 +1837,7 @@ pub const Spec = struct {
         self: Stream,
         data: []u8,
     ) ![]u8 {
-        const ret = try errors.wrapCall(c_int, C.SDL_GetAudioStreamData(self.value, data.ptr, @intCast(data.len)), -1);
+        const ret = try errors.wrapCall(c_int, c.SDL_GetAudioStreamData(self.value, data.ptr, @intCast(data.len)), -1);
         return data.ptr[0..@intCast(ret)];
     }
 
@@ -1879,7 +1879,7 @@ pub const Spec = struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getCurrentDriverName() ?[:0]const u8 {
-    const ret = C.SDL_GetCurrentAudioDriver();
+    const ret = c.SDL_GetCurrentAudioDriver();
     if (ret == null)
         return null;
     return std.mem.span(ret);
@@ -1908,7 +1908,7 @@ pub fn getCurrentDriverName() ?[:0]const u8 {
 pub fn getDriverName(
     index: usize,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetAudioDriver(
+    const ret = c.SDL_GetAudioDriver(
         @intCast(index),
     );
     if (ret == null)
@@ -1935,7 +1935,7 @@ pub fn getDriverName(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getNumDrivers() usize {
-    const ret = C.SDL_GetNumAudioDrivers();
+    const ret = c.SDL_GetNumAudioDrivers();
     return @intCast(ret);
 }
 
@@ -1958,7 +1958,7 @@ pub fn getNumDrivers() usize {
 /// This function is available since SDL 3.2.0.
 pub fn getPlaybackDevices() ![]Device {
     var count: c_int = undefined;
-    const ret = @as([*]Device, @ptrCast(try errors.wrapCallCPtr(C.SDL_AudioDeviceID, C.SDL_GetAudioPlaybackDevices(&count))));
+    const ret = @as([*]Device, @ptrCast(try errors.wrapCallCPtr(c.SDL_AudioDeviceID, c.SDL_GetAudioPlaybackDevices(&count))));
     return ret[0..@intCast(count)];
 }
 
@@ -1981,7 +1981,7 @@ pub fn getPlaybackDevices() ![]Device {
 /// This function is available since SDL 3.2.0.
 pub fn getRecordingDevices() ![]Device {
     var count: c_int = undefined;
-    const ret = @as([*]Device, @ptrCast(try errors.wrapCallCPtr(C.SDL_AudioDeviceID, C.SDL_GetAudioRecordingDevices(&count))));
+    const ret = @as([*]Device, @ptrCast(try errors.wrapCallCPtr(c.SDL_AudioDeviceID, c.SDL_GetAudioRecordingDevices(&count))));
     return ret[0..@intCast(count)];
 }
 
@@ -2008,8 +2008,8 @@ pub fn loadWav(
 ) !struct { spec: Spec, data: []u8 } {
     var data: [*c]u8 = undefined;
     var len: u32 = undefined;
-    var spec: C.SDL_AudioSpec = undefined;
-    try errors.wrapCallBool(C.SDL_LoadWAV(
+    var spec: c.SDL_AudioSpec = undefined;
+    try errors.wrapCallBool(c.SDL_LoadWAV(
         path.ptr,
         &spec,
         &data,
@@ -2065,8 +2065,8 @@ pub fn loadWavIo(
 ) !struct { spec: Spec, data: []u8 } {
     var data: [*c]u8 = undefined;
     var len: u32 = undefined;
-    var spec: C.SDL_AudioSpec = undefined;
-    try errors.wrapCallBool(C.SDL_LoadWAV_IO(
+    var spec: c.SDL_AudioSpec = undefined;
+    try errors.wrapCallBool(c.SDL_LoadWAV_IO(
         src.value,
         close_io,
         &spec,
@@ -2113,7 +2113,7 @@ pub fn mix(
 ) !void {
     if (src.len != dst.len)
         return errors.set("Source and destination audio length for mix do not match");
-    return errors.wrapCallBool(C.SDL_MixAudio(
+    return errors.wrapCallBool(c.SDL_MixAudio(
         dst.ptr,
         src.ptr,
         format.value,
@@ -2141,7 +2141,7 @@ pub fn mix(
 pub fn unbindStreams(
     streams: []const Stream,
 ) void {
-    C.SDL_UnbindAudioStreams(
+    c.SDL_UnbindAudioStreams(
         @ptrCast(streams.ptr),
         @intCast(streams.len),
     );

--- a/src/audio.zig
+++ b/src/audio.zig
@@ -32,7 +32,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const PostmixCallback = *const fn (user_data: ?*anyopaque, spec: [*c]const c.SDL_AudioSpec, buffer: [*c]f32, buffer_len: c_int) callconv(.C) void;
+pub const PostmixCallback = *const fn (user_data: ?*anyopaque, spec: [*c]const c.SDL_AudioSpec, buffer: [*c]f32, buffer_len: c_int) callconv(.c) void;
 
 /// A callback that fires when data passes through a `Stream`.
 ///
@@ -64,7 +64,7 @@ pub const PostmixCallback = *const fn (user_data: ?*anyopaque, spec: [*c]const c
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const StreamCallback = *const fn (user_data: ?*anyopaque, stream: ?*c.SDL_AudioStream, additional_amount: c_int, total_amount: c_int) callconv(.C) void;
+pub const StreamCallback = *const fn (user_data: ?*anyopaque, stream: ?*c.SDL_AudioStream, additional_amount: c_int, total_amount: c_int) callconv(.c) void;
 
 /// Audio format.
 ///

--- a/src/bits.zig
+++ b/src/bits.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// Determine if a unsigned 32-bit value has exactly one bit set.
@@ -19,7 +19,7 @@ const std = @import("std");
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasExactlyOneBitSet(val: u32) bool {
-    return C.SDL_HasExactlyOneBitSet32(val);
+    return c.SDL_HasExactlyOneBitSet32(val);
 }
 
 /// Get the index of the most significant (set) bit in a 32-bit number.
@@ -36,7 +36,7 @@ pub fn hasExactlyOneBitSet(val: u32) bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn mostSignificantBitIndex(val: u32) ?u5 {
-    const ret = C.SDL_MostSignificantBitIndex32(val);
+    const ret = c.SDL_MostSignificantBitIndex32(val);
     if (ret == -1)
         return null;
     return @intCast(ret);

--- a/src/blend_mode.zig
+++ b/src/blend_mode.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// The normalized factor used to multiply pixel components.
@@ -12,25 +12,25 @@ const std = @import("std");
 /// This enum is available since SDL 3.2.0.
 pub const Factor = enum(c_uint) {
     /// (0, 0, 0, 0)
-    zero = C.SDL_BLENDFACTOR_ZERO,
+    zero = c.SDL_BLENDFACTOR_ZERO,
     /// (1, 1, 1, 1)
-    one = C.SDL_BLENDFACTOR_ONE,
+    one = c.SDL_BLENDFACTOR_ONE,
     /// (r, g, b, a)
-    source_color = C.SDL_BLENDFACTOR_SRC_COLOR,
+    source_color = c.SDL_BLENDFACTOR_SRC_COLOR,
     /// (1-r, 1-g, 1-b, 1-a)
-    one_minus_source_color = C.SDL_BLENDFACTOR_ONE_MINUS_SRC_COLOR,
+    one_minus_source_color = c.SDL_BLENDFACTOR_ONE_MINUS_SRC_COLOR,
     /// (a, a, a, a)
-    soure_alpha = C.SDL_BLENDFACTOR_SRC_ALPHA,
+    soure_alpha = c.SDL_BLENDFACTOR_SRC_ALPHA,
     /// (1-a, 1-a, 1-a, 1-a)
-    one_minus_source_alpha = C.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+    one_minus_source_alpha = c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
     /// (r, g, b, a)
-    destination_color = C.SDL_BLENDFACTOR_DST_COLOR,
+    destination_color = c.SDL_BLENDFACTOR_DST_COLOR,
     /// (1-r, 1-g, 1-b, 1-a)
-    one_minus_destination_color = C.SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR,
+    one_minus_destination_color = c.SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR,
     /// (a, a, a, a)
-    destination_alpha = C.SDL_BLENDFACTOR_DST_ALPHA,
+    destination_alpha = c.SDL_BLENDFACTOR_DST_ALPHA,
     /// (1-a, 1-a, 1-a, 1-a)
-    one_minus_destination_alpha = C.SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA,
+    one_minus_destination_alpha = c.SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA,
 };
 
 /// The blend operation used when combining source and destination pixel components.
@@ -39,15 +39,15 @@ pub const Factor = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const Operation = enum(c_uint) {
     /// Destination + Source. Supported by all renderers.
-    add = C.SDL_BLENDOPERATION_ADD,
+    add = c.SDL_BLENDOPERATION_ADD,
     /// Source - Destination. Supported by D3D, OpenGL, OpenGLES, and Vulkan.
-    sub = C.SDL_BLENDOPERATION_SUBTRACT,
+    sub = c.SDL_BLENDOPERATION_SUBTRACT,
     /// Destination - Source. Supported by D3D, OpenGL, OpenGLES, and Vulkan.
-    rev_sub = C.SDL_BLENDOPERATION_REV_SUBTRACT,
+    rev_sub = c.SDL_BLENDOPERATION_REV_SUBTRACT,
     /// Min(Destination, Source). Supported by D3D, OpenGL, OpenGLES, and Vulkan.
-    min = C.SDL_BLENDOPERATION_MINIMUM,
+    min = c.SDL_BLENDOPERATION_MINIMUM,
     /// Max(Destination, Source). Supported by D3D, OpenGL, OpenGLES, and Vulkan.
-    max = C.SDL_BLENDOPERATION_MAXIMUM,
+    max = c.SDL_BLENDOPERATION_MAXIMUM,
 };
 
 /// A set of blend modes used in drawing operations.
@@ -60,35 +60,35 @@ pub const Operation = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const Mode = struct {
-    value: C.SDL_BlendMode,
+    value: c.SDL_BlendMode,
     /// Destination = Source.
-    pub const none = Mode{ .value = C.SDL_BLENDMODE_NONE };
+    pub const none = Mode{ .value = c.SDL_BLENDMODE_NONE };
     /// DestinationRGB = (SourceRGB * SourceA) + (DestinationRGB * (1-SourceA)), DestinationA = SourceA + (DestinationA * (1-SourceA)).
-    pub const blend = Mode{ .value = C.SDL_BLENDMODE_BLEND };
+    pub const blend = Mode{ .value = c.SDL_BLENDMODE_BLEND };
     /// DestinationRGBA = SourceRGBA + (DestinationRGBA * (1-SourceA)).
-    pub const blend_premultiplied = Mode{ .value = C.SDL_BLENDMODE_BLEND_PREMULTIPLIED };
+    pub const blend_premultiplied = Mode{ .value = c.SDL_BLENDMODE_BLEND_PREMULTIPLIED };
     /// DestinationRGB = (SourceRGB * SourceA) + DestinationRGB, DestinationA = DestinationA.
-    pub const add = Mode{ .value = C.SDL_BLENDMODE_ADD };
+    pub const add = Mode{ .value = c.SDL_BLENDMODE_ADD };
     /// DestinationRGB = SourceRGB + DestinationRGB, DestinationA = DestinationA.
-    pub const add_premultiplied = Mode{ .value = C.SDL_BLENDMODE_ADD_PREMULTIPLIED };
+    pub const add_premultiplied = Mode{ .value = c.SDL_BLENDMODE_ADD_PREMULTIPLIED };
     /// DestinationRGB = SourceRGB * DestinationRGB, DestinationA = DestinationA.
-    pub const mod = Mode{ .value = C.SDL_BLENDMODE_MOD };
+    pub const mod = Mode{ .value = c.SDL_BLENDMODE_MOD };
     /// DestinationRGB = (SourceRGB * DestinationRGB) + (DestinationRGB * (1-SourceA)), DestinationA = DestinationA.
-    pub const mul = Mode{ .value = C.SDL_BLENDMODE_MUL };
+    pub const mul = Mode{ .value = c.SDL_BLENDMODE_MUL };
 
     /// Convert from SDL. Returns null if invalid.
-    pub fn fromSdl(val: C.SDL_BlendMode) ?Mode {
-        if (val == C.SDL_BLENDMODE_INVALID)
+    pub fn fromSdl(val: c.SDL_BlendMode) ?Mode {
+        if (val == c.SDL_BLENDMODE_INVALID)
             return null;
         return .{ .value = val };
     }
 
     /// Convert to SDL.
-    pub fn toSdl(val: ?Mode) C.SDL_BlendMode {
+    pub fn toSdl(val: ?Mode) c.SDL_BlendMode {
         if (val) |id| {
             return id.value;
         }
-        return C.SDL_BLENDMODE_INVALID;
+        return c.SDL_BLENDMODE_INVALID;
     }
 
     /// Compose a custom blend mode for renderers.
@@ -159,7 +159,7 @@ pub const Mode = struct {
         dstAlpha: Factor,
         alphaOp: Operation,
     ) ?Mode {
-        const ret = C.SDL_ComposeCustomBlendMode(
+        const ret = c.SDL_ComposeCustomBlendMode(
             @intFromEnum(srcRgb),
             @intFromEnum(dstRgb),
             @intFromEnum(rgbOp),

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,6 +1,6 @@
 const extension_options = @import("extension_options");
 
-pub const C = @cImport({
+pub const c = @cImport({
     @cInclude("SDL3/SDL.h");
     if (extension_options.main) {
         @cInclude("SDL3/SDL_main.h");

--- a/src/camera.zig
+++ b/src/camera.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const pixels = @import("pixels.zig");
 const properties = @import("properties.zig");
@@ -24,8 +24,8 @@ pub const PermissionState = enum(c_int) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Position = enum(c_uint) {
-    front_facing = C.SDL_CAMERA_POSITION_FRONT_FACING,
-    back_facing = C.SDL_CAMERA_POSITION_BACK_FACING,
+    front_facing = c.SDL_CAMERA_POSITION_FRONT_FACING,
+    back_facing = c.SDL_CAMERA_POSITION_BACK_FACING,
 };
 
 /// This is a unique ID for a camera device for the time it is connected to the system, and is never reused for the lifetime of the application.
@@ -36,11 +36,11 @@ pub const Position = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_CameraID,
+    value: c.SDL_CameraID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_CameraID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_CameraID) == @sizeOf(ID));
     }
 
     /// Get a list of currently connected camera devices.
@@ -56,10 +56,10 @@ pub const ID = packed struct {
     /// This function is available since SDL 3.2.0.
     pub fn getAll() ![]ID {
         var count: c_int = undefined;
-        const val = C.SDL_GetCameras(
+        const val = c.SDL_GetCameras(
             &count,
         );
-        const ret = try errors.wrapCallCPtr(C.SDL_CameraID, val);
+        const ret = try errors.wrapCallCPtr(c.SDL_CameraID, val);
         return @as([*]ID, @ptrCast(ret))[0..@intCast(count)];
     }
 
@@ -79,7 +79,7 @@ pub const ID = packed struct {
     pub fn getName(
         self: ID,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetCameraName(
+        const ret = c.SDL_GetCameraName(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -105,10 +105,10 @@ pub const ID = packed struct {
     pub fn getPosition(
         self: ID,
     ) ?Position {
-        const ret = C.SDL_GetCameraPosition(
+        const ret = c.SDL_GetCameraPosition(
             self.value,
         );
-        if (ret == C.SDL_CAMERA_POSITION_UNKNOWN)
+        if (ret == c.SDL_CAMERA_POSITION_UNKNOWN)
             return null;
         return @enumFromInt(ret);
     }
@@ -144,12 +144,12 @@ pub const ID = packed struct {
         allocator: std.mem.Allocator,
     ) ![]Specification {
         var count: c_int = undefined;
-        const val = C.SDL_GetCameraSupportedFormats(
+        const val = c.SDL_GetCameraSupportedFormats(
             self.value,
             &count,
         );
-        defer C.SDL_free(@ptrCast(val));
-        const ret = try errors.wrapCallCPtr([*c]C.SDL_CameraSpec, val);
+        defer c.SDL_free(@ptrCast(val));
+        const ret = try errors.wrapCallCPtr([*c]c.SDL_CameraSpec, val);
         var converted_ret = try allocator.alloc(Specification, @intCast(count));
         for (0..@intCast(count)) |ind| {
             converted_ret[ind] = Specification.fromSdl(ret[ind].*);
@@ -163,11 +163,11 @@ pub const ID = packed struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Camera = packed struct {
-    value: *C.SDL_Camera,
+    value: *c.SDL_Camera,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(*C.SDL_Camera) == @sizeOf(Camera));
+        std.debug.assert(@sizeOf(*c.SDL_Camera) == @sizeOf(Camera));
     }
 
     /// Acquire a frame.
@@ -207,7 +207,7 @@ pub const Camera = packed struct {
         self: Camera,
     ) struct { frame: ?surface.Surface, timestamp_nanoseconds: ?u64 } {
         var timestamp_nanoseconds: u64 = undefined;
-        const ret = C.SDL_AcquireCameraFrame(
+        const ret = c.SDL_AcquireCameraFrame(
             self.value,
             &timestamp_nanoseconds,
         );
@@ -227,7 +227,7 @@ pub const Camera = packed struct {
     pub fn deinit(
         self: Camera,
     ) void {
-        C.SDL_CloseCamera(
+        c.SDL_CloseCamera(
             self.value,
         );
     }
@@ -255,8 +255,8 @@ pub const Camera = packed struct {
     pub fn getFormat(
         self: Camera,
     ) !Specification {
-        var specification: C.SDL_CameraSpec = undefined;
-        const ret = C.SDL_GetCameraFormat(
+        var specification: c.SDL_CameraSpec = undefined;
+        const ret = c.SDL_GetCameraFormat(
             self.value,
             &specification,
         );
@@ -280,10 +280,10 @@ pub const Camera = packed struct {
     pub fn getID(
         self: Camera,
     ) !ID {
-        const ret = C.SDL_GetCameraID(
+        const ret = c.SDL_GetCameraID(
             self.value,
         );
-        return ID{ .value = try errors.wrapCall(C.SDL_CameraID, ret, 0) };
+        return ID{ .value = try errors.wrapCall(c.SDL_CameraID, ret, 0) };
     }
 
     /// Query if camera access has been approved by the user.
@@ -312,7 +312,7 @@ pub const Camera = packed struct {
     pub fn getPermissionState(
         self: Camera,
     ) PermissionState {
-        const ret = C.SDL_GetCameraPermissionState(
+        const ret = c.SDL_GetCameraPermissionState(
             self.value,
         );
         return @enumFromInt(ret);
@@ -334,7 +334,7 @@ pub const Camera = packed struct {
     pub fn getProperties(
         self: Camera,
     ) !properties.Group {
-        const ret = C.SDL_GetCameraProperties(
+        const ret = c.SDL_GetCameraProperties(
             self.value,
         );
         if (ret == 0)
@@ -382,8 +382,8 @@ pub const Camera = packed struct {
         id: ID,
         specification: ?Specification,
     ) !Camera {
-        const specification_sdl: ?C.SDL_CameraSpec = if (specification) |val| val.toSdl() else null;
-        const ret = C.SDL_OpenCamera(
+        const specification_sdl: ?c.SDL_CameraSpec = if (specification) |val| val.toSdl() else null;
+        const ret = c.SDL_OpenCamera(
             id.value,
             if (specification != null) &specification_sdl.? else null,
         );
@@ -418,7 +418,7 @@ pub const Camera = packed struct {
         self: Camera,
         frame: surface.Surface,
     ) void {
-        C.SDL_ReleaseCameraFrame(
+        c.SDL_ReleaseCameraFrame(
             self.value,
             frame.value,
         );
@@ -441,10 +441,10 @@ pub const Specification = struct {
     framerate_denominator: usize,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(data: C.SDL_CameraSpec) Specification {
+    pub fn fromSdl(data: c.SDL_CameraSpec) Specification {
         return .{
-            .format = if (data.format == C.SDL_PIXELFORMAT_UNKNOWN) null else pixels.Format{ .value = data.format },
-            .colorspace = if (data.colorspace == C.SDL_COLORSPACE_UNKNOWN) null else pixels.Colorspace{ .value = data.colorspace },
+            .format = if (data.format == c.SDL_PIXELFORMAT_UNKNOWN) null else pixels.Format{ .value = data.format },
+            .colorspace = if (data.colorspace == c.SDL_COLORSPACE_UNKNOWN) null else pixels.Colorspace{ .value = data.colorspace },
             .width = @intCast(data.width),
             .height = @intCast(data.height),
             .framerate_numerator = @intCast(data.framerate_numerator),
@@ -453,10 +453,10 @@ pub const Specification = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Specification) C.SDL_CameraSpec {
+    pub fn toSdl(self: Specification) c.SDL_CameraSpec {
         return .{
-            .format = if (self.format) |val| val.value else C.SDL_PIXELFORMAT_UNKNOWN,
-            .colorspace = if (self.colorspace) |val| val.value else C.SDL_COLORSPACE_UNKNOWN,
+            .format = if (self.format) |val| val.value else c.SDL_PIXELFORMAT_UNKNOWN,
+            .colorspace = if (self.colorspace) |val| val.value else c.SDL_COLORSPACE_UNKNOWN,
             .width = @intCast(self.width),
             .height = @intCast(self.height),
             .framerate_numerator = @intCast(self.framerate_numerator),
@@ -480,7 +480,7 @@ pub const Specification = struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getCurrentDriverName() ?[:0]const u8 {
-    const ret = C.SDL_GetCurrentCameraDriver();
+    const ret = c.SDL_GetCurrentCameraDriver();
     if (ret == null)
         return null;
     return std.mem.span(ret);
@@ -509,7 +509,7 @@ pub fn getCurrentDriverName() ?[:0]const u8 {
 pub fn getDriverName(
     driver_index: usize,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetCameraDriver(
+    const ret = c.SDL_GetCameraDriver(
         @intCast(driver_index),
     );
     if (ret == null)
@@ -536,7 +536,7 @@ pub fn getDriverName(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getNumDrivers() usize {
-    const ret = C.SDL_GetNumCameraDrivers();
+    const ret = c.SDL_GetNumCameraDrivers();
     return @intCast(ret);
 }
 

--- a/src/clipboard.zig
+++ b/src/clipboard.zig
@@ -11,7 +11,7 @@ const stdinc = @import("stdinc.zig");
 ///
 /// ## Version
 /// This function is available since SDL 3.2.0.
-pub const CleanupCallback = *const fn (user_data: ?*anyopaque) callconv(.C) void;
+pub const CleanupCallback = *const fn (user_data: ?*anyopaque) callconv(.c) void;
 
 /// Callback function that will be called when data for the specified mime-type is requested by the OS.
 ///
@@ -33,7 +33,7 @@ pub const CleanupCallback = *const fn (user_data: ?*anyopaque) callconv(.C) void
 ///
 /// ## Version
 /// This function is available since SDL 3.2.0.
-pub const DataCallback = *const fn (user_data: ?*anyopaque, mime_type: [*c]const u8, size: [*c]usize) callconv(.C) ?*anyopaque;
+pub const DataCallback = *const fn (user_data: ?*anyopaque, mime_type: [*c]const u8, size: [*c]usize) callconv(.c) ?*anyopaque;
 
 /// Clear the clipboard data.
 ///
@@ -272,7 +272,7 @@ pub fn setText(
 
 fn cleanup_cb(
     user_data: ?*anyopaque,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = user_data;
 }
 
@@ -280,7 +280,7 @@ fn data_cb(
     user_data: ?*anyopaque,
     mime_type: [*c]const u8,
     size: [*c]usize,
-) callconv(.C) ?*anyopaque {
+) callconv(.c) ?*anyopaque {
     _ = user_data;
     _ = mime_type;
     size.* = 1;

--- a/src/clipboard.zig
+++ b/src/clipboard.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const init = @import("init.zig");
 const errors = @import("errors.zig");
 const std = @import("std");
@@ -43,7 +43,7 @@ pub const DataCallback = *const fn (user_data: ?*anyopaque, mime_type: [*c]const
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn clearData() !void {
-    const ret = C.SDL_ClearClipboardData();
+    const ret = c.SDL_ClearClipboardData();
     return errors.wrapCallBool(ret);
 }
 
@@ -67,7 +67,7 @@ pub fn getData(
     mime_type: [:0]const u8,
 ) ![:0]const u8 {
     var size: usize = undefined;
-    const val = C.SDL_GetClipboardData(
+    const val = c.SDL_GetClipboardData(
         mime_type,
         &size,
     );
@@ -88,7 +88,7 @@ pub fn getData(
 /// This function is available since SDL 3.2.0.
 pub fn getMimeTypes() ![][*:0]u8 {
     var num_mime_types: usize = undefined;
-    const val = C.SDL_GetClipboardMimeTypes(
+    const val = c.SDL_GetClipboardMimeTypes(
         &num_mime_types,
     );
     const ret = try errors.wrapCallCPtr([*c]u8, val);
@@ -110,7 +110,7 @@ pub fn getMimeTypes() ![][*:0]u8 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getPrimarySelectionText() ![:0]const u8 {
-    const ret = C.SDL_GetPrimarySelectionText();
+    const ret = c.SDL_GetPrimarySelectionText();
     const converted_ret = std.mem.span(ret);
     if (std.mem.eql(u8, converted_ret, "")) {
         if (errors.error_callback) |val|
@@ -135,7 +135,7 @@ pub fn getPrimarySelectionText() ![:0]const u8 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getText() ![:0]u8 {
-    const ret = C.SDL_GetClipboardText();
+    const ret = c.SDL_GetClipboardText();
     const converted_ret: [:0]u8 = std.mem.span(ret);
     if (std.mem.eql(u8, converted_ret, "")) {
         if (errors.error_callback) |val|
@@ -161,7 +161,7 @@ pub fn getText() ![:0]u8 {
 pub fn hasData(
     mime_type: [:0]const u8,
 ) bool {
-    const ret = C.SDL_HasClipboardData(
+    const ret = c.SDL_HasClipboardData(
         mime_type.ptr,
     );
     return ret;
@@ -178,7 +178,7 @@ pub fn hasData(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasPrimarySelectionText() bool {
-    const ret = C.SDL_HasPrimarySelectionText();
+    const ret = c.SDL_HasPrimarySelectionText();
     return ret;
 }
 
@@ -193,7 +193,7 @@ pub fn hasPrimarySelectionText() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasText() bool {
-    const ret = C.SDL_HasClipboardText();
+    const ret = c.SDL_HasClipboardText();
     return ret;
 }
 
@@ -222,7 +222,7 @@ pub fn setData(
     user_data: ?*anyopaque,
     mime_types: [][*:0]const u8,
 ) !void {
-    const ret = C.SDL_SetClipboardData(
+    const ret = c.SDL_SetClipboardData(
         callback,
         cleanup,
         user_data,
@@ -245,7 +245,7 @@ pub fn setData(
 pub fn setPrimarySelectionText(
     text: [:0]const u8,
 ) !void {
-    const ret = C.SDL_SetPrimarySelectionText(
+    const ret = c.SDL_SetPrimarySelectionText(
         text,
     );
     return errors.wrapCallBool(ret);
@@ -264,7 +264,7 @@ pub fn setPrimarySelectionText(
 pub fn setText(
     text: [:0]const u8,
 ) !void {
-    const ret = C.SDL_SetClipboardText(
+    const ret = c.SDL_SetClipboardText(
         text.ptr,
     );
     return errors.wrapCallBool(ret);

--- a/src/cpu_info.zig
+++ b/src/cpu_info.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// A guess for the cacheline size used for padding.
@@ -10,7 +10,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This macro is available since SDL 3.2.0.
-pub const cacheline_size = C.SDL_CACHELINE_SIZE;
+pub const cacheline_size = c.SDL_CACHELINE_SIZE;
 
 /// Determine the L1 cache line size of the CPU.
 ///
@@ -26,7 +26,7 @@ pub const cacheline_size = C.SDL_CACHELINE_SIZE;
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getCacheLineSize() usize {
-    return @intCast(C.SDL_GetCPUCacheLineSize());
+    return @intCast(c.SDL_GetCPUCacheLineSize());
 }
 
 /// Get the number of logical CPU cores available.
@@ -41,7 +41,7 @@ pub fn getCacheLineSize() usize {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getNumLogicalCores() usize {
-    return @intCast(C.SDL_GetNumLogicalCPUCores());
+    return @intCast(c.SDL_GetNumLogicalCPUCores());
 }
 
 /// Report the alignment this system needs for SIMD allocations.
@@ -62,7 +62,7 @@ pub fn getNumLogicalCores() usize {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getSimdAlignment() usize {
-    return C.SDL_GetSIMDAlignment();
+    return c.SDL_GetSIMDAlignment();
 }
 
 /// Get the amount of RAM configured in the system.
@@ -76,7 +76,7 @@ pub fn getSimdAlignment() usize {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getSystemRam() usize {
-    return @intCast(C.SDL_GetSystemRAM());
+    return @intCast(c.SDL_GetSystemRAM());
 }
 
 /// Determine whether the CPU has AltiVec features.
@@ -93,7 +93,7 @@ pub fn getSystemRam() usize {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasAltiVec() bool {
-    return C.SDL_HasAltiVec();
+    return c.SDL_HasAltiVec();
 }
 
 /// Determine whether the CPU has ARM SIMD (ARMv6) features.
@@ -112,7 +112,7 @@ pub fn hasAltiVec() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasArmSimd() bool {
-    return C.SDL_HasARMSIMD();
+    return c.SDL_HasARMSIMD();
 }
 
 /// Determine whether the CPU has AVX features.
@@ -129,7 +129,7 @@ pub fn hasArmSimd() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasAvx() bool {
-    return C.SDL_HasAVX();
+    return c.SDL_HasAVX();
 }
 
 /// Determine whether the CPU has AVX2 features.
@@ -146,7 +146,7 @@ pub fn hasAvx() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasAvx2() bool {
-    return C.SDL_HasAVX2();
+    return c.SDL_HasAVX2();
 }
 
 /// Determine whether the CPU has AVX-512F (foundation) features.
@@ -163,7 +163,7 @@ pub fn hasAvx2() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasAvx512F() bool {
-    return C.SDL_HasAVX512F();
+    return c.SDL_HasAVX512F();
 }
 
 /// Determine whether the CPU has LASX (LOONGARCH SIMD) features.
@@ -180,7 +180,7 @@ pub fn hasAvx512F() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasLasx() bool {
-    return C.SDL_HasLASX();
+    return c.SDL_HasLASX();
 }
 
 /// Determine whether the CPU has LSX (LOONGARCH SIMD) features.
@@ -197,7 +197,7 @@ pub fn hasLasx() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasLsx() bool {
-    return C.SDL_HasLSX();
+    return c.SDL_HasLSX();
 }
 
 /// Determine whether the CPU has MMX features.
@@ -214,7 +214,7 @@ pub fn hasLsx() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasMmx() bool {
-    return C.SDL_HasMMX();
+    return c.SDL_HasMMX();
 }
 
 /// Determine whether the CPU has NEON (ARM SIMD) features.
@@ -231,7 +231,7 @@ pub fn hasMmx() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasNeon() bool {
-    return C.SDL_HasNEON();
+    return c.SDL_HasNEON();
 }
 
 /// Determine whether the CPU has SSE features.
@@ -248,7 +248,7 @@ pub fn hasNeon() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasSse() bool {
-    return C.SDL_HasSSE();
+    return c.SDL_HasSSE();
 }
 
 /// Determine whether the CPU has SSE2 features.
@@ -265,7 +265,7 @@ pub fn hasSse() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasSse2() bool {
-    return C.SDL_HasSSE2();
+    return c.SDL_HasSSE2();
 }
 
 /// Determine whether the CPU has SSE3 features.
@@ -282,7 +282,7 @@ pub fn hasSse2() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasSse3() bool {
-    return C.SDL_HasSSE3();
+    return c.SDL_HasSSE3();
 }
 
 /// Determine whether the CPU has SSE4.1 features.
@@ -299,7 +299,7 @@ pub fn hasSse3() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasSse41() bool {
-    return C.SDL_HasSSE41();
+    return c.SDL_HasSSE41();
 }
 
 /// Determine whether the CPU has SSE4.2 features.
@@ -316,7 +316,7 @@ pub fn hasSse41() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasSse42() bool {
-    return C.SDL_HasSSE42();
+    return c.SDL_HasSSE42();
 }
 
 // CPU testing.

--- a/src/dialog.zig
+++ b/src/dialog.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const properties = @import("properties.zig");
 const std = @import("std");
@@ -76,11 +76,11 @@ pub const FileFilter = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_DialogFileFilter) == @sizeOf(FileFilter));
-        std.debug.assert(@offsetOf(C.SDL_DialogFileFilter, "name") == @offsetOf(FileFilter, "name"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_DialogFileFilter, "name")) == @sizeOf(@FieldType(FileFilter, "name")));
-        std.debug.assert(@offsetOf(C.SDL_DialogFileFilter, "pattern") == @offsetOf(FileFilter, "pattern"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_DialogFileFilter, "pattern")) == @sizeOf(@FieldType(FileFilter, "pattern")));
+        std.debug.assert(@sizeOf(c.SDL_DialogFileFilter) == @sizeOf(FileFilter));
+        std.debug.assert(@offsetOf(c.SDL_DialogFileFilter, "name") == @offsetOf(FileFilter, "name"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_DialogFileFilter, "name")) == @sizeOf(@FieldType(FileFilter, "name")));
+        std.debug.assert(@offsetOf(c.SDL_DialogFileFilter, "pattern") == @offsetOf(FileFilter, "pattern"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_DialogFileFilter, "pattern")) == @sizeOf(@FieldType(FileFilter, "pattern")));
     }
 };
 
@@ -114,21 +114,21 @@ pub const Properties = struct {
         const ret = try properties.Group.init();
         errdefer ret.deinit();
         if (self.filters) |val| {
-            try ret.set(C.SDL_PROP_FILE_DIALOG_FILTERS_POINTER, .{ .pointer = @constCast(@as([*]const C.SDL_DialogFileFilter, @ptrCast(val.ptr))) });
-            try ret.set(C.SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, .{ .number = @intCast(val.len) });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_FILTERS_POINTER, .{ .pointer = @constCast(@as([*]const c.SDL_DialogFileFilter, @ptrCast(val.ptr))) });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, .{ .number = @intCast(val.len) });
         }
         if (self.window) |val|
-            try ret.set(C.SDL_PROP_FILE_DIALOG_WINDOW_POINTER, .{ .pointer = val.value });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_WINDOW_POINTER, .{ .pointer = val.value });
         if (self.location) |val|
-            try ret.set(C.SDL_PROP_FILE_DIALOG_LOCATION_STRING, .{ .string = val });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_LOCATION_STRING, .{ .string = val });
         if (self.many) |val|
-            try ret.set(C.SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, .{ .boolean = val });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, .{ .boolean = val });
         if (self.title) |val|
-            try ret.set(C.SDL_PROP_FILE_DIALOG_TITLE_STRING, .{ .string = val });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_TITLE_STRING, .{ .string = val });
         if (self.accept) |val|
-            try ret.set(C.SDL_PROP_FILE_DIALOG_ACCEPT_STRING, .{ .string = val });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_ACCEPT_STRING, .{ .string = val });
         if (self.cancel) |val|
-            try ret.set(C.SDL_PROP_FILE_DIALOG_CANCEL_STRING, .{ .string = val });
+            try ret.set(c.SDL_PROP_FILE_DIALOG_CANCEL_STRING, .{ .string = val });
         return ret;
     }
 };
@@ -141,9 +141,9 @@ pub const Properties = struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Type = enum(c_uint) {
-    open_file = C.SDL_FILEDIALOG_OPENFILE,
-    save_file = C.SDL_FILEDIALOG_SAVEFILE,
-    open_folder = C.SDL_FILEDIALOG_OPENFOLDER,
+    open_file = c.SDL_FILEDIALOG_OPENFILE,
+    save_file = c.SDL_FILEDIALOG_SAVEFILE,
+    open_folder = c.SDL_FILEDIALOG_OPENFOLDER,
 };
 
 /// Sanatize data from a dialog callback.
@@ -219,7 +219,7 @@ pub fn showOpenFile(
     default_location: ?[:0]const u8,
     allow_many: bool,
 ) void {
-    C.SDL_ShowOpenFileDialog(
+    c.SDL_ShowOpenFileDialog(
         callback,
         user_data,
         if (window) |val| val.value else null,
@@ -265,7 +265,7 @@ pub fn showOpenFolder(
     default_location: ?[:0]const u8,
     allow_many: bool,
 ) void {
-    C.SDL_ShowOpenFolderDialog(
+    c.SDL_ShowOpenFolderDialog(
         callback,
         user_data,
         if (window) |val| val.value else null,
@@ -309,7 +309,7 @@ pub fn showSaveFile(
     filters: ?[]const FileFilter,
     default_location: ?[:0]const u8,
 ) void {
-    C.SDL_ShowSaveFileDialog(
+    c.SDL_ShowSaveFileDialog(
         callback,
         user_data,
         if (window) |val| val.value else null,
@@ -343,7 +343,7 @@ pub fn showWithProperties(
     props: Properties,
 ) !properties.Group {
     const ret = try props.toProperties();
-    C.SDL_ShowFileDialogWithProperties(
+    c.SDL_ShowFileDialogWithProperties(
         @intFromEnum(dialog_type),
         callback,
         user_data,

--- a/src/dialog.zig
+++ b/src/dialog.zig
@@ -33,7 +33,7 @@ const video = @import("video.zig");
 ///
 /// ## Code Examples
 /// TODO!!!
-pub const FileCallback = *const fn (user_data: ?*anyopaque, file_list: [*c]const [*c]const u8, filter: c_int) callconv(.C) void;
+pub const FileCallback = *const fn (user_data: ?*anyopaque, file_list: [*c]const [*c]const u8, filter: c_int) callconv(.c) void;
 
 /// Data for a file callback.
 ///

--- a/src/endian.zig
+++ b/src/endian.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -8,9 +8,9 @@ const std = @import("std");
 /// This enum is provided by zig-sdl3.
 pub const ByteOrder = enum(c_int) {
     /// A value to represent bigendian byteorder.
-    big = C.BIG_ENDIAN,
+    big = c.BIG_ENDIAN,
     /// A value to represent littleendian byteorder.
-    little = C.LITTLE_ENDIAN,
+    little = c.LITTLE_ENDIAN,
 };
 
 /// A function that reports the target system's byte order.
@@ -21,7 +21,7 @@ pub const ByteOrder = enum(c_int) {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn byteOrder() ByteOrder {
-    return @enumFromInt(C.BYTE_ORDER);
+    return @enumFromInt(c.BYTE_ORDER);
 }
 
 /// A function that reports the target system's floating point word order.
@@ -32,7 +32,7 @@ pub inline fn byteOrder() ByteOrder {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn floatWordOrder() ByteOrder {
-    return @enumFromInt(C.SDL_FLOATWORDORDER);
+    return @enumFromInt(c.SDL_FLOATWORDORDER);
 }
 
 /// Byte-swap an unsigned 16-bit number.
@@ -53,7 +53,7 @@ pub inline fn floatWordOrder() ByteOrder {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap16(val: u16) u16 {
-    return C.SDL_Swap16(val);
+    return c.SDL_Swap16(val);
 }
 
 /// Swap a 16-bit value from bigendian to native byte order.
@@ -70,7 +70,7 @@ pub inline fn swap16(val: u16) u16 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap16Be(val: u16) u16 {
-    return C.SDL_Swap16BE(val);
+    return c.SDL_Swap16BE(val);
 }
 
 /// Swap a 16-bit value from littleendian to native byte order.
@@ -87,7 +87,7 @@ pub inline fn swap16Be(val: u16) u16 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap16Le(val: u16) u16 {
-    return C.SDL_Swap16LE(val);
+    return c.SDL_Swap16LE(val);
 }
 
 /// Byte-swap an unsigned 32-bit number.
@@ -108,7 +108,7 @@ pub inline fn swap16Le(val: u16) u16 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap32(val: u32) u32 {
-    return C.SDL_Swap32(val);
+    return c.SDL_Swap32(val);
 }
 
 /// Swap a 32-bit value from bigendian to native byte order.
@@ -125,7 +125,7 @@ pub inline fn swap32(val: u32) u32 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap32Be(val: u32) u32 {
-    return C.SDL_Swap32BE(val);
+    return c.SDL_Swap32BE(val);
 }
 
 /// Swap a 32-bit value from littleendian to native byte order.
@@ -142,7 +142,7 @@ pub inline fn swap32Be(val: u32) u32 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap32Le(val: u32) u32 {
-    return C.SDL_Swap32LE(val);
+    return c.SDL_Swap32LE(val);
 }
 
 /// Byte-swap an unsigned 64-bit number.
@@ -163,7 +163,7 @@ pub inline fn swap32Le(val: u32) u32 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap64(val: u64) u64 {
-    return C.SDL_Swap64(val);
+    return c.SDL_Swap64(val);
 }
 
 /// Swap a 64-bit value from bigendian to native byte order.
@@ -180,7 +180,7 @@ pub inline fn swap64(val: u64) u64 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap64Be(val: u64) u64 {
-    return C.SDL_Swap64BE(val);
+    return c.SDL_Swap64BE(val);
 }
 
 /// Swap a 64-bit value from littleendian to native byte order.
@@ -197,7 +197,7 @@ pub inline fn swap64Be(val: u64) u64 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swap64Le(val: u64) u64 {
-    return C.SDL_Swap64LE(val);
+    return c.SDL_Swap64LE(val);
 }
 
 /// Byte-swap a floating point number.
@@ -218,7 +218,7 @@ pub inline fn swap64Le(val: u64) u64 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swapFloat(val: f32) f32 {
-    return C.SDL_SwapFloat(val);
+    return c.SDL_SwapFloat(val);
 }
 
 /// Swap a floating point value from bigendian to native byte order.
@@ -238,7 +238,7 @@ pub inline fn swapFloat(val: f32) f32 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swapFloatBe(val: f32) f32 {
-    return C.SDL_SwapFloatBE(val);
+    return c.SDL_SwapFloatBE(val);
 }
 
 /// Swap a floating point value from littleendian to native byte order.
@@ -258,7 +258,7 @@ pub inline fn swapFloatBe(val: f32) f32 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub inline fn swapFloatLe(val: f32) f32 {
-    return C.SDL_SwapFloatLE(val);
+    return c.SDL_SwapFloatLE(val);
 }
 
 // Endian tests.

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// Callback for when an SDL error occurs.
@@ -65,7 +65,7 @@ pub fn callErrorCallback() void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn clear() void {
-    _ = C.SDL_ClearError();
+    _ = c.SDL_ClearError();
 }
 
 /// Standardize error reporting on unsupported operations.
@@ -84,7 +84,7 @@ pub fn clear() void {
 pub fn invalidParamError(
     err: [:0]const u8,
 ) !void {
-    _ = C.SDL_InvalidParamError(err.ptr);
+    _ = c.SDL_InvalidParamError(err.ptr);
     return error.SdlError;
 }
 
@@ -116,7 +116,7 @@ pub fn invalidParamError(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn get() ?[:0]const u8 {
-    const ret = C.SDL_GetError();
+    const ret = c.SDL_GetError();
     const converted_ret = std.mem.span(ret);
     if (std.mem.eql(u8, converted_ret, ""))
         return null;
@@ -141,7 +141,7 @@ pub fn get() ?[:0]const u8 {
 pub fn set(
     err: [:0]const u8,
 ) !void {
-    _ = C.SDL_SetError(
+    _ = c.SDL_SetError(
         "%s",
         err.ptr,
     );
@@ -159,7 +159,7 @@ pub fn set(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn signalOutOfMemory() !void {
-    _ = C.SDL_OutOfMemory();
+    _ = c.SDL_OutOfMemory();
     return error.SdlError;
 }
 
@@ -174,7 +174,7 @@ pub fn signalOutOfMemory() !void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn unsupported() !void {
-    _ = C.SDL_Unsupported();
+    _ = c.SDL_Unsupported();
     return error.SdlError;
 }
 

--- a/src/events.zig
+++ b/src/events.zig
@@ -6,6 +6,7 @@ const video = @import("video.zig");
 const keyboard = @import("keyboard.zig");
 const keycode = @import("keycode.zig");
 const scancode = @import("scancode.zig");
+const mouse = @import("mouse.zig");
 
 /// The type of action to request from `events.peep()`.
 ///
@@ -268,8 +269,10 @@ pub const Type = enum(c.SDL_EventType) {
     // KeyboardRemoved,
     // TextEditingCandidates,
     // MouseMotion,
-    // MouseButtonDown,
-    // MouseButtonUp,
+    /// Mouse button pressed.
+    mouse_button_down = c.SDL_EVENT_MOUSE_BUTTON_DOWN,
+    /// Mouse button released.
+    mouse_button_up = c.SDL_EVENT_MOUSE_BUTTON_UP,
     // MouseWheel,
     // MouseAdded,
     // MouseRemoved,
@@ -439,6 +442,42 @@ pub const Key = struct {
     repeat: bool,
 };
 
+/// Mouse button event structure
+///
+/// ## Version
+/// This struct is available since SDL 3.2.0.
+///
+/// ## Code Examples
+/// ```zig
+///     const mouse_button =
+///     if (event.* == .mouse_button_down) event.mouse_button_down.button else return;
+///     if (mouse_button.left) {
+///         std.debug.print("left click\n", .{});
+///     } else if (mouse_button.right) {
+///         std.debug.print("right click\n", .{});
+///     }
+/// ```
+/// ## Remarks
+/// Only one button can be set to true per event
+pub const MouseButton = struct {
+    /// Common event information.
+    common: Common,
+    /// The window with mouse focus, if any.
+    window_id: ?video.WindowID = null,
+    /// The mouse instance id in relative mode, or null.
+    which: ?mouse.ID,
+    /// The mouse button index.
+    button: mouse.ButtonFlags,
+    /// true if the button is pressed.
+    down: bool,
+    /// 1 for single-click, 2 for double-click, etc.
+    clicks: u8,
+    /// X coordinate, relative to window.
+    x: f32,
+    /// Y coordinate, relative to window.
+    y: f32,
+};
+
 /// The "quit requested" event.
 pub const Quit = struct {
     /// Common event information.
@@ -467,6 +506,10 @@ pub const Event = union(Type) {
     key_down: Key,
     /// A key released event.
     key_up: Key,
+    /// A mouse pressed event.
+    mouse_button_down: MouseButton,
+    /// A mouse released event.
+    mouse_button_up: MouseButton,
     /// A user event.
     user: User,
     /// An unknown event.
@@ -509,7 +552,7 @@ pub const Event = union(Type) {
             c.SDL_EVENT_KEY_DOWN => .{
                 .key_down = .{
                     .common = Common.fromSdl(&event),
-                    .window_id = if (event.user.windowID == 0) null else event.key.windowID,
+                    .window_id = if (event.key.windowID == 0) null else event.key.windowID,
                     .which = .{
                         .value = event.key.which,
                     },
@@ -524,7 +567,7 @@ pub const Event = union(Type) {
             c.SDL_EVENT_KEY_UP => .{
                 .key_up = .{
                     .common = Common.fromSdl(&event),
-                    .window_id = if (event.user.windowID == 0) null else event.key.windowID,
+                    .window_id = if (event.key.windowID == 0) null else event.key.windowID,
                     .which = .{
                         .value = event.key.which,
                     },
@@ -534,6 +577,34 @@ pub const Event = union(Type) {
                     .raw = event.key.raw,
                     .down = event.key.down,
                     .repeat = event.key.repeat,
+                },
+            },
+            c.SDL_EVENT_MOUSE_BUTTON_DOWN => .{
+                .mouse_button_down = .{
+                    .common = Common.fromSdl(&event),
+                    .window_id = if (event.button.windowID == 0) null else event.button.windowID,
+                    .which = if (event.button.which == 0) null else .{
+                        .value = event.button.which,
+                    },
+                    .button = mouse.ButtonFlags.fromSdl(event.button.button),
+                    .down = event.button.down,
+                    .clicks = event.button.clicks,
+                    .x = event.button.x,
+                    .y = event.button.y,
+                },
+            },
+            c.SDL_EVENT_MOUSE_BUTTON_UP => .{
+                .mouse_button_up = .{
+                    .common = Common.fromSdl(&event),
+                    .window_id = if (event.button.windowID == 0) null else event.button.windowID,
+                    .which = if (event.button.which == 0) null else .{
+                        .value = event.button.which,
+                    },
+                    .button = mouse.ButtonFlags.fromSdl(event.button.button),
+                    .down = event.button.down,
+                    .clicks = event.button.clicks,
+                    .x = event.button.x,
+                    .y = event.button.y,
                 },
             },
             c.SDL_EVENT_ENUM_PADDING => .{
@@ -625,11 +696,55 @@ pub const Event = union(Type) {
                 .data1 = val.data1,
                 .data2 = val.data2,
             } },
-            .key_up => .{
+            .key_up => |val| .{ .key = .{
                 .type = c.SDL_EVENT_KEY_UP,
-            },
-            .key_down => .{
+                .timestamp = val.common.timestamp,
+                .windowID = if (val.window_id) |id| id else 0,
+                .which = if (val.which) |which| which.value else 0,
+                .scancode = if (val.scancode) |code| code.toSdl() else c.SDL_SCANCODE_UNKNOWN,
+                .key = keycode.Keycode.toSdl(val.key),
+                .mod = val.mod.toSdl(),
+                .raw = val.raw,
+                .down = val.down,
+                .repeat = val.repeat,
+            } },
+            .key_down => |val| .{ .key = .{
                 .type = c.SDL_EVENT_KEY_DOWN,
+                .timestamp = val.common.timestamp,
+                .windowID = if (val.window_id) |id| id else 0,
+                .which = if (val.which) |which| which.value else 0,
+                .scancode = if (val.scancode) |code| code.toSdl() else c.SDL_SCANCODE_UNKNOWN,
+                .key = keycode.Keycode.toSdl(val.key),
+                .mod = val.mod.toSdl(),
+                .raw = val.raw,
+                .down = val.down,
+                .repeat = val.repeat,
+            } },
+            .mouse_button_up => |val| .{
+                .button = .{
+                    .type = c.SDL_EVENT_MOUSE_BUTTON_UP,
+                    .timestamp = val.common.timestamp,
+                    .windowID = if (val.window_id) |id| id else 0,
+                    .which = mouse.ID.toSdl(val.which),
+                    .button = @intCast(val.button.toSdl()),
+                    .down = val.down,
+                    .clicks = val.clicks,
+                    .x = val.x,
+                    .y = val.y,
+                },
+            },
+            .mouse_button_down => |val| .{
+                .button = .{
+                    .type = c.SDL_EVENT_MOUSE_BUTTON_DOWN,
+                    .timestamp = val.common.timestamp,
+                    .windowID = if (val.window_id) |id| id else 0,
+                    .which = mouse.ID.toSdl(val.which),
+                    .button = @intCast(val.button.toSdl()),
+                    .down = val.down,
+                    .clicks = val.clicks,
+                    .x = val.x,
+                    .y = val.y,
+                },
             },
             .padding => .{
                 .type = c.SDL_EVENT_ENUM_PADDING,
@@ -1194,6 +1309,8 @@ fn dummyFilter(
 
 // Test SDL events.
 test "Events" {
+    std.testing.refAllDeclsRecursive(@This());
+
     defer init.shutdown();
     try init.init(.{ .events = true });
     defer init.quit(.{ .events = true });

--- a/src/events.zig
+++ b/src/events.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const init = @import("init.zig");
 const std = @import("std");
@@ -35,7 +35,7 @@ pub const Action = enum(c_uint) {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const Filter = *const fn (user_data: ?*anyopaque, event: [*c]C.SDL_Event) callconv(.C) bool;
+pub const Filter = *const fn (user_data: ?*anyopaque, event: [*c]c.SDL_Event) callconv(.C) bool;
 
 /// For clearing out a group of events.
 ///
@@ -86,8 +86,8 @@ pub const Group = enum {
     /// ## Version
     /// Provided by zig-sdl3.
     pub const Iterator = struct {
-        curr: C.SDL_EventType,
-        max: C.SDL_EventType,
+        curr: c.SDL_EventType,
+        max: c.SDL_EventType,
 
         /// Get the next event type in the iterator.
         ///
@@ -104,7 +104,7 @@ pub const Group = enum {
         /// Provided by zig-sdl3.
         pub fn next(
             self: *Iterator,
-        ) ?C.SDL_EventType {
+        ) ?c.SDL_EventType {
             if (self.curr <= self.max) {
                 const ret = self.curr;
                 self.curr += 1;
@@ -132,7 +132,7 @@ pub const Group = enum {
         self: Group,
         event_type: Type,
     ) bool {
-        const raw: C.SDL_EventType = @intFromEnum(event_type);
+        const raw: c.SDL_EventType = @intFromEnum(event_type);
         const minmax = self.minMax();
         return raw >= minmax.min and raw <= minmax.max;
     }
@@ -175,27 +175,27 @@ pub const Group = enum {
     /// Provided by zig-sdl3.
     pub fn minMax(
         self: Group,
-    ) struct { min: C.SDL_EventType, max: C.SDL_EventType } {
+    ) struct { min: c.SDL_EventType, max: c.SDL_EventType } {
         return switch (self) {
-            .all => .{ .min = 0, .max = std.math.maxInt(C.SDL_EventType) },
-            .application => .{ .min = C.SDL_EVENT_QUIT, .max = C.SDL_EVENT_SYSTEM_THEME_CHANGED },
-            .display => .{ .min = C.SDL_EVENT_DISPLAY_FIRST, .max = C.SDL_EVENT_DISPLAY_LAST },
-            .window => .{ .min = C.SDL_EVENT_WINDOW_FIRST, .max = C.SDL_EVENT_WINDOW_LAST },
-            .keyboard => .{ .min = C.SDL_EVENT_KEY_DOWN, .max = C.SDL_EVENT_TEXT_EDITING_CANDIDATES },
-            .mouse => .{ .min = C.SDL_EVENT_MOUSE_MOTION, .max = C.SDL_EVENT_MOUSE_REMOVED },
-            .joystick => .{ .min = C.SDL_EVENT_JOYSTICK_AXIS_MOTION, .max = C.SDL_EVENT_JOYSTICK_UPDATE_COMPLETE },
-            .gamepad => .{ .min = C.SDL_EVENT_GAMEPAD_AXIS_MOTION, .max = C.SDL_EVENT_GAMEPAD_STEAM_HANDLE_UPDATED },
-            .touch => .{ .min = C.SDL_EVENT_FINGER_DOWN, .max = C.SDL_EVENT_FINGER_CANCELED },
-            .clipboard => .{ .min = C.SDL_EVENT_CLIPBOARD_UPDATE, .max = C.SDL_EVENT_CLIPBOARD_UPDATE },
-            .drag_and_drop => .{ .min = C.SDL_EVENT_DROP_FILE, .max = C.SDL_EVENT_DROP_POSITION },
-            .audio => .{ .min = C.SDL_EVENT_AUDIO_DEVICE_ADDED, .max = C.SDL_EVENT_AUDIO_DEVICE_FORMAT_CHANGED },
-            .sensor => .{ .min = C.SDL_EVENT_SENSOR_UPDATE, .max = C.SDL_EVENT_SENSOR_UPDATE },
-            .pen => .{ .min = C.SDL_EVENT_PEN_PROXIMITY_IN, .max = C.SDL_EVENT_PEN_AXIS },
-            .camera => .{ .min = C.SDL_EVENT_CAMERA_DEVICE_ADDED, .max = C.SDL_EVENT_CAMERA_DEVICE_DENIED },
-            .render => .{ .min = C.SDL_EVENT_RENDER_TARGETS_RESET, .max = C.SDL_EVENT_RENDER_DEVICE_LOST },
-            .reserved => .{ .min = C.SDL_EVENT_PRIVATE0, .max = C.SDL_EVENT_PRIVATE3 },
-            .internal => .{ .min = C.SDL_EVENT_POLL_SENTINEL, .max = C.SDL_EVENT_POLL_SENTINEL },
-            .user => .{ .min = C.SDL_EVENT_USER, .max = C.SDL_EVENT_LAST },
+            .all => .{ .min = 0, .max = std.math.maxInt(c.SDL_EventType) },
+            .application => .{ .min = c.SDL_EVENT_QUIT, .max = c.SDL_EVENT_SYSTEM_THEME_CHANGED },
+            .display => .{ .min = c.SDL_EVENT_DISPLAY_FIRST, .max = c.SDL_EVENT_DISPLAY_LAST },
+            .window => .{ .min = c.SDL_EVENT_WINDOW_FIRST, .max = c.SDL_EVENT_WINDOW_LAST },
+            .keyboard => .{ .min = c.SDL_EVENT_KEY_DOWN, .max = c.SDL_EVENT_TEXT_EDITING_CANDIDATES },
+            .mouse => .{ .min = c.SDL_EVENT_MOUSE_MOTION, .max = c.SDL_EVENT_MOUSE_REMOVED },
+            .joystick => .{ .min = c.SDL_EVENT_JOYSTICK_AXIS_MOTION, .max = c.SDL_EVENT_JOYSTICK_UPDATE_COMPLETE },
+            .gamepad => .{ .min = c.SDL_EVENT_GAMEPAD_AXIS_MOTION, .max = c.SDL_EVENT_GAMEPAD_STEAM_HANDLE_UPDATED },
+            .touch => .{ .min = c.SDL_EVENT_FINGER_DOWN, .max = c.SDL_EVENT_FINGER_CANCELED },
+            .clipboard => .{ .min = c.SDL_EVENT_CLIPBOARD_UPDATE, .max = c.SDL_EVENT_CLIPBOARD_UPDATE },
+            .drag_and_drop => .{ .min = c.SDL_EVENT_DROP_FILE, .max = c.SDL_EVENT_DROP_POSITION },
+            .audio => .{ .min = c.SDL_EVENT_AUDIO_DEVICE_ADDED, .max = c.SDL_EVENT_AUDIO_DEVICE_FORMAT_CHANGED },
+            .sensor => .{ .min = c.SDL_EVENT_SENSOR_UPDATE, .max = c.SDL_EVENT_SENSOR_UPDATE },
+            .pen => .{ .min = c.SDL_EVENT_PEN_PROXIMITY_IN, .max = c.SDL_EVENT_PEN_AXIS },
+            .camera => .{ .min = c.SDL_EVENT_CAMERA_DEVICE_ADDED, .max = c.SDL_EVENT_CAMERA_DEVICE_DENIED },
+            .render => .{ .min = c.SDL_EVENT_RENDER_TARGETS_RESET, .max = c.SDL_EVENT_RENDER_DEVICE_LOST },
+            .reserved => .{ .min = c.SDL_EVENT_PRIVATE0, .max = c.SDL_EVENT_PRIVATE3 },
+            .internal => .{ .min = c.SDL_EVENT_POLL_SENTINEL, .max = c.SDL_EVENT_POLL_SENTINEL },
+            .user => .{ .min = c.SDL_EVENT_USER, .max = c.SDL_EVENT_LAST },
         };
     }
 };
@@ -204,22 +204,22 @@ pub const Group = enum {
 ///
 /// ## Version
 /// This enum is available since SDL 3.2.0.
-pub const Type = enum(C.SDL_EventType) {
+pub const Type = enum(c.SDL_EventType) {
     /// User-requested quit.
-    quit = C.SDL_EVENT_QUIT,
+    quit = c.SDL_EVENT_QUIT,
     /// The application is being terminated by the OS.
     /// This event must be handled in a callback set with `events.addWatch()`.
     /// Called on iOS in `applicationWillTerminate()`.
     /// Called on Android in `onDestroy()`.
-    terminating = C.SDL_EVENT_TERMINATING,
+    terminating = c.SDL_EVENT_TERMINATING,
     // /// The application is low on memory, free memory if possible.
     // /// This event must be handled in a callback set with `events.addWatch()`.
-    // low_memory = C.SDL_EVENT_LOW_MEMORY,
+    // low_memory = c.SDL_EVENT_LOW_MEMORY,
     // /// The application is about to enter the background.
     // /// This event must be handled in a callback set with `events.addWatch()`.
     // /// Called on iOS in `applicationWillResignActive()`.
     // /// Called on Android in `onPause()`.
-    // WillEnterBackground = C.SDL_EVENT_WILL_ENTER_BACKGROUND,
+    // WillEnterBackground = c.SDL_EVENT_WILL_ENTER_BACKGROUND,
     // DidEnterBackground,
     // WillEnterForeground,
     // DidEnterForeground,
@@ -258,9 +258,9 @@ pub const Type = enum(C.SDL_EventType) {
     // WindowDestroyed,
     // WindowHdrStateChanged,
     /// Key pressed.
-    key_down = C.SDL_EVENT_KEY_DOWN,
+    key_down = c.SDL_EVENT_KEY_DOWN,
     /// Key released.
-    key_up = C.SDL_EVENT_KEY_UP,
+    key_up = c.SDL_EVENT_KEY_UP,
     // TextEditing,
     // TextInput,
     // KeymapChanged,
@@ -330,9 +330,9 @@ pub const Type = enum(C.SDL_EventType) {
     /// User events, should be allocated with `events.register()`.
     user,
     /// An unknown event type.
-    unknown = C.SDL_EVENT_FIRST,
+    unknown = c.SDL_EVENT_FIRST,
     /// For padding out the union.
-    padding = C.SDL_EVENT_ENUM_PADDING,
+    padding = c.SDL_EVENT_ENUM_PADDING,
     // _,
 };
 
@@ -345,7 +345,7 @@ pub const Common = struct {
     timestamp: u64,
 
     /// Create a common event from an SDL one.
-    fn fromSdl(event: *const C.SDL_Event) Common {
+    fn fromSdl(event: *const c.SDL_Event) Common {
         return .{ .timestamp = event.common.timestamp };
     }
 };
@@ -355,7 +355,7 @@ pub const Unknown = struct {
     /// Common event information.
     common: Common,
     /// Event type that was not known.
-    event_type: C.SDL_EventType,
+    event_type: c.SDL_EventType,
 };
 
 /// A user-defined event type (event.user.*).
@@ -384,7 +384,7 @@ pub const User = struct {
     /// Common event information.
     common: Common,
     /// The event type.
-    event_type: C.SDL_EventType,
+    event_type: c.SDL_EventType,
     /// Associated window if any.
     window_id: ?video.WindowID = null,
     /// User defined event code.
@@ -446,7 +446,7 @@ pub const Quit = struct {
 };
 
 /// Needed to calculate padding.
-const DummyEnum = enum(C.SDL_EventType) {
+const DummyEnum = enum(c.SDL_EventType) {
     empty,
 };
 
@@ -471,12 +471,12 @@ pub const Event = union(Type) {
     user: User,
     /// An unknown event.
     unknown: Unknown,
-    // Padding to make union the same size of a `C.SDL_Event`.
-    padding: [@sizeOf(C.SDL_Event) - @sizeOf(DummyUnion)]u8,
+    // Padding to make union the same size of a `c.SDL_Event`.
+    padding: [@sizeOf(c.SDL_Event) - @sizeOf(DummyUnion)]u8,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_Event) == @sizeOf(Event));
+        std.debug.assert(@sizeOf(c.SDL_Event) == @sizeOf(Event));
     }
 
     /// Create a managed event from an SDL event.
@@ -492,13 +492,13 @@ pub const Event = union(Type) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn fromSdl(event: C.SDL_Event) Event {
+    pub fn fromSdl(event: c.SDL_Event) Event {
         return switch (event.type) {
-            C.SDL_EVENT_QUIT => .{ .quit = .{
+            c.SDL_EVENT_QUIT => .{ .quit = .{
                 .common = Common.fromSdl(&event),
             } },
-            C.SDL_EVENT_TERMINATING => .{ .terminating = Common.fromSdl(&event) },
-            C.SDL_EVENT_USER...C.SDL_EVENT_LAST => .{ .user = .{
+            c.SDL_EVENT_TERMINATING => .{ .terminating = Common.fromSdl(&event) },
+            c.SDL_EVENT_USER...c.SDL_EVENT_LAST => .{ .user = .{
                 .common = Common.fromSdl(&event),
                 .event_type = event.type,
                 .window_id = if (event.user.windowID == 0) null else event.user.windowID,
@@ -506,7 +506,7 @@ pub const Event = union(Type) {
                 .data1 = event.user.data1,
                 .data2 = event.user.data2,
             } },
-            C.SDL_EVENT_KEY_DOWN => .{
+            c.SDL_EVENT_KEY_DOWN => .{
                 .key_down = .{
                     .common = Common.fromSdl(&event),
                     .window_id = if (event.user.windowID == 0) null else event.key.windowID,
@@ -521,7 +521,7 @@ pub const Event = union(Type) {
                     .repeat = event.key.repeat,
                 },
             },
-            C.SDL_EVENT_KEY_UP => .{
+            c.SDL_EVENT_KEY_UP => .{
                 .key_up = .{
                     .common = Common.fromSdl(&event),
                     .window_id = if (event.user.windowID == 0) null else event.key.windowID,
@@ -536,7 +536,7 @@ pub const Event = union(Type) {
                     .repeat = event.key.repeat,
                 },
             },
-            C.SDL_EVENT_ENUM_PADDING => .{
+            c.SDL_EVENT_ENUM_PADDING => .{
                 .padding = @splat(0),
             },
             else => .{ .unknown = .{
@@ -560,7 +560,7 @@ pub const Event = union(Type) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn fromSdlInPlace(event: *C.SDL_Event) *Event {
+    pub fn fromSdlInPlace(event: *c.SDL_Event) *Event {
         const managed: *Event = @ptrCast(event);
         managed.* = fromSdl(event.*);
         return managed;
@@ -583,7 +583,7 @@ pub const Event = union(Type) {
         self: Event,
     ) ?video.Window {
         const event = toSdl(self);
-        const ret = C.SDL_GetWindowFromEvent(&event);
+        const ret = c.SDL_GetWindowFromEvent(&event);
         if (ret) |val| {
             return .{ .value = val };
         }
@@ -603,14 +603,14 @@ pub const Event = union(Type) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn toSdl(event: Event) C.SDL_Event {
+    pub fn toSdl(event: Event) c.SDL_Event {
         return switch (event) {
             .quit => |val| .{ .quit = .{
-                .type = C.SDL_EVENT_QUIT,
+                .type = c.SDL_EVENT_QUIT,
                 .timestamp = val.common.timestamp,
             } },
             .terminating => |val| .{ .common = .{
-                .type = C.SDL_EVENT_TERMINATING,
+                .type = c.SDL_EVENT_TERMINATING,
                 .timestamp = val.timestamp,
             } },
             .unknown => |val| .{ .common = .{
@@ -626,13 +626,13 @@ pub const Event = union(Type) {
                 .data2 = val.data2,
             } },
             .key_up => .{
-                .type = C.SDL_EVENT_KEY_UP,
+                .type = c.SDL_EVENT_KEY_UP,
             },
             .key_down => .{
-                .type = C.SDL_EVENT_KEY_DOWN,
+                .type = c.SDL_EVENT_KEY_DOWN,
             },
             .padding => .{
-                .type = C.SDL_EVENT_ENUM_PADDING,
+                .type = c.SDL_EVENT_ENUM_PADDING,
             },
         };
     }
@@ -651,8 +651,8 @@ pub const Event = union(Type) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn toSdlInPlace(event: *Event) *C.SDL_Event {
-        const unmanaged: *C.SDL_Event = @ptrCast(event);
+    pub fn toSdlInPlace(event: *Event) *c.SDL_Event {
+        const unmanaged: *c.SDL_Event = @ptrCast(event);
         unmanaged.* = toSdl(event.*);
         return unmanaged;
     }
@@ -684,7 +684,7 @@ pub fn addWatch(
     event_filter: Filter,
     user_data: ?*anyopaque,
 ) !void {
-    return errors.wrapCallBool(C.SDL_AddEventWatch(event_filter, user_data));
+    return errors.wrapCallBool(c.SDL_AddEventWatch(event_filter, user_data));
 }
 
 /// If an event is available in the queue.
@@ -701,7 +701,7 @@ pub fn addWatch(
 /// ## Version
 /// This is provided by zig-sdl3.
 pub fn available() bool {
-    return C.SDL_PollEvent(null);
+    return c.SDL_PollEvent(null);
 }
 
 /// Query the state of processing events by type.
@@ -720,7 +720,7 @@ pub fn available() bool {
 pub fn enabled(
     event_type: Type,
 ) bool {
-    return C.SDL_EventEnabled(@intFromEnum(event_type));
+    return c.SDL_EventEnabled(@intFromEnum(event_type));
 }
 
 /// Run a specific filter function on the current event queue, removing any events for which the filter returns false.
@@ -742,7 +742,7 @@ pub fn filter(
     event_filter: Filter,
     user_data: ?*anyopaque,
 ) void {
-    C.SDL_FilterEvents(event_filter, user_data);
+    c.SDL_FilterEvents(event_filter, user_data);
 }
 
 /// Clear events of a specific type from the event queue.
@@ -770,7 +770,7 @@ pub fn filter(
 pub fn flush(
     event_type: Type,
 ) void {
-    C.SDL_FlushEvent(@intFromEnum(event_type));
+    c.SDL_FlushEvent(@intFromEnum(event_type));
 }
 
 /// Clear events of a range of types from the event queue.
@@ -796,7 +796,7 @@ pub fn flushGroup(
     group: Group,
 ) void {
     const minmax = group.minMax();
-    C.SDL_FlushEvents(minmax.min, minmax.max);
+    c.SDL_FlushEvents(minmax.min, minmax.max);
 }
 
 /// Query the current event filter.
@@ -813,9 +813,9 @@ pub fn flushGroup(
 ///
 /// This function is available since SDL 3.2.0.
 pub fn getFilter() ?struct { event_filter: Filter, user_data: ?*anyopaque } {
-    var event_filter: C.SDL_FunctionPointer = undefined;
+    var event_filter: c.SDL_FunctionPointer = undefined;
     var user_data: ?*anyopaque = undefined;
-    const ret = C.SDL_GetEventFilter(&event_filter, &user_data);
+    const ret = c.SDL_GetEventFilter(&event_filter, &user_data);
     if (!ret)
         return null;
     return .{ .event_filter = @ptrCast(event_filter), .user_data = user_data };
@@ -837,7 +837,7 @@ pub fn getFilter() ?struct { event_filter: Filter, user_data: ?*anyopaque } {
 pub fn has(
     event_type: Type,
 ) bool {
-    return C.SDL_HasEvent(@intFromEnum(event_type));
+    return c.SDL_HasEvent(@intFromEnum(event_type));
 }
 
 /// Check for the existence of certain event types in the event queue.
@@ -860,7 +860,7 @@ pub fn hasGroup(
     group: Group,
 ) bool {
     const minmax = group.minMax();
-    return C.SDL_HasEvents(minmax.min, minmax.max);
+    return c.SDL_HasEvents(minmax.min, minmax.max);
 }
 
 /// Check the event queue for messages and optionally return them.
@@ -888,8 +888,8 @@ pub fn peep(
     group: Group,
 ) !usize {
     const minmax = group.minMax();
-    const raw: [*]C.SDL_Event = @ptrCast(events.ptr); // Hacky! We ensure in unit tests our enum is the same size so we can do this, then convert in-place.
-    const ret = C.SDL_PeepEvents(raw, @intCast(events.len), @intFromEnum(action), minmax.min, minmax.max);
+    const raw: [*]c.SDL_Event = @ptrCast(events.ptr); // Hacky! We ensure in unit tests our enum is the same size so we can do this, then convert in-place.
+    const ret = c.SDL_PeepEvents(raw, @intCast(events.len), @intFromEnum(action), minmax.min, minmax.max);
     for (0..@intCast(ret)) |ind| {
         _ = Event.fromSdlInPlace(&raw[ind]);
     }
@@ -921,7 +921,7 @@ pub fn peepSize(
     group: Group,
 ) !usize {
     const minmax = group.minMax();
-    const ret = C.SDL_PeepEvents(null, @intCast(num_events), @intFromEnum(action), minmax.min, minmax.max);
+    const ret = c.SDL_PeepEvents(null, @intCast(num_events), @intFromEnum(action), minmax.min, minmax.max);
     return @intCast(try errors.wrapCall(c_int, ret, -1));
 }
 
@@ -955,8 +955,8 @@ pub fn peepSize(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn poll() ?Event {
-    var event: C.SDL_Event = undefined;
-    const ret = C.SDL_PollEvent(&event);
+    var event: c.SDL_Event = undefined;
+    const ret = c.SDL_PollEvent(&event);
     if (!ret)
         return null;
     return Event.fromSdl(event);
@@ -978,7 +978,7 @@ pub fn poll() ?Event {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn pump() void {
-    C.SDL_PumpEvents();
+    c.SDL_PumpEvents();
 }
 
 /// Add an event to the event queue.
@@ -1007,7 +1007,7 @@ pub fn push(
     event: Event,
 ) !void {
     var event_umanaged = event.toSdl();
-    const ret = C.SDL_PushEvent(&event_umanaged);
+    const ret = c.SDL_PushEvent(&event_umanaged);
     return errors.wrapCallBool(ret);
 }
 
@@ -1026,8 +1026,8 @@ pub fn push(
 /// This function is available since SDL 3.2.0.
 pub fn register(
     num_events: usize,
-) ?C.SDL_EventType {
-    const ret = C.SDL_RegisterEvents(@intCast(num_events));
+) ?c.SDL_EventType {
+    const ret = c.SDL_RegisterEvents(@intCast(num_events));
     if (ret == 0)
         return null;
     return ret;
@@ -1051,7 +1051,7 @@ pub fn removeWatch(
     event_filter: Filter,
     user_data: ?*anyopaque,
 ) void {
-    C.SDL_RemoveEventWatch(event_filter, user_data);
+    c.SDL_RemoveEventWatch(event_filter, user_data);
 }
 
 /// Set the state of processing events by type.
@@ -1069,7 +1069,7 @@ pub fn setEnabled(
     event_type: Type,
     enable: bool,
 ) void {
-    C.SDL_SetEventEnabled(@intFromEnum(event_type), enable);
+    c.SDL_SetEventEnabled(@intFromEnum(event_type), enable);
 }
 
 /// Set up a filter to process all events before they are added to the internal event queue.
@@ -1105,7 +1105,7 @@ pub fn setFilter(
     event_filter: Filter,
     user_data: ?*anyopaque,
 ) void {
-    C.SDL_SetEventFilter(event_filter, user_data);
+    c.SDL_SetEventFilter(event_filter, user_data);
 }
 
 /// Wait indefinitely for the next available event.
@@ -1131,12 +1131,12 @@ pub fn wait(
     pop_event: bool,
 ) !?Event {
     if (pop_event) {
-        var event: C.SDL_Event = undefined;
-        const ret = C.SDL_WaitEvent(&event);
+        var event: c.SDL_Event = undefined;
+        const ret = c.SDL_WaitEvent(&event);
         try errors.wrapCallBool(ret);
         return Event.fromSdl(event);
     } else {
-        const ret = C.SDL_WaitEvent(null);
+        const ret = c.SDL_WaitEvent(null);
         try errors.wrapCallBool(ret);
         return null;
     }
@@ -1170,13 +1170,13 @@ pub fn waitTimeout(
     timeout_milliseconds: u31,
 ) ?struct { event: ?Event } {
     if (pop_event) {
-        var event: C.SDL_Event = undefined;
-        const ret = C.SDL_WaitEventTimeout(&event, @intCast(timeout_milliseconds));
+        var event: c.SDL_Event = undefined;
+        const ret = c.SDL_WaitEventTimeout(&event, @intCast(timeout_milliseconds));
         if (!ret)
             return null;
         return .{ .event = Event.fromSdl(event) };
     } else {
-        const ret = C.SDL_WaitEventTimeout(null, @intCast(timeout_milliseconds));
+        const ret = c.SDL_WaitEventTimeout(null, @intCast(timeout_milliseconds));
         if (!ret)
             return null;
         return .{ .event = null };
@@ -1185,7 +1185,7 @@ pub fn waitTimeout(
 
 fn dummyFilter(
     user_data: ?*anyopaque,
-    event: [*c]C.SDL_Event,
+    event: [*c]c.SDL_Event,
 ) callconv(.C) bool {
     _ = user_data;
     _ = event;

--- a/src/events.zig
+++ b/src/events.zig
@@ -35,7 +35,7 @@ pub const Action = enum(c_uint) {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const Filter = *const fn (user_data: ?*anyopaque, event: [*c]c.SDL_Event) callconv(.C) bool;
+pub const Filter = *const fn (user_data: ?*anyopaque, event: [*c]c.SDL_Event) callconv(.c) bool;
 
 /// For clearing out a group of events.
 ///
@@ -1186,7 +1186,7 @@ pub fn waitTimeout(
 fn dummyFilter(
     user_data: ?*anyopaque,
     event: [*c]c.SDL_Event,
-) callconv(.C) bool {
+) callconv(.c) bool {
     _ = user_data;
     _ = event;
     return true;

--- a/src/filesystem.zig
+++ b/src/filesystem.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const time = @import("time.zig");
@@ -163,7 +163,7 @@ pub const Path = struct {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const EnumerateDirectoryCallback = *const fn (user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) C.SDL_EnumerationResult;
+pub const EnumerateDirectoryCallback = *const fn (user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) c.SDL_EnumerationResult;
 
 /// Possible results from an enumeration callback.
 ///
@@ -171,11 +171,11 @@ pub const EnumerateDirectoryCallback = *const fn (user_data: ?*anyopaque, dir_na
 /// This enum is available since SDL 3.2.0.
 pub const EnumerationResult = enum(c_uint) {
     /// Value that requests that enumeration continue.
-    run = C.SDL_ENUM_CONTINUE,
+    run = c.SDL_ENUM_CONTINUE,
     /// Value that requests that enumeration stop, successfully.
-    success = C.SDL_ENUM_SUCCESS,
+    success = c.SDL_ENUM_SUCCESS,
     /// Value that requests that enumeration stop, as a failure.
-    failure = C.SDL_ENUM_FAILURE,
+    failure = c.SDL_ENUM_FAILURE,
 };
 
 /// The type of the OS-provided default folder for a specific purpose.
@@ -207,31 +207,31 @@ pub const Folder = enum(c_uint) {
     /// The folder which contains all of the current user's data, preferences, and documents.
     /// It usually contains most of the other folders.
     /// If a requested folder does not exist, the home folder can be considered a safe fallback to store a user's documents.
-    home = C.SDL_FOLDER_HOME,
+    home = c.SDL_FOLDER_HOME,
     /// The folder of files that are displayed on the desktop.
     /// Note that the existence of a desktop folder does not guarantee that the system does show icons on its desktop;
     /// certain GNU/Linux distros with a graphical environment may not have desktop icons.
-    desktop = C.SDL_FOLDER_DESKTOP,
+    desktop = c.SDL_FOLDER_DESKTOP,
     /// User document files, possibly application-specific.
     /// This is a good place to save a user's projects.
-    documents = C.SDL_FOLDER_DOCUMENTS,
+    documents = c.SDL_FOLDER_DOCUMENTS,
     /// Standard folder for user files downloaded from the internet.
-    downloads = C.SDL_FOLDER_DOWNLOADS,
+    downloads = c.SDL_FOLDER_DOWNLOADS,
     /// Music files that can be played using a standard music player (mp3, ogg...)./
-    music = C.SDL_FOLDER_MUSIC,
+    music = c.SDL_FOLDER_MUSIC,
     /// Image files that can be displayed using a standard viewer (png, jpg...).
-    pictures = C.SDL_FOLDER_PICTURES,
+    pictures = c.SDL_FOLDER_PICTURES,
     /// Files that are meant to be shared with other users on the same computer.
-    public_share = C.SDL_FOLDER_PUBLICSHARE,
+    public_share = c.SDL_FOLDER_PUBLICSHARE,
     /// Save files for games.
-    saved_games = C.SDL_FOLDER_SAVEDGAMES,
+    saved_games = c.SDL_FOLDER_SAVEDGAMES,
     /// Application screenshots.
-    screenshots = C.SDL_FOLDER_SCREENSHOTS,
+    screenshots = c.SDL_FOLDER_SCREENSHOTS,
     /// Template files to be used when the user requests the desktop environment to create a new file in a certain folder, such as "New Text File.txt".
     /// Any file in the Templates folder can be used as a starting point for a new file.
-    templates = C.SDL_FOLDER_TEMPLATES,
+    templates = c.SDL_FOLDER_TEMPLATES,
     /// Video files that can be played using a standard video player (mp4, webm...).
-    videos = C.SDL_FOLDER_VIDEOS,
+    videos = c.SDL_FOLDER_VIDEOS,
 };
 
 /// Flags for path matching.
@@ -242,17 +242,17 @@ pub const GlobFlags = struct {
     case_insensitive: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GlobFlags) GlobFlags {
+    pub fn fromSdl(value: c.SDL_GlobFlags) GlobFlags {
         return .{
-            .case_insensitive = value & C.SDL_GLOB_CASEINSENSITIVE > 0,
+            .case_insensitive = value & c.SDL_GLOB_CASEINSENSITIVE > 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: GlobFlags) C.SDL_GlobFlags {
-        var ret: C.SDL_GlobFlags = 0;
+    pub fn toSdl(self: GlobFlags) c.SDL_GlobFlags {
+        var ret: c.SDL_GlobFlags = 0;
         if (self.case_insensitive)
-            ret |= C.SDL_GLOB_CASEINSENSITIVE;
+            ret |= c.SDL_GLOB_CASEINSENSITIVE;
         return ret;
     }
 };
@@ -274,7 +274,7 @@ pub const PathInfo = struct {
     access_time: time.Time,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_PathInfo) PathInfo {
+    pub fn fromSdl(value: c.SDL_PathInfo) PathInfo {
         return .{
             .path_type = PathType.fromSdl(value.type).?,
             .file_size = value.size,
@@ -285,7 +285,7 @@ pub const PathInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: PathInfo) C.SDL_PathInfo {
+    pub fn toSdl(self: PathInfo) c.SDL_PathInfo {
         return .{
             .type = PathType.toSdl(self.path_type),
             .size = self.file_size,
@@ -306,24 +306,24 @@ pub const PathInfo = struct {
 /// This enum is available since SDL 3.2.0.
 pub const PathType = enum(c_uint) {
     /// A normal file.
-    file = C.SDL_PATHTYPE_FILE,
+    file = c.SDL_PATHTYPE_FILE,
     /// A directory.
-    directory = C.SDL_PATHTYPE_DIRECTORY,
+    directory = c.SDL_PATHTYPE_DIRECTORY,
     /// Something completely different like a device node (not a symlink, those are always followed).
-    other = C.SDL_PATHTYPE_OTHER,
+    other = c.SDL_PATHTYPE_OTHER,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_PathType) ?PathType {
-        if (value == C.SDL_PATHTYPE_NONE)
+    pub fn fromSdl(value: c.SDL_PathType) ?PathType {
+        if (value == c.SDL_PATHTYPE_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?PathType) C.SDL_PathType {
+    pub fn toSdl(self: ?PathType) c.SDL_PathType {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_PATHTYPE_NONE;
+        return c.SDL_PATHTYPE_NONE;
     }
 };
 
@@ -359,7 +359,7 @@ pub fn copyFile(
     old_path: [:0]const u8,
     new_path: [:0]const u8,
 ) !void {
-    return errors.wrapCallBool(C.SDL_CopyFile(old_path.ptr, new_path.ptr));
+    return errors.wrapCallBool(c.SDL_CopyFile(old_path.ptr, new_path.ptr));
 }
 
 /// Create a directory, and any missing parent directories.
@@ -378,7 +378,7 @@ pub fn copyFile(
 pub fn createDirectory(
     path: [:0]const u8,
 ) !void {
-    return errors.wrapCallBool(C.SDL_CreateDirectory(path.ptr));
+    return errors.wrapCallBool(c.SDL_CreateDirectory(path.ptr));
 }
 
 /// Enumerate a directory through a callback function.
@@ -402,7 +402,7 @@ pub fn enumerateDirectory(
     callback: EnumerateDirectoryCallback,
     user_data: ?*anyopaque,
 ) !void {
-    return errors.wrapCallBool(C.SDL_EnumerateDirectory(path.ptr, callback, user_data));
+    return errors.wrapCallBool(c.SDL_EnumerateDirectory(path.ptr, callback, user_data));
 }
 
 /// Data for getting all properties.
@@ -413,20 +413,20 @@ const GetAllData = struct {
 };
 
 /// Callback for getting all directory items.
-fn getAllDirectoryItemsCb(user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) C.SDL_EnumerationResult {
+fn getAllDirectoryItemsCb(user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) c.SDL_EnumerationResult {
     _ = dir_name;
     const data_ptr: *GetAllData = @ptrCast(@alignCast(user_data));
     const name_str = std.mem.span(name);
     const copy = data_ptr.allocator.allocSentinel(u8, name_str.len, 0) catch |err| {
         data_ptr.err = err;
-        return C.SDL_ENUM_FAILURE;
+        return c.SDL_ENUM_FAILURE;
     };
     @memcpy(copy, name_str);
     data_ptr.arr.append(copy) catch |err| {
         data_ptr.err = err;
-        return C.SDL_ENUM_FAILURE;
+        return c.SDL_ENUM_FAILURE;
     };
-    return C.SDL_ENUM_CONTINUE;
+    return c.SDL_ENUM_CONTINUE;
 }
 
 /// Free all directory items obtained through `filesystem.getAllDirectoryItems()`.
@@ -501,7 +501,7 @@ pub fn getAllDirectoryItems(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getBasePath() ![:0]const u8 {
-    return errors.wrapCallCString(C.SDL_GetBasePath());
+    return errors.wrapCallCString(c.SDL_GetBasePath());
 }
 
 /// Get what the system believes is the "current working directory."
@@ -520,7 +520,7 @@ pub fn getBasePath() ![:0]const u8 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getCurrentDirectory() ![:0]u8 {
-    const ret: [*:0]u8 = @ptrCast(try errors.wrapCallCPtr(u8, C.SDL_GetCurrentDirectory()));
+    const ret: [*:0]u8 = @ptrCast(try errors.wrapCallCPtr(u8, c.SDL_GetCurrentDirectory()));
     return std.mem.span(ret);
 }
 
@@ -537,7 +537,7 @@ pub fn getCurrentDirectory() ![:0]u8 {
 pub fn getPathExists(
     path: [:0]const u8,
 ) bool {
-    return C.SDL_GetPathInfo(path.ptr, null);
+    return c.SDL_GetPathInfo(path.ptr, null);
 }
 
 /// Get information about a filesystem path.
@@ -553,8 +553,8 @@ pub fn getPathExists(
 pub fn getPathInfo(
     path: [:0]const u8,
 ) !PathInfo {
-    var info: C.SDL_PathInfo = undefined;
-    try errors.wrapCallBool(C.SDL_GetPathInfo(path.ptr, &info));
+    var info: c.SDL_PathInfo = undefined;
+    try errors.wrapCallBool(c.SDL_GetPathInfo(path.ptr, &info));
     return PathInfo.fromSdl(info);
 }
 
@@ -601,7 +601,7 @@ pub fn getPrefPath(
     org: [:0]const u8,
     app: [:0]const u8,
 ) ![:0]u8 {
-    return errors.wrapCallCStringMut(C.SDL_GetPrefPath(org.ptr, app.ptr));
+    return errors.wrapCallCStringMut(c.SDL_GetPrefPath(org.ptr, app.ptr));
 }
 
 /// Finds the most suitable user folder for a specific purpose.
@@ -626,7 +626,7 @@ pub fn getPrefPath(
 pub fn getUserFolder(
     folder: Folder,
 ) ![:0]const u8 {
-    return errors.wrapCallCString(C.SDL_GetUserFolder(@intFromEnum(folder)));
+    return errors.wrapCallCString(c.SDL_GetUserFolder(@intFromEnum(folder)));
 }
 
 /// Enumerate a directory tree, filtered by pattern, and return a list.
@@ -659,7 +659,7 @@ pub fn globDirectory(
     flags: GlobFlags,
 ) ![][*:0]u8 {
     var count: c_int = undefined;
-    const ret: [*][*:0]u8 = @ptrCast(try errors.wrapCallCPtr([*c]u8, C.SDL_GlobDirectory(path.ptr, if (pattern) |val| val.ptr else null, flags.toSdl(), &count)));
+    const ret: [*][*:0]u8 = @ptrCast(try errors.wrapCallCPtr([*c]u8, c.SDL_GlobDirectory(path.ptr, if (pattern) |val| val.ptr else null, flags.toSdl(), &count)));
     return ret[0..@intCast(count)];
 }
 
@@ -676,7 +676,7 @@ pub fn globDirectory(
 pub fn removePath(
     path: [:0]const u8,
 ) !void {
-    return errors.wrapCallBool(C.SDL_RemovePath(path.ptr));
+    return errors.wrapCallBool(c.SDL_RemovePath(path.ptr));
 }
 
 /// Rename a file or directory.
@@ -700,7 +700,7 @@ pub fn renamePath(
     old_path: [:0]const u8,
     new_path: [:0]const u8,
 ) !void {
-    return errors.wrapCallBool(C.SDL_RenamePath(old_path, new_path));
+    return errors.wrapCallBool(c.SDL_RenamePath(old_path, new_path));
 }
 
 // Filesystem related tests.

--- a/src/filesystem.zig
+++ b/src/filesystem.zig
@@ -163,7 +163,7 @@ pub const Path = struct {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const EnumerateDirectoryCallback = *const fn (user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) c.SDL_EnumerationResult;
+pub const EnumerateDirectoryCallback = *const fn (user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.c) c.SDL_EnumerationResult;
 
 /// Possible results from an enumeration callback.
 ///
@@ -413,7 +413,7 @@ const GetAllData = struct {
 };
 
 /// Callback for getting all directory items.
-fn getAllDirectoryItemsCb(user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) c.SDL_EnumerationResult {
+fn getAllDirectoryItemsCb(user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.c) c.SDL_EnumerationResult {
     _ = dir_name;
     const data_ptr: *GetAllData = @ptrCast(@alignCast(user_data));
     const name_str = std.mem.span(name);

--- a/src/gpu.zig
+++ b/src/gpu.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const pixels = @import("pixels.zig");
 const properties = @import("properties.zig");
@@ -17,46 +17,46 @@ const video = @import("video.zig");
 /// This enum is available since SDL 3.2.0.
 pub const BlendFactor = enum(c_uint) {
     /// 0.
-    zero = C.SDL_GPU_BLENDFACTOR_ZERO,
+    zero = c.SDL_GPU_BLENDFACTOR_ZERO,
     /// 1.
-    one = C.SDL_GPU_BLENDFACTOR_ONE,
+    one = c.SDL_GPU_BLENDFACTOR_ONE,
     /// Source color.
-    src_color = C.SDL_GPU_BLENDFACTOR_SRC_COLOR,
+    src_color = c.SDL_GPU_BLENDFACTOR_SRC_COLOR,
     /// 1 - Source color.
-    one_minus_src_color = C.SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_COLOR,
+    one_minus_src_color = c.SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_COLOR,
     /// Destination color.
-    dst_color = C.SDL_GPU_BLENDFACTOR_DST_COLOR,
+    dst_color = c.SDL_GPU_BLENDFACTOR_DST_COLOR,
     /// 1 - Destination color.
-    one_minus_dst_color = C.SDL_GPU_BLENDFACTOR_ONE_MINUS_DST_COLOR,
+    one_minus_dst_color = c.SDL_GPU_BLENDFACTOR_ONE_MINUS_DST_COLOR,
     /// Source alpha.
-    src_alpha = C.SDL_GPU_BLENDFACTOR_SRC_ALPHA,
+    src_alpha = c.SDL_GPU_BLENDFACTOR_SRC_ALPHA,
     /// 1 - Source alpha.
-    one_minus_src_alpha = C.SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+    one_minus_src_alpha = c.SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
     /// Destination alpha.
-    dst_alpha = C.SDL_GPU_BLENDFACTOR_DST_ALPHA,
+    dst_alpha = c.SDL_GPU_BLENDFACTOR_DST_ALPHA,
     /// 1 - Destination alpha.
-    one_minus_dst_alpha = C.SDL_GPU_BLENDFACTOR_ONE_MINUS_DST_ALPHA,
+    one_minus_dst_alpha = c.SDL_GPU_BLENDFACTOR_ONE_MINUS_DST_ALPHA,
     /// Blend constant.
-    constant_color = C.SDL_GPU_BLENDFACTOR_CONSTANT_COLOR,
+    constant_color = c.SDL_GPU_BLENDFACTOR_CONSTANT_COLOR,
     /// 1 - Blend constant.
-    one_minus_constant_color = C.SDL_GPU_BLENDFACTOR_ONE_MINUS_CONSTANT_COLOR,
+    one_minus_constant_color = c.SDL_GPU_BLENDFACTOR_ONE_MINUS_CONSTANT_COLOR,
     /// Min(Source alpha, Destination alpha).
-    src_alpha_saturate = C.SDL_GPU_BLENDFACTOR_SRC_ALPHA_SATURATE,
+    src_alpha_saturate = c.SDL_GPU_BLENDFACTOR_SRC_ALPHA_SATURATE,
 
     /// Make a blend factor from SDL.
-    pub fn fromSdl(val: C.SDL_GPUBlendFactor) ?BlendFactor {
-        if (val == C.SDL_GPU_BLENDFACTOR_INVALID) {
+    pub fn fromSdl(val: c.SDL_GPUBlendFactor) ?BlendFactor {
+        if (val == c.SDL_GPU_BLENDFACTOR_INVALID) {
             return null;
         }
         return @enumFromInt(val);
     }
 
     /// Convert a blend factor to an SDL value.
-    pub fn toSdl(val: ?BlendFactor) C.SDL_GPUBlendFactor {
+    pub fn toSdl(val: ?BlendFactor) c.SDL_GPUBlendFactor {
         if (val) |tmp| {
             return @intFromEnum(tmp);
         }
-        return C.SDL_GPU_BLENDFACTOR_INVALID;
+        return c.SDL_GPU_BLENDFACTOR_INVALID;
     }
 };
 
@@ -70,30 +70,30 @@ pub const BlendFactor = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const BlendOperation = enum(c_uint) {
     /// (Source * Source Factor) + (Destination * Destination Factor).
-    add = C.SDL_BLENDOPERATION_ADD,
+    add = c.SDL_BLENDOPERATION_ADD,
     /// (Source * Source Factor) - (Destination * Destination Factor).
-    subtract = C.SDL_BLENDOPERATION_SUBTRACT,
+    subtract = c.SDL_BLENDOPERATION_SUBTRACT,
     /// (Destination * Destination Factor) - (Source * Source Factor).
-    reverse_subtract = C.SDL_BLENDOPERATION_REV_SUBTRACT,
+    reverse_subtract = c.SDL_BLENDOPERATION_REV_SUBTRACT,
     /// Min(Source, Destination).
-    min = C.SDL_BLENDOPERATION_MINIMUM,
+    min = c.SDL_BLENDOPERATION_MINIMUM,
     /// Max(Source, Destination).
-    max = C.SDL_BLENDOPERATION_MAXIMUM,
+    max = c.SDL_BLENDOPERATION_MAXIMUM,
 
     /// Create from SDL.
-    pub fn fromSdl(val: C.SDL_GPUBlendOp) ?BlendOperation {
-        if (val == C.SDL_GPU_BLENDOP_INVALID) {
+    pub fn fromSdl(val: c.SDL_GPUBlendOp) ?BlendOperation {
+        if (val == c.SDL_GPU_BLENDOP_INVALID) {
             return null;
         }
         return @enumFromInt(val);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(val: ?BlendOperation) C.SDL_GPUBlendOp {
+    pub fn toSdl(val: ?BlendOperation) c.SDL_GPUBlendOp {
         if (val) |tmp| {
             return @intFromEnum(tmp);
         }
-        return C.SDL_GPU_BLENDOP_INVALID;
+        return c.SDL_GPU_BLENDOP_INVALID;
     }
 };
 
@@ -119,7 +119,7 @@ pub const BlitInfo = struct {
     cycle: bool,
 
     /// Convert from SDL.
-    pub fn fromSdl(value: C.SDL_GPUBlitInfo) BlitInfo {
+    pub fn fromSdl(value: c.SDL_GPUBlitInfo) BlitInfo {
         return .{
             .source = BlitRegion.fromSdl(value.source),
             .destination = BlitRegion.fromSdl(value.destination),
@@ -132,7 +132,7 @@ pub const BlitInfo = struct {
     }
 
     /// Convert to SDL.
-    pub fn toSdl(self: BlitInfo) C.SDL_GPUBlitInfo {
+    pub fn toSdl(self: BlitInfo) c.SDL_GPUBlitInfo {
         return .{
             .source = self.source.toSdl(),
             .destination = self.destination.toSdl(),
@@ -161,7 +161,7 @@ pub const BlitRegion = struct {
     region: rect.Rect(u32),
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUBlitRegion) BlitRegion {
+    pub fn fromSdl(value: c.SDL_GPUBlitRegion) BlitRegion {
         return .{
             .texture = .{ .value = value.texture.? },
             .mip_level = value.mip_level,
@@ -176,7 +176,7 @@ pub const BlitRegion = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: BlitRegion) C.SDL_GPUBlitRegion {
+    pub fn toSdl(self: BlitRegion) c.SDL_GPUBlitRegion {
         return .{
             .texture = self.texture.value,
             .mip_level = self.mip_level,
@@ -197,7 +197,7 @@ pub const BlitRegion = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Buffer = packed struct {
-    value: *C.SDL_GPUBuffer,
+    value: *c.SDL_GPUBuffer,
 };
 
 /// A structure specifying parameters in a buffer binding call.
@@ -213,11 +213,11 @@ pub const BufferBinding = extern struct {
 
     // Binding tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUBufferBinding) == @sizeOf(BufferBinding));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUBufferBinding, "buffer")) == @sizeOf(@FieldType(BufferBinding, "buffer")));
-        std.debug.assert(@offsetOf(C.SDL_GPUBufferBinding, "buffer") == @offsetOf(BufferBinding, "buffer"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUBufferBinding, "offset")) == @sizeOf(@FieldType(BufferBinding, "offset")));
-        std.debug.assert(@offsetOf(C.SDL_GPUBufferBinding, "offset") == @offsetOf(BufferBinding, "offset"));
+        std.debug.assert(@sizeOf(c.SDL_GPUBufferBinding) == @sizeOf(BufferBinding));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUBufferBinding, "buffer")) == @sizeOf(@FieldType(BufferBinding, "buffer")));
+        std.debug.assert(@offsetOf(c.SDL_GPUBufferBinding, "buffer") == @offsetOf(BufferBinding, "buffer"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUBufferBinding, "offset")) == @sizeOf(@FieldType(BufferBinding, "offset")));
+        std.debug.assert(@offsetOf(c.SDL_GPUBufferBinding, "offset") == @offsetOf(BufferBinding, "offset"));
     }
 };
 
@@ -234,7 +234,7 @@ pub const BufferCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUBufferCreateInfo) BufferCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUBufferCreateInfo) BufferCreateInfo {
         return .{
             .usage = BufferUsageFlags.fromSdl(value.usage),
             .size = value.size,
@@ -243,7 +243,7 @@ pub const BufferCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: BufferCreateInfo) C.SDL_GPUBufferCreateInfo {
+    pub fn toSdl(self: BufferCreateInfo) c.SDL_GPUBufferCreateInfo {
         return .{
             .usage = self.usage.toSdl(),
             .size = self.size,
@@ -266,7 +266,7 @@ pub const BufferLocation = struct {
     offset: u32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUBufferLocation) BufferLocation {
+    pub fn fromSdl(value: c.SDL_GPUBufferLocation) BufferLocation {
         return .{
             .buffer = .{ .value = value.buffer.? },
             .offset = value.offset,
@@ -274,7 +274,7 @@ pub const BufferLocation = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: BufferLocation) C.SDL_GPUBufferLocation {
+    pub fn toSdl(self: BufferLocation) c.SDL_GPUBufferLocation {
         return .{
             .buffer = self.buffer.value,
             .offset = self.offset,
@@ -298,7 +298,7 @@ pub const BufferRegion = struct {
     size: u32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUBufferRegion) BufferRegion {
+    pub fn fromSdl(value: c.SDL_GPUBufferRegion) BufferRegion {
         return .{
             .buffer = .{ .value = value.buffer.? },
             .offset = value.offset,
@@ -307,7 +307,7 @@ pub const BufferRegion = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: BufferRegion) C.SDL_GPUBufferRegion {
+    pub fn toSdl(self: BufferRegion) c.SDL_GPUBufferRegion {
         return .{
             .buffer = self.buffer.value,
             .offset = self.offset,
@@ -345,32 +345,32 @@ pub const BufferUsageFlags = struct {
     compute_storage_write: bool = false,
 
     /// Convert flags from SDL.
-    pub fn fromSdl(val: C.SDL_GPUBufferUsageFlags) BufferUsageFlags {
+    pub fn fromSdl(val: c.SDL_GPUBufferUsageFlags) BufferUsageFlags {
         return .{
-            .vertex = val & C.SDL_GPU_BUFFERUSAGE_VERTEX != 0,
-            .index = val & C.SDL_GPU_BUFFERUSAGE_INDEX != 0,
-            .indirect = val & C.SDL_GPU_BUFFERUSAGE_INDIRECT != 0,
-            .graphics_storage_read = val & C.SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ != 0,
-            .compute_storage_read = val & C.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ != 0,
-            .compute_storage_write = val & C.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE != 0,
+            .vertex = val & c.SDL_GPU_BUFFERUSAGE_VERTEX != 0,
+            .index = val & c.SDL_GPU_BUFFERUSAGE_INDEX != 0,
+            .indirect = val & c.SDL_GPU_BUFFERUSAGE_INDIRECT != 0,
+            .graphics_storage_read = val & c.SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ != 0,
+            .compute_storage_read = val & c.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ != 0,
+            .compute_storage_write = val & c.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE != 0,
         };
     }
 
     /// Get the SDL flags.
-    pub fn toSdl(self: BufferUsageFlags) C.SDL_GPUBufferUsageFlags {
-        var ret: C.SDL_GPUBufferUsageFlags = 0;
+    pub fn toSdl(self: BufferUsageFlags) c.SDL_GPUBufferUsageFlags {
+        var ret: c.SDL_GPUBufferUsageFlags = 0;
         if (self.vertex)
-            ret |= C.SDL_GPU_BUFFERUSAGE_VERTEX;
+            ret |= c.SDL_GPU_BUFFERUSAGE_VERTEX;
         if (self.index)
-            ret |= C.SDL_GPU_BUFFERUSAGE_INDEX;
+            ret |= c.SDL_GPU_BUFFERUSAGE_INDEX;
         if (self.indirect)
-            ret |= C.SDL_GPU_BUFFERUSAGE_INDIRECT;
+            ret |= c.SDL_GPU_BUFFERUSAGE_INDIRECT;
         if (self.graphics_storage_read)
-            ret |= C.SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ;
+            ret |= c.SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ;
         if (self.compute_storage_read)
-            ret |= C.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ;
+            ret |= c.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ;
         if (self.compute_storage_write)
-            ret |= C.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE;
+            ret |= c.SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE;
         return ret;
     }
 };
@@ -379,7 +379,7 @@ pub const BufferUsageFlags = struct {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const ColorComponentFlags = packed struct(C.SDL_GPUColorComponentFlags) {
+pub const ColorComponentFlags = packed struct(c.SDL_GPUColorComponentFlags) {
     red: bool = false,
     green: bool = false,
     blue: bool = false,
@@ -388,11 +388,11 @@ pub const ColorComponentFlags = packed struct(C.SDL_GPUColorComponentFlags) {
 
     // Flag tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUColorComponentFlags) == @sizeOf(ColorComponentFlags));
-        std.debug.assert(C.SDL_GPU_COLORCOMPONENT_R == @as(C.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .red = true })));
-        std.debug.assert(C.SDL_GPU_COLORCOMPONENT_G == @as(C.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .green = true })));
-        std.debug.assert(C.SDL_GPU_COLORCOMPONENT_B == @as(C.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .blue = true })));
-        std.debug.assert(C.SDL_GPU_COLORCOMPONENT_A == @as(C.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .alpha = true })));
+        std.debug.assert(@sizeOf(c.SDL_GPUColorComponentFlags) == @sizeOf(ColorComponentFlags));
+        std.debug.assert(c.SDL_GPU_COLORCOMPONENT_R == @as(c.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .red = true })));
+        std.debug.assert(c.SDL_GPU_COLORCOMPONENT_G == @as(c.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .green = true })));
+        std.debug.assert(c.SDL_GPU_COLORCOMPONENT_B == @as(c.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .blue = true })));
+        std.debug.assert(c.SDL_GPU_COLORCOMPONENT_A == @as(c.SDL_GPUColorComponentFlags, @bitCast(ColorComponentFlags{ .alpha = true })));
     }
 };
 
@@ -425,25 +425,25 @@ pub const ColorTargetBlendState = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUColorTargetBlendState) == @sizeOf(ColorTargetBlendState));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "src_color_blendfactor") == @offsetOf(ColorTargetBlendState, "source_color"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "src_color_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "source_color")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "dst_color_blendfactor") == @offsetOf(ColorTargetBlendState, "destination_color"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "dst_color_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "destination_color")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "color_blend_op") == @offsetOf(ColorTargetBlendState, "color_blend"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "color_blend_op")) == @sizeOf(@FieldType(ColorTargetBlendState, "color_blend")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "src_alpha_blendfactor") == @offsetOf(ColorTargetBlendState, "source_alpha"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "src_alpha_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "source_alpha")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "dst_alpha_blendfactor") == @offsetOf(ColorTargetBlendState, "destination_alpha"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "dst_alpha_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "destination_alpha")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "alpha_blend_op") == @offsetOf(ColorTargetBlendState, "alpha_blend"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "alpha_blend_op")) == @sizeOf(@FieldType(ColorTargetBlendState, "alpha_blend")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "color_write_mask") == @offsetOf(ColorTargetBlendState, "color_write_mask"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "color_write_mask")) == @sizeOf(@FieldType(ColorTargetBlendState, "color_write_mask")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "enable_blend") == @offsetOf(ColorTargetBlendState, "enable_blend"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "enable_blend")) == @sizeOf(@FieldType(ColorTargetBlendState, "enable_blend")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetBlendState, "enable_color_write_mask") == @offsetOf(ColorTargetBlendState, "enable_color_write_mask"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetBlendState, "enable_color_write_mask")) == @sizeOf(@FieldType(ColorTargetBlendState, "enable_color_write_mask")));
+        std.debug.assert(@sizeOf(c.SDL_GPUColorTargetBlendState) == @sizeOf(ColorTargetBlendState));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "src_color_blendfactor") == @offsetOf(ColorTargetBlendState, "source_color"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "src_color_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "source_color")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "dst_color_blendfactor") == @offsetOf(ColorTargetBlendState, "destination_color"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "dst_color_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "destination_color")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "color_blend_op") == @offsetOf(ColorTargetBlendState, "color_blend"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "color_blend_op")) == @sizeOf(@FieldType(ColorTargetBlendState, "color_blend")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "src_alpha_blendfactor") == @offsetOf(ColorTargetBlendState, "source_alpha"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "src_alpha_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "source_alpha")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "dst_alpha_blendfactor") == @offsetOf(ColorTargetBlendState, "destination_alpha"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "dst_alpha_blendfactor")) == @sizeOf(@FieldType(ColorTargetBlendState, "destination_alpha")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "alpha_blend_op") == @offsetOf(ColorTargetBlendState, "alpha_blend"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "alpha_blend_op")) == @sizeOf(@FieldType(ColorTargetBlendState, "alpha_blend")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "color_write_mask") == @offsetOf(ColorTargetBlendState, "color_write_mask"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "color_write_mask")) == @sizeOf(@FieldType(ColorTargetBlendState, "color_write_mask")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "enable_blend") == @offsetOf(ColorTargetBlendState, "enable_blend"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "enable_blend")) == @sizeOf(@FieldType(ColorTargetBlendState, "enable_blend")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetBlendState, "enable_color_write_mask") == @offsetOf(ColorTargetBlendState, "enable_color_write_mask"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetBlendState, "enable_color_write_mask")) == @sizeOf(@FieldType(ColorTargetBlendState, "enable_color_write_mask")));
     }
 };
 
@@ -459,11 +459,11 @@ pub const ColorTargetDescription = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUColorTargetDescription) == @sizeOf(ColorTargetDescription));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetDescription, "format") == @offsetOf(ColorTargetDescription, "format"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetDescription, "format")) == @sizeOf(@FieldType(ColorTargetDescription, "format")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetDescription, "blend_state") == @offsetOf(ColorTargetDescription, "blend_state"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetDescription, "blend_state")) == @sizeOf(@FieldType(ColorTargetDescription, "blend_state")));
+        std.debug.assert(@sizeOf(c.SDL_GPUColorTargetDescription) == @sizeOf(ColorTargetDescription));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetDescription, "format") == @offsetOf(ColorTargetDescription, "format"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetDescription, "format")) == @sizeOf(@FieldType(ColorTargetDescription, "format")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetDescription, "blend_state") == @offsetOf(ColorTargetDescription, "blend_state"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetDescription, "blend_state")) == @sizeOf(@FieldType(ColorTargetDescription, "blend_state")));
     }
 };
 
@@ -517,29 +517,29 @@ pub const ColorTargetInfo = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUColorTargetInfo) == @sizeOf(ColorTargetInfo));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "texture")) == @sizeOf(@FieldType(ColorTargetInfo, "texture")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "texture") == @offsetOf(ColorTargetInfo, "texture"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "mip_level")) == @sizeOf(@FieldType(ColorTargetInfo, "mip_level")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "mip_level") == @offsetOf(ColorTargetInfo, "mip_level"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "layer_or_depth_plane")) == @sizeOf(@FieldType(ColorTargetInfo, "layer_or_depth_plane")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "layer_or_depth_plane") == @offsetOf(ColorTargetInfo, "layer_or_depth_plane"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "clear_color")) == @sizeOf(@FieldType(ColorTargetInfo, "clear_color")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "clear_color") == @offsetOf(ColorTargetInfo, "clear_color"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "load_op")) == @sizeOf(@FieldType(ColorTargetInfo, "load")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "load_op") == @offsetOf(ColorTargetInfo, "load"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "store_op")) == @sizeOf(@FieldType(ColorTargetInfo, "store")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "store_op") == @offsetOf(ColorTargetInfo, "store"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "resolve_texture")) == @sizeOf(@FieldType(ColorTargetInfo, "resolve_texture")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "resolve_texture") == @offsetOf(ColorTargetInfo, "resolve_texture"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "resolve_mip_level")) == @sizeOf(@FieldType(ColorTargetInfo, "resolve_mip_level")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "resolve_mip_level") == @offsetOf(ColorTargetInfo, "resolve_mip_level"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "resolve_layer")) == @sizeOf(@FieldType(ColorTargetInfo, "resolve_layer")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "resolve_layer") == @offsetOf(ColorTargetInfo, "resolve_layer"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "cycle")) == @sizeOf(@FieldType(ColorTargetInfo, "cycle")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "cycle") == @offsetOf(ColorTargetInfo, "cycle"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUColorTargetInfo, "cycle_resolve_texture")) == @sizeOf(@FieldType(ColorTargetInfo, "cycle_resolve_texture")));
-        std.debug.assert(@offsetOf(C.SDL_GPUColorTargetInfo, "cycle_resolve_texture") == @offsetOf(ColorTargetInfo, "cycle_resolve_texture"));
+        std.debug.assert(@sizeOf(c.SDL_GPUColorTargetInfo) == @sizeOf(ColorTargetInfo));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "texture")) == @sizeOf(@FieldType(ColorTargetInfo, "texture")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "texture") == @offsetOf(ColorTargetInfo, "texture"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "mip_level")) == @sizeOf(@FieldType(ColorTargetInfo, "mip_level")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "mip_level") == @offsetOf(ColorTargetInfo, "mip_level"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "layer_or_depth_plane")) == @sizeOf(@FieldType(ColorTargetInfo, "layer_or_depth_plane")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "layer_or_depth_plane") == @offsetOf(ColorTargetInfo, "layer_or_depth_plane"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "clear_color")) == @sizeOf(@FieldType(ColorTargetInfo, "clear_color")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "clear_color") == @offsetOf(ColorTargetInfo, "clear_color"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "load_op")) == @sizeOf(@FieldType(ColorTargetInfo, "load")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "load_op") == @offsetOf(ColorTargetInfo, "load"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "store_op")) == @sizeOf(@FieldType(ColorTargetInfo, "store")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "store_op") == @offsetOf(ColorTargetInfo, "store"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "resolve_texture")) == @sizeOf(@FieldType(ColorTargetInfo, "resolve_texture")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "resolve_texture") == @offsetOf(ColorTargetInfo, "resolve_texture"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "resolve_mip_level")) == @sizeOf(@FieldType(ColorTargetInfo, "resolve_mip_level")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "resolve_mip_level") == @offsetOf(ColorTargetInfo, "resolve_mip_level"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "resolve_layer")) == @sizeOf(@FieldType(ColorTargetInfo, "resolve_layer")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "resolve_layer") == @offsetOf(ColorTargetInfo, "resolve_layer"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "cycle")) == @sizeOf(@FieldType(ColorTargetInfo, "cycle")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "cycle") == @offsetOf(ColorTargetInfo, "cycle"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUColorTargetInfo, "cycle_resolve_texture")) == @sizeOf(@FieldType(ColorTargetInfo, "cycle_resolve_texture")));
+        std.debug.assert(@offsetOf(c.SDL_GPUColorTargetInfo, "cycle_resolve_texture") == @offsetOf(ColorTargetInfo, "cycle_resolve_texture"));
     }
 };
 
@@ -560,7 +560,7 @@ pub const ColorTargetInfo = extern struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const CommandBuffer = packed struct {
-    value: *C.SDL_GPUCommandBuffer,
+    value: *c.SDL_GPUCommandBuffer,
 
     /// Acquire a texture to use in presentation.
     ///
@@ -596,8 +596,8 @@ pub const CommandBuffer = packed struct {
     ) !struct { texture: ?Texture, width: u32, height: u32 } {
         var width: u32 = undefined;
         var height: u32 = undefined;
-        var texture: ?*C.SDL_GPUTexture = undefined;
-        try errors.wrapCallBool(C.SDL_AcquireGPUSwapchainTexture(self.value, window.value, &texture, &width, &height));
+        var texture: ?*c.SDL_GPUTexture = undefined;
+        try errors.wrapCallBool(c.SDL_AcquireGPUSwapchainTexture(self.value, window.value, &texture, &width, &height));
         return .{
             .texture = if (texture) |val| .{ .value = val } else null,
             .width = width,
@@ -638,7 +638,7 @@ pub const CommandBuffer = packed struct {
         storage_buffer_bindings: []const StorageBufferReadWriteBinding,
     ) ComputePass {
         return .{
-            .value = C.SDL_BeginGPUComputePass(
+            .value = c.SDL_BeginGPUComputePass(
                 self.value,
                 @ptrCast(storage_texture_bindings.ptr),
                 @intCast(storage_texture_bindings.len),
@@ -666,7 +666,7 @@ pub const CommandBuffer = packed struct {
         self: CommandBuffer,
     ) CopyPass {
         return .{
-            .value = C.SDL_BeginGPUCopyPass(self.value).?,
+            .value = c.SDL_BeginGPUCopyPass(self.value).?,
         };
     }
 
@@ -700,7 +700,7 @@ pub const CommandBuffer = packed struct {
     ) RenderPass {
         const depth_stencil = if (depth_stencil_target_info) |val| val.toSdl() else undefined;
         return .{
-            .value = C.SDL_BeginGPURenderPass(
+            .value = c.SDL_BeginGPURenderPass(
                 self.value,
                 @ptrCast(color_target_infos.ptr),
                 @intCast(color_target_infos.len),
@@ -725,7 +725,7 @@ pub const CommandBuffer = packed struct {
         blit_info: BlitInfo,
     ) void {
         const blit_info_sdl = blit_info.toSdl();
-        C.SDL_BlitGPUTexture(
+        c.SDL_BlitGPUTexture(
             self.value,
             &blit_info_sdl,
         );
@@ -750,7 +750,7 @@ pub const CommandBuffer = packed struct {
     pub fn cancel(
         self: CommandBuffer,
     ) !void {
-        return errors.wrapCallBool(C.SDL_CancelGPUCommandBuffer(self.value));
+        return errors.wrapCallBool(c.SDL_CancelGPUCommandBuffer(self.value));
     }
 
     /// Generates mipmaps for the given texture.
@@ -768,7 +768,7 @@ pub const CommandBuffer = packed struct {
         self: CommandBuffer,
         texture: Texture,
     ) void {
-        C.SDL_GenerateMipmapsForGPUTexture(
+        c.SDL_GenerateMipmapsForGPUTexture(
             self.value,
             texture.value,
         );
@@ -789,7 +789,7 @@ pub const CommandBuffer = packed struct {
         self: CommandBuffer,
         text: [:0]const u8,
     ) void {
-        C.SDL_InsertGPUDebugLabel(
+        c.SDL_InsertGPUDebugLabel(
             self.value,
             text.ptr,
         );
@@ -804,7 +804,7 @@ pub const CommandBuffer = packed struct {
     pub fn popDebugGroup(
         self: CommandBuffer,
     ) void {
-        C.SDL_PopGPUDebugGroup(
+        c.SDL_PopGPUDebugGroup(
             self.value,
         );
     }
@@ -829,7 +829,7 @@ pub const CommandBuffer = packed struct {
         slot_index: u32,
         data: []const u8,
     ) void {
-        C.SDL_PushGPUComputeUniformData(
+        c.SDL_PushGPUComputeUniformData(
             self.value,
             slot_index,
             data.ptr,
@@ -857,7 +857,7 @@ pub const CommandBuffer = packed struct {
         self: CommandBuffer,
         name: [:0]const u8,
     ) void {
-        C.SDL_PushGPUDebugGroup(
+        c.SDL_PushGPUDebugGroup(
             self.value,
             name.ptr,
         );
@@ -883,7 +883,7 @@ pub const CommandBuffer = packed struct {
         slot_index: u32,
         data: []const u8,
     ) void {
-        C.SDL_PushGPUFragmentUniformData(
+        c.SDL_PushGPUFragmentUniformData(
             self.value,
             slot_index,
             data.ptr,
@@ -911,7 +911,7 @@ pub const CommandBuffer = packed struct {
         slot_index: u32,
         data: []const u8,
     ) void {
-        C.SDL_PushGPUVertexUniformData(
+        c.SDL_PushGPUVertexUniformData(
             self.value,
             slot_index,
             data.ptr,
@@ -936,7 +936,7 @@ pub const CommandBuffer = packed struct {
     pub fn submit(
         self: CommandBuffer,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SubmitGPUCommandBuffer(self.value));
+        return errors.wrapCallBool(c.SDL_SubmitGPUCommandBuffer(self.value));
     }
 
     /// Submits a command buffer so its commands can be processed on the GPU, and acquires a fence associated with the command buffer.
@@ -960,7 +960,7 @@ pub const CommandBuffer = packed struct {
     pub fn submitAndAcquireFence(
         self: CommandBuffer,
     ) !Fence {
-        return .{ .value = try errors.wrapNull(*C.SDL_GPUFence, C.SDL_SubmitGPUCommandBufferAndAcquireFence(self.value)) };
+        return .{ .value = try errors.wrapNull(*c.SDL_GPUFence, c.SDL_SubmitGPUCommandBufferAndAcquireFence(self.value)) };
     }
 
     /// Blocks the thread until a swapchain texture is available to be acquired, and then acquires it.
@@ -995,8 +995,8 @@ pub const CommandBuffer = packed struct {
     ) !struct { texture: ?Texture, width: u32, height: u32 } {
         var width: u32 = undefined;
         var height: u32 = undefined;
-        var texture: ?*C.SDL_GPUTexture = undefined;
-        try errors.wrapCallBool(C.SDL_WaitAndAcquireGPUSwapchainTexture(self.value, window.value, &texture, &width, &height));
+        var texture: ?*c.SDL_GPUTexture = undefined;
+        try errors.wrapCallBool(c.SDL_WaitAndAcquireGPUSwapchainTexture(self.value, window.value, &texture, &width, &height));
         return .{
             .texture = if (texture) |val| .{ .value = val } else null,
             .width = width,
@@ -1011,36 +1011,36 @@ pub const CommandBuffer = packed struct {
 /// This enum is available since SDL 3.2.0.
 pub const CompareOperation = enum(c_uint) {
     /// The comparison always evaluates false.
-    never = C.SDL_GPU_COMPAREOP_NEVER,
+    never = c.SDL_GPU_COMPAREOP_NEVER,
     /// The comparison evaluates reference < test.
-    less = C.SDL_GPU_COMPAREOP_LESS,
+    less = c.SDL_GPU_COMPAREOP_LESS,
     /// The comparison evaluates reference == test.
-    equal = C.SDL_GPU_COMPAREOP_EQUAL,
+    equal = c.SDL_GPU_COMPAREOP_EQUAL,
     /// The comparison evaluates reference <= test.
-    less_or_equal = C.SDL_GPU_COMPAREOP_LESS_OR_EQUAL,
+    less_or_equal = c.SDL_GPU_COMPAREOP_LESS_OR_EQUAL,
     /// The comparison evaluates reference > test.
-    greater = C.SDL_GPU_COMPAREOP_GREATER,
+    greater = c.SDL_GPU_COMPAREOP_GREATER,
     /// The comparison evaluates reference != test.
-    not_equal = C.SDL_GPU_COMPAREOP_NOT_EQUAL,
+    not_equal = c.SDL_GPU_COMPAREOP_NOT_EQUAL,
     /// The comparison evaluates reference >= test.
-    greater_or_equal = C.SDL_GPU_COMPAREOP_GREATER_OR_EQUAL,
+    greater_or_equal = c.SDL_GPU_COMPAREOP_GREATER_OR_EQUAL,
     /// The comparison always evaluates true.
-    always = C.SDL_GPU_COMPAREOP_ALWAYS,
+    always = c.SDL_GPU_COMPAREOP_ALWAYS,
 
     /// Create from SDL.
-    pub fn fromSdl(val: C.SDL_GPUCompareOp) ?CompareOperation {
-        if (val == C.SDL_GPU_COMPAREOP_INVALID) {
+    pub fn fromSdl(val: c.SDL_GPUCompareOp) ?CompareOperation {
+        if (val == c.SDL_GPU_COMPAREOP_INVALID) {
             return null;
         }
         return @enumFromInt(val);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(val: ?CompareOperation) C.SDL_GPUCompareOp {
+    pub fn toSdl(val: ?CompareOperation) c.SDL_GPUCompareOp {
         if (val) |tmp| {
             return @intFromEnum(tmp);
         }
-        return C.SDL_GPU_COMPAREOP_INVALID;
+        return c.SDL_GPU_COMPAREOP_INVALID;
     }
 };
 
@@ -1052,7 +1052,7 @@ pub const CompareOperation = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const ComputePass = packed struct {
-    value: *C.SDL_GPUComputePass,
+    value: *c.SDL_GPUComputePass,
 
     /// Binds a compute pipeline on a command buffer for use in compute dispatch.
     ///
@@ -1066,7 +1066,7 @@ pub const ComputePass = packed struct {
         self: ComputePass,
         compute_pipeline: ComputePipeline,
     ) void {
-        C.SDL_BindGPUComputePipeline(self.value, compute_pipeline.value);
+        c.SDL_BindGPUComputePipeline(self.value, compute_pipeline.value);
     }
 
     /// Binds texture-sampler pairs for use on the compute shader.
@@ -1088,7 +1088,7 @@ pub const ComputePass = packed struct {
         first_slot: u32,
         texture_sampler_bindings: []const TextureSamplerBinding,
     ) void {
-        C.SDL_BindGPUComputeSamplers(
+        c.SDL_BindGPUComputeSamplers(
             self.value,
             first_slot,
             @ptrCast(texture_sampler_bindings.ptr),
@@ -1115,7 +1115,7 @@ pub const ComputePass = packed struct {
         first_slot: u32,
         storage_buffers: []const Buffer,
     ) void {
-        C.SDL_BindGPUComputeStorageBuffers(
+        c.SDL_BindGPUComputeStorageBuffers(
             self.value,
             first_slot,
             @ptrCast(storage_buffers.ptr),
@@ -1142,7 +1142,7 @@ pub const ComputePass = packed struct {
         first_slot: u32,
         storage_textures: []const Texture,
     ) void {
-        C.SDL_BindGPUComputeStorageTextures(
+        c.SDL_BindGPUComputeStorageTextures(
             self.value,
             first_slot,
             @ptrCast(storage_textures.ptr),
@@ -1173,7 +1173,7 @@ pub const ComputePass = packed struct {
         group_count_y: u32,
         group_count_z: u32,
     ) void {
-        C.SDL_DispatchGPUCompute(
+        c.SDL_DispatchGPUCompute(
             self.value,
             group_count_x,
             group_count_y,
@@ -1203,7 +1203,7 @@ pub const ComputePass = packed struct {
         buffer: Buffer,
         offset: u32,
     ) void {
-        C.SDL_DispatchGPUComputeIndirect(
+        c.SDL_DispatchGPUComputeIndirect(
             self.value,
             buffer.value,
             offset,
@@ -1224,7 +1224,7 @@ pub const ComputePass = packed struct {
     pub fn end(
         self: ComputePass,
     ) void {
-        C.SDL_EndGPUComputePass(self.value);
+        c.SDL_EndGPUComputePass(self.value);
     }
 };
 
@@ -1236,7 +1236,7 @@ pub const ComputePass = packed struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const ComputePipeline = packed struct {
-    value: *C.SDL_GPUComputePipeline,
+    value: *c.SDL_GPUComputePipeline,
 };
 
 /// A structure specifying the parameters of a compute pipeline state.
@@ -1276,7 +1276,7 @@ pub const ComputePipelineCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// From an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUComputePipelineCreateInfo) ComputePipelineCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUComputePipelineCreateInfo) ComputePipelineCreateInfo {
         return .{
             .code = value.code[0..value.code_size],
             .entry_point = std.mem.span(value.entrypoint),
@@ -1295,7 +1295,7 @@ pub const ComputePipelineCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ComputePipelineCreateInfo) C.SDL_GPUComputePipelineCreateInfo {
+    pub fn toSdl(self: ComputePipelineCreateInfo) c.SDL_GPUComputePipelineCreateInfo {
         return .{
             .code = self.code.ptr,
             .code_size = self.code.len,
@@ -1322,7 +1322,7 @@ pub const ComputePipelineCreateInfo = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const CopyPass = packed struct {
-    value: *C.SDL_GPUCopyPass,
+    value: *c.SDL_GPUCopyPass,
 
     /// Performs a buffer-to-buffer copy.
     ///
@@ -1348,7 +1348,7 @@ pub const CopyPass = packed struct {
     ) void {
         const source_sdl = source.toSdl();
         const destination_sdl = destination.toSdl();
-        C.SDL_CopyGPUBufferToBuffer(
+        c.SDL_CopyGPUBufferToBuffer(
             self.value,
             &source_sdl,
             &destination_sdl,
@@ -1376,7 +1376,7 @@ pub const CopyPass = packed struct {
     ) void {
         const source_sdl = source.toSdl();
         const destination_sdl = destination.toSdl();
-        C.SDL_DownloadFromGPUBuffer(
+        c.SDL_DownloadFromGPUBuffer(
             self.value,
             &source_sdl,
             &destination_sdl,
@@ -1402,7 +1402,7 @@ pub const CopyPass = packed struct {
     ) void {
         const source_sdl = source.toSdl();
         const destination_sdl = destination.toSdl();
-        C.SDL_DownloadFromGPUTexture(
+        c.SDL_DownloadFromGPUTexture(
             self.value,
             &source_sdl,
             &destination_sdl,
@@ -1419,7 +1419,7 @@ pub const CopyPass = packed struct {
     pub fn end(
         self: CopyPass,
     ) void {
-        C.SDL_EndGPUCopyPass(
+        c.SDL_EndGPUCopyPass(
             self.value,
         );
     }
@@ -1452,7 +1452,7 @@ pub const CopyPass = packed struct {
     ) void {
         const source_sdl = source.toSdl();
         const destination_sdl = destination.toSdl();
-        C.SDL_CopyGPUTextureToTexture(
+        c.SDL_CopyGPUTextureToTexture(
             self.value,
             &source_sdl,
             &destination_sdl,
@@ -1485,7 +1485,7 @@ pub const CopyPass = packed struct {
     ) void {
         const source_sdl = source.toSdl();
         const destination_sdl = destination.toSdl();
-        C.SDL_UploadToGPUBuffer(
+        c.SDL_UploadToGPUBuffer(
             self.value,
             &source_sdl,
             &destination_sdl,
@@ -1517,7 +1517,7 @@ pub const CopyPass = packed struct {
     ) void {
         const source_sdl = source.toSdl();
         const destination_sdl = destination.toSdl();
-        C.SDL_UploadToGPUTexture(
+        c.SDL_UploadToGPUTexture(
             self.value,
             &source_sdl,
             &destination_sdl,
@@ -1534,12 +1534,12 @@ pub const CopyPass = packed struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const CubeMap = enum(c_uint) {
-    positive_x = C.SDL_GPU_CUBEMAPFACE_POSITIVEX,
-    negative_x = C.SDL_GPU_CUBEMAPFACE_NEGATIVEX,
-    positive_y = C.SDL_GPU_CUBEMAPFACE_POSITIVEY,
-    negative_y = C.SDL_GPU_CUBEMAPFACE_NEGATIVEY,
-    positive_z = C.SDL_GPU_CUBEMAPFACE_POSITIVEZ,
-    negative_z = C.SDL_GPU_CUBEMAPFACE_NEGATIVEZ,
+    positive_x = c.SDL_GPU_CUBEMAPFACE_POSITIVEX,
+    negative_x = c.SDL_GPU_CUBEMAPFACE_NEGATIVEX,
+    positive_y = c.SDL_GPU_CUBEMAPFACE_POSITIVEY,
+    negative_y = c.SDL_GPU_CUBEMAPFACE_NEGATIVEY,
+    positive_z = c.SDL_GPU_CUBEMAPFACE_POSITIVEZ,
+    negative_z = c.SDL_GPU_CUBEMAPFACE_NEGATIVEZ,
 };
 
 /// Specifies the facing direction in which triangle faces will be culled.
@@ -1548,11 +1548,11 @@ pub const CubeMap = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const CullMode = enum(c_uint) {
     /// No triangles are culled.
-    none = C.SDL_GPU_CULLMODE_NONE,
+    none = c.SDL_GPU_CULLMODE_NONE,
     /// Front-facing triangles are culled.
-    front = C.SDL_GPU_CULLMODE_FRONT,
+    front = c.SDL_GPU_CULLMODE_FRONT,
     /// Back-facing triangles are culled.
-    back = C.SDL_GPU_CULLMODE_BACK,
+    back = c.SDL_GPU_CULLMODE_BACK,
 };
 
 /// A structure specifying the parameters of the graphics pipeline depth stencil state. TODO!!!
@@ -1578,7 +1578,7 @@ pub const DepthStencilState = struct {
     enable_stencil_test: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUDepthStencilState) DepthStencilState {
+    pub fn fromSdl(value: c.SDL_GPUDepthStencilState) DepthStencilState {
         return .{
             .compare = @enumFromInt(value.compare_op),
             .back_stencil_state = StencilOperationState.fromSdl(value.back_stencil_state),
@@ -1592,7 +1592,7 @@ pub const DepthStencilState = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: DepthStencilState) C.SDL_GPUDepthStencilState {
+    pub fn toSdl(self: DepthStencilState) c.SDL_GPUDepthStencilState {
         return .{
             .compare_op = @intFromEnum(self.compare),
             .back_stencil_state = self.back_stencil_state.toSdl(),
@@ -1652,7 +1652,7 @@ pub const DepthStencilTargetInfo = struct {
     clear_stencil: u8,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUDepthStencilTargetInfo) DepthStencilTargetInfo {
+    pub fn fromSdl(value: c.SDL_GPUDepthStencilTargetInfo) DepthStencilTargetInfo {
         return .{
             .texture = .{ .value = value.texture.? },
             .clear_depth = value.clear_depth,
@@ -1666,7 +1666,7 @@ pub const DepthStencilTargetInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: DepthStencilTargetInfo) C.SDL_GPUDepthStencilTargetInfo {
+    pub fn toSdl(self: DepthStencilTargetInfo) c.SDL_GPUDepthStencilTargetInfo {
         return .{
             .texture = self.texture.value,
             .clear_depth = self.clear_depth,
@@ -1685,7 +1685,7 @@ pub const DepthStencilTargetInfo = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Device = packed struct {
-    value: *C.SDL_GPUDevice,
+    value: *c.SDL_GPUDevice,
 
     /// Acquire a command buffer.
     ///
@@ -1711,7 +1711,7 @@ pub const Device = packed struct {
         self: Device,
     ) !CommandBuffer {
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUCommandBuffer, C.SDL_AcquireGPUCommandBuffer(self.value)),
+            .value = try errors.wrapNull(*c.SDL_GPUCommandBuffer, c.SDL_AcquireGPUCommandBuffer(self.value)),
         };
     }
 
@@ -1737,7 +1737,7 @@ pub const Device = packed struct {
         self: Device,
         window: video.Window,
     ) !void {
-        return errors.wrapCallBool(C.SDL_ClaimWindowForGPUDevice(
+        return errors.wrapCallBool(c.SDL_ClaimWindowForGPUDevice(
             self.value,
             window.value,
         ));
@@ -1777,8 +1777,8 @@ pub const Device = packed struct {
         const create_info_sdl = create_info.toSdl();
         return .{
             .value = try errors.wrapNull(
-                *C.SDL_GPUBuffer,
-                C.SDL_CreateGPUBuffer(self.value, &create_info_sdl),
+                *c.SDL_GPUBuffer,
+                c.SDL_CreateGPUBuffer(self.value, &create_info_sdl),
             ),
         };
     }
@@ -1822,7 +1822,7 @@ pub const Device = packed struct {
     ) !ComputePipeline {
         const create_info_sdl = create_info.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUComputePipeline, C.SDL_CreateGPUComputePipeline(self.value, &create_info_sdl)),
+            .value = try errors.wrapNull(*c.SDL_GPUComputePipeline, c.SDL_CreateGPUComputePipeline(self.value, &create_info_sdl)),
         };
     }
 
@@ -1849,7 +1849,7 @@ pub const Device = packed struct {
     ) !GraphicsPipeline {
         const create_info_sdl = create_info.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUGraphicsPipeline, C.SDL_CreateGPUGraphicsPipeline(
+            .value = try errors.wrapNull(*c.SDL_GPUGraphicsPipeline, c.SDL_CreateGPUGraphicsPipeline(
                 self.value,
                 &create_info_sdl,
             )),
@@ -1879,7 +1879,7 @@ pub const Device = packed struct {
     ) !Sampler {
         const create_info_sdl = create_info.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUSampler, C.SDL_CreateGPUSampler(
+            .value = try errors.wrapNull(*c.SDL_GPUSampler, c.SDL_CreateGPUSampler(
                 self.value,
                 &create_info_sdl,
             )),
@@ -1943,7 +1943,7 @@ pub const Device = packed struct {
     ) !Shader {
         const create_info_sdl = create_info.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUShader, C.SDL_CreateGPUShader(
+            .value = try errors.wrapNull(*c.SDL_GPUShader, c.SDL_CreateGPUShader(
                 self.value,
                 &create_info_sdl,
             )),
@@ -1986,7 +1986,7 @@ pub const Device = packed struct {
     ) !Texture {
         const create_info_sdl = create_info.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUTexture, C.SDL_CreateGPUTexture(
+            .value = try errors.wrapNull(*c.SDL_GPUTexture, c.SDL_CreateGPUTexture(
                 self.value,
                 &create_info_sdl,
             )),
@@ -2018,7 +2018,7 @@ pub const Device = packed struct {
     ) !TransferBuffer {
         const create_info_sdl = create_info.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUTransferBuffer, C.SDL_CreateGPUTransferBuffer(
+            .value = try errors.wrapNull(*c.SDL_GPUTransferBuffer, c.SDL_CreateGPUTransferBuffer(
                 self.value,
                 &create_info_sdl,
             )),
@@ -2035,7 +2035,7 @@ pub const Device = packed struct {
     pub fn deinit(
         self: Device,
     ) void {
-        return C.SDL_DestroyGPUDevice(
+        return c.SDL_DestroyGPUDevice(
             self.value,
         );
     }
@@ -2053,7 +2053,7 @@ pub const Device = packed struct {
     pub fn gdkResume(
         self: Device,
     ) void {
-        C.SDL_GDKResumeGPU(self.value);
+        c.SDL_GDKResumeGPU(self.value);
     }
 
     /// Call this to suspend GPU operation on Xbox when you receive the `events.Type.did_enter_background` event.
@@ -2070,7 +2070,7 @@ pub const Device = packed struct {
     pub fn gdkSuspend(
         self: Device,
     ) void {
-        C.SDL_GDKSuspendGPU(self.value);
+        c.SDL_GDKSuspendGPU(self.value);
     }
 
     /// Returns the name of the backend used to create this GPU context.
@@ -2086,7 +2086,7 @@ pub const Device = packed struct {
     pub fn getDriver(
         self: Device,
     ) ![:0]const u8 {
-        return errors.wrapCallCString(C.SDL_GetGPUDeviceDriver(
+        return errors.wrapCallCString(c.SDL_GetGPUDeviceDriver(
             self.value,
         ));
     }
@@ -2099,7 +2099,7 @@ pub const Device = packed struct {
     //     self: Device,
     // ) !properties.Group {
     //     return .{
-    //         .value = try errors.wrapCall(C.SDL_PropertiesID, C.SDL_GetGPUDeviceProperties(self.value), 0),
+    //         .value = try errors.wrapCall(c.SDL_PropertiesID, c.SDL_GetGPUDeviceProperties(self.value), 0),
     //     };
     // }
 
@@ -2117,7 +2117,7 @@ pub const Device = packed struct {
         self: Device,
     ) ShaderFormatFlags {
         return ShaderFormatFlags.fromSdl(
-            C.SDL_GetGPUShaderFormats(self.value),
+            c.SDL_GetGPUShaderFormats(self.value),
         );
     }
 
@@ -2139,7 +2139,7 @@ pub const Device = packed struct {
         self: Device,
         window: video.Window,
     ) TextureFormat {
-        return @enumFromInt(C.SDL_GetGPUSwapchainTextureFormat(
+        return @enumFromInt(c.SDL_GetGPUSwapchainTextureFormat(
             self.value,
             window.value,
         ));
@@ -2170,7 +2170,7 @@ pub const Device = packed struct {
         name: ?[:0]const u8,
     ) !Device {
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUDevice, C.SDL_CreateGPUDevice(
+            .value = try errors.wrapNull(*c.SDL_GPUDevice, c.SDL_CreateGPUDevice(
                 ShaderFormatFlags.toSdl(shader_format),
                 debug_mode,
                 if (name) |val| val.ptr else null,
@@ -2185,7 +2185,7 @@ pub const Device = packed struct {
         props: properties.Group,
     ) !Device {
         return .{
-            .value = try errors.wrapNull(*C.SDL_GPUDevice, C.SDL_CreateGPUDeviceWithProperties(
+            .value = try errors.wrapNull(*c.SDL_GPUDevice, c.SDL_CreateGPUDeviceWithProperties(
                 props.value,
             )),
         };
@@ -2212,7 +2212,7 @@ pub const Device = packed struct {
         transfer_buffer: TransferBuffer,
         cycle: bool,
     ) ![*]u8 {
-        return @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, C.SDL_MapGPUTransferBuffer(
+        return @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, c.SDL_MapGPUTransferBuffer(
             self.value,
             transfer_buffer.value,
             cycle,
@@ -2234,7 +2234,7 @@ pub const Device = packed struct {
         self: Device,
         fence: Fence,
     ) void {
-        return C.SDL_QueryGPUFence(
+        return c.SDL_QueryGPUFence(
             self.value,
             fence.value,
         );
@@ -2255,7 +2255,7 @@ pub const Device = packed struct {
         self: Device,
         buffer: Buffer,
     ) void {
-        C.SDL_ReleaseGPUBuffer(
+        c.SDL_ReleaseGPUBuffer(
             self.value,
             buffer.value,
         );
@@ -2276,7 +2276,7 @@ pub const Device = packed struct {
         self: Device,
         compute_pipeline: ComputePipeline,
     ) void {
-        C.SDL_ReleaseGPUComputePipeline(
+        c.SDL_ReleaseGPUComputePipeline(
             self.value,
             compute_pipeline.value,
         );
@@ -2297,7 +2297,7 @@ pub const Device = packed struct {
         self: Device,
         fence: Fence,
     ) void {
-        C.SDL_ReleaseGPUFence(
+        c.SDL_ReleaseGPUFence(
             self.value,
             fence.value,
         );
@@ -2318,7 +2318,7 @@ pub const Device = packed struct {
         self: Device,
         graphics_pipeline: GraphicsPipeline,
     ) void {
-        C.SDL_ReleaseGPUGraphicsPipeline(
+        c.SDL_ReleaseGPUGraphicsPipeline(
             self.value,
             graphics_pipeline.value,
         );
@@ -2339,7 +2339,7 @@ pub const Device = packed struct {
         self: Device,
         sampler: Sampler,
     ) void {
-        C.SDL_ReleaseGPUSampler(
+        c.SDL_ReleaseGPUSampler(
             self.value,
             sampler.value,
         );
@@ -2360,7 +2360,7 @@ pub const Device = packed struct {
         self: Device,
         shader: Shader,
     ) void {
-        C.SDL_ReleaseGPUShader(
+        c.SDL_ReleaseGPUShader(
             self.value,
             shader.value,
         );
@@ -2381,7 +2381,7 @@ pub const Device = packed struct {
         self: Device,
         texture: Texture,
     ) void {
-        C.SDL_ReleaseGPUTexture(
+        c.SDL_ReleaseGPUTexture(
             self.value,
             texture.value,
         );
@@ -2402,7 +2402,7 @@ pub const Device = packed struct {
         self: Device,
         transfer_buffer: TransferBuffer,
     ) void {
-        C.SDL_ReleaseGPUTransferBuffer(
+        c.SDL_ReleaseGPUTransferBuffer(
             self.value,
             transfer_buffer.value,
         );
@@ -2420,7 +2420,7 @@ pub const Device = packed struct {
         self: Device,
         window: video.Window,
     ) void {
-        C.SDL_ReleaseWindowFromGPUDevice(
+        c.SDL_ReleaseWindowFromGPUDevice(
             self.value,
             window.value,
         );
@@ -2450,7 +2450,7 @@ pub const Device = packed struct {
         self: Device,
         allowed_frames_in_flight: u32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SetGPUAllowedFramesInFlight(
+        return errors.wrapCallBool(c.SDL_SetGPUAllowedFramesInFlight(
             self.value,
             allowed_frames_in_flight,
         ));
@@ -2476,7 +2476,7 @@ pub const Device = packed struct {
         buffer: Buffer,
         text: [:0]const u8,
     ) void {
-        C.SDL_SetGPUBufferName(
+        c.SDL_SetGPUBufferName(
             self.value,
             buffer.value,
             text.ptr,
@@ -2505,7 +2505,7 @@ pub const Device = packed struct {
         swapchain_composition: SwapchainComposition,
         present_mode: PresentMode,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SetGPUSwapchainParameters(
+        return errors.wrapCallBool(c.SDL_SetGPUSwapchainParameters(
             self.value,
             window.value,
             @intFromEnum(swapchain_composition),
@@ -2533,7 +2533,7 @@ pub const Device = packed struct {
         texture: Texture,
         text: [:0]const u8,
     ) void {
-        C.SDL_SetGPUTextureName(
+        c.SDL_SetGPUTextureName(
             self.value,
             texture.value,
             text.ptr,
@@ -2559,7 +2559,7 @@ pub const Device = packed struct {
         texture_type: TextureType,
         usage: TextureUsageFlags,
     ) bool {
-        return C.SDL_GPUTextureSupportsFormat(
+        return c.SDL_GPUTextureSupportsFormat(
             self.value,
             @intFromEnum(format),
             @intFromEnum(texture_type),
@@ -2584,7 +2584,7 @@ pub const Device = packed struct {
         format: TextureFormat,
         sample_count: SampleCount,
     ) bool {
-        return C.SDL_GPUTextureSupportsSampleCount(
+        return c.SDL_GPUTextureSupportsSampleCount(
             self.value,
             @intFromEnum(format),
             @intFromEnum(sample_count),
@@ -2603,7 +2603,7 @@ pub const Device = packed struct {
         self: Device,
         transfer_buffer: TransferBuffer,
     ) void {
-        C.SDL_UnmapGPUTransferBuffer(
+        c.SDL_UnmapGPUTransferBuffer(
             self.value,
             transfer_buffer.value,
         );
@@ -2623,7 +2623,7 @@ pub const Device = packed struct {
         wait_all: bool,
         fences: []const Fence,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WaitForGPUFences(
+        return errors.wrapCallBool(c.SDL_WaitForGPUFences(
             self.value,
             wait_all,
             @ptrCast(fences.ptr),
@@ -2641,7 +2641,7 @@ pub const Device = packed struct {
     pub fn waitForIdle(
         self: Device,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WaitForGPUIdle(
+        return errors.wrapCallBool(c.SDL_WaitForGPUIdle(
             self.value,
         ));
     }
@@ -2661,7 +2661,7 @@ pub const Device = packed struct {
         self: Device,
         window: video.Window,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WaitForGPUSwapchain(
+        return errors.wrapCallBool(c.SDL_WaitForGPUSwapchain(
             self.value,
             window.value,
         ));
@@ -2687,7 +2687,7 @@ pub const Device = packed struct {
         window: video.Window,
         present_mode: PresentMode,
     ) bool {
-        return C.SDL_WindowSupportsGPUPresentMode(
+        return c.SDL_WindowSupportsGPUPresentMode(
             self.value,
             window.value,
             @intFromEnum(present_mode),
@@ -2714,7 +2714,7 @@ pub const Device = packed struct {
         window: video.Window,
         swapchain_composition: SwapchainComposition,
     ) bool {
-        return C.SDL_WindowSupportsGPUSwapchainComposition(
+        return c.SDL_WindowSupportsGPUSwapchainComposition(
             self.value,
             window.value,
             @intFromEnum(swapchain_composition),
@@ -2727,7 +2727,7 @@ pub const Device = packed struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Fence = packed struct {
-    value: *C.SDL_GPUFence,
+    value: *c.SDL_GPUFence,
 };
 
 /// Specifies the fill mode of the graphics pipeline.
@@ -2736,9 +2736,9 @@ pub const Fence = packed struct {
 /// This enum is available since SDL 3.2.0.
 pub const FillMode = enum(c_uint) {
     /// Polygons will be rendered via rasterization.
-    fill = C.SDL_GPU_FILLMODE_FILL,
+    fill = c.SDL_GPU_FILLMODE_FILL,
     /// Polygon edges will be drawn as line segments.
-    line = C.SDL_GPU_FILLMODE_LINE,
+    line = c.SDL_GPU_FILLMODE_LINE,
 };
 
 /// Specifies a filter operation used by a sampler.
@@ -2747,9 +2747,9 @@ pub const FillMode = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const Filter = enum(c_uint) {
     /// Point filtering.
-    nearest = C.SDL_GPU_FILTER_NEAREST,
+    nearest = c.SDL_GPU_FILTER_NEAREST,
     /// Linear filtering.
-    linear = C.SDL_GPU_FILTER_LINEAR,
+    linear = c.SDL_GPU_FILTER_LINEAR,
 };
 
 /// Specifies the vertex winding that will cause a triangle to be determined to be front-facing.
@@ -2758,9 +2758,9 @@ pub const Filter = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const FrontFace = enum(c_uint) {
     /// A triangle with counter-clockwise vertex winding will be considered front-facing.
-    counter_clockwise = C.SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE,
+    counter_clockwise = c.SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE,
     /// A triangle with clockwise vertex winding will be considered front-facing.
-    clockwise = C.SDL_GPU_FRONTFACE_CLOCKWISE,
+    clockwise = c.SDL_GPU_FRONTFACE_CLOCKWISE,
 };
 
 /// An opaque handle representing a graphics pipeline.
@@ -2771,7 +2771,7 @@ pub const FrontFace = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const GraphicsPipeline = packed struct {
-    value: *C.SDL_GPUGraphicsPipeline,
+    value: *c.SDL_GPUGraphicsPipeline,
 };
 
 /// A structure specifying the parameters of a graphics pipeline state.
@@ -2799,7 +2799,7 @@ pub const GraphicsPipelineCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUGraphicsPipelineCreateInfo) GraphicsPipelineCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUGraphicsPipelineCreateInfo) GraphicsPipelineCreateInfo {
         return .{
             .vertex_shader = .{ .value = value.vertex_shader.? },
             .fragment_shader = .{ .value = value.fragment_shader.? },
@@ -2814,7 +2814,7 @@ pub const GraphicsPipelineCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: GraphicsPipelineCreateInfo) C.SDL_GPUGraphicsPipelineCreateInfo {
+    pub fn toSdl(self: GraphicsPipelineCreateInfo) c.SDL_GPUGraphicsPipelineCreateInfo {
         return .{
             .vertex_shader = self.vertex_shader.value,
             .fragment_shader = self.fragment_shader.value,
@@ -2840,7 +2840,7 @@ pub const GraphicsPipelineTargetInfo = struct {
     depth_stencil_format: ?TextureFormat = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUGraphicsPipelineTargetInfo) GraphicsPipelineTargetInfo {
+    pub fn fromSdl(value: c.SDL_GPUGraphicsPipelineTargetInfo) GraphicsPipelineTargetInfo {
         return .{
             .color_target_descriptions = @as([*]const ColorTargetDescription, @ptrCast(value.color_target_descriptions))[0..@intCast(value.num_color_targets)],
             .depth_stencil_format = if (value.has_depth_stencil_target) @enumFromInt(value.depth_stencil_format) else null,
@@ -2848,7 +2848,7 @@ pub const GraphicsPipelineTargetInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: GraphicsPipelineTargetInfo) C.SDL_GPUGraphicsPipelineTargetInfo {
+    pub fn toSdl(self: GraphicsPipelineTargetInfo) c.SDL_GPUGraphicsPipelineTargetInfo {
         return .{
             .color_target_descriptions = @ptrCast(self.color_target_descriptions.ptr),
             .num_color_targets = @intCast(self.color_target_descriptions.len),
@@ -2864,9 +2864,9 @@ pub const GraphicsPipelineTargetInfo = struct {
 /// This enum is available since SDL 3.2.0.
 pub const IndexElementSize = enum(c_uint) {
     /// The index elements are 16-bit.
-    indices_16bit = C.SDL_GPU_INDEXELEMENTSIZE_16BIT,
+    indices_16bit = c.SDL_GPU_INDEXELEMENTSIZE_16BIT,
     /// The index elements are 32-bit.
-    indices_32bit = C.SDL_GPU_INDEXELEMENTSIZE_32BIT,
+    indices_32bit = c.SDL_GPU_INDEXELEMENTSIZE_32BIT,
 };
 
 /// A structure specifying the parameters of an indexed indirect draw command.
@@ -2892,17 +2892,17 @@ pub const IndexedIndirectDrawCommand = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUIndexedIndirectDrawCommand) == @sizeOf(IndexedIndirectDrawCommand));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndexedIndirectDrawCommand, "num_indices")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "num_indices")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndexedIndirectDrawCommand, "num_indices") == @offsetOf(IndexedIndirectDrawCommand, "num_indices"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndexedIndirectDrawCommand, "num_instances")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "num_instances")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndexedIndirectDrawCommand, "num_instances") == @offsetOf(IndexedIndirectDrawCommand, "num_instances"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndexedIndirectDrawCommand, "first_index")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "first_index")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndexedIndirectDrawCommand, "first_index") == @offsetOf(IndexedIndirectDrawCommand, "first_index"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndexedIndirectDrawCommand, "vertex_offset")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "vertex_offset")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndexedIndirectDrawCommand, "vertex_offset") == @offsetOf(IndexedIndirectDrawCommand, "vertex_offset"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndexedIndirectDrawCommand, "first_instance")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "first_instance")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndexedIndirectDrawCommand, "first_instance") == @offsetOf(IndexedIndirectDrawCommand, "first_instance"));
+        std.debug.assert(@sizeOf(c.SDL_GPUIndexedIndirectDrawCommand) == @sizeOf(IndexedIndirectDrawCommand));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndexedIndirectDrawCommand, "num_indices")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "num_indices")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndexedIndirectDrawCommand, "num_indices") == @offsetOf(IndexedIndirectDrawCommand, "num_indices"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndexedIndirectDrawCommand, "num_instances")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "num_instances")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndexedIndirectDrawCommand, "num_instances") == @offsetOf(IndexedIndirectDrawCommand, "num_instances"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndexedIndirectDrawCommand, "first_index")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "first_index")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndexedIndirectDrawCommand, "first_index") == @offsetOf(IndexedIndirectDrawCommand, "first_index"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndexedIndirectDrawCommand, "vertex_offset")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "vertex_offset")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndexedIndirectDrawCommand, "vertex_offset") == @offsetOf(IndexedIndirectDrawCommand, "vertex_offset"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndexedIndirectDrawCommand, "first_instance")) == @sizeOf(@FieldType(IndexedIndirectDrawCommand, "first_instance")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndexedIndirectDrawCommand, "first_instance") == @offsetOf(IndexedIndirectDrawCommand, "first_instance"));
     }
 };
 
@@ -2920,13 +2920,13 @@ pub const IndirectDispatchCommand = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUIndirectDispatchCommand) == @sizeOf(IndirectDispatchCommand));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDispatchCommand, "groupcount_x")) == @sizeOf(@FieldType(IndirectDispatchCommand, "group_count_x")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDispatchCommand, "groupcount_x") == @offsetOf(IndirectDispatchCommand, "group_count_x"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDispatchCommand, "groupcount_y")) == @sizeOf(@FieldType(IndirectDispatchCommand, "group_count_y")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDispatchCommand, "groupcount_y") == @offsetOf(IndirectDispatchCommand, "group_count_y"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDispatchCommand, "groupcount_z")) == @sizeOf(@FieldType(IndirectDispatchCommand, "group_count_z")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDispatchCommand, "groupcount_z") == @offsetOf(IndirectDispatchCommand, "group_count_z"));
+        std.debug.assert(@sizeOf(c.SDL_GPUIndirectDispatchCommand) == @sizeOf(IndirectDispatchCommand));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDispatchCommand, "groupcount_x")) == @sizeOf(@FieldType(IndirectDispatchCommand, "group_count_x")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDispatchCommand, "groupcount_x") == @offsetOf(IndirectDispatchCommand, "group_count_x"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDispatchCommand, "groupcount_y")) == @sizeOf(@FieldType(IndirectDispatchCommand, "group_count_y")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDispatchCommand, "groupcount_y") == @offsetOf(IndirectDispatchCommand, "group_count_y"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDispatchCommand, "groupcount_z")) == @sizeOf(@FieldType(IndirectDispatchCommand, "group_count_z")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDispatchCommand, "groupcount_z") == @offsetOf(IndirectDispatchCommand, "group_count_z"));
     }
 };
 
@@ -2951,15 +2951,15 @@ pub const IndirectDrawCommand = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUIndirectDrawCommand) == @sizeOf(IndirectDrawCommand));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDrawCommand, "num_vertices")) == @sizeOf(@FieldType(IndirectDrawCommand, "num_vertices")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDrawCommand, "num_vertices") == @offsetOf(IndirectDrawCommand, "num_vertices"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDrawCommand, "num_instances")) == @sizeOf(@FieldType(IndirectDrawCommand, "num_instances")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDrawCommand, "num_instances") == @offsetOf(IndirectDrawCommand, "num_instances"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDrawCommand, "first_vertex")) == @sizeOf(@FieldType(IndirectDrawCommand, "first_vertex")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDrawCommand, "first_vertex") == @offsetOf(IndirectDrawCommand, "first_vertex"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUIndirectDrawCommand, "first_instance")) == @sizeOf(@FieldType(IndirectDrawCommand, "first_instance")));
-        std.debug.assert(@offsetOf(C.SDL_GPUIndirectDrawCommand, "first_instance") == @offsetOf(IndirectDrawCommand, "first_instance"));
+        std.debug.assert(@sizeOf(c.SDL_GPUIndirectDrawCommand) == @sizeOf(IndirectDrawCommand));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDrawCommand, "num_vertices")) == @sizeOf(@FieldType(IndirectDrawCommand, "num_vertices")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDrawCommand, "num_vertices") == @offsetOf(IndirectDrawCommand, "num_vertices"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDrawCommand, "num_instances")) == @sizeOf(@FieldType(IndirectDrawCommand, "num_instances")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDrawCommand, "num_instances") == @offsetOf(IndirectDrawCommand, "num_instances"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDrawCommand, "first_vertex")) == @sizeOf(@FieldType(IndirectDrawCommand, "first_vertex")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDrawCommand, "first_vertex") == @offsetOf(IndirectDrawCommand, "first_vertex"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUIndirectDrawCommand, "first_instance")) == @sizeOf(@FieldType(IndirectDrawCommand, "first_instance")));
+        std.debug.assert(@offsetOf(c.SDL_GPUIndirectDrawCommand, "first_instance") == @offsetOf(IndirectDrawCommand, "first_instance"));
     }
 };
 
@@ -2969,12 +2969,12 @@ pub const IndirectDrawCommand = extern struct {
 /// This enum is available since SDL 3.2.0.
 pub const LoadOperation = enum(c_uint) {
     /// The previous contents of the texture will be preserved.
-    load = C.SDL_GPU_LOADOP_LOAD,
+    load = c.SDL_GPU_LOADOP_LOAD,
     /// The contents of the texture will be cleared to a color.
-    clear = C.SDL_GPU_LOADOP_CLEAR,
+    clear = c.SDL_GPU_LOADOP_CLEAR,
     /// The previous contents of the texture need not be preserved.
     /// The contents will be undefined.
-    do_not_care = C.SDL_GPU_LOADOP_DONT_CARE,
+    do_not_care = c.SDL_GPU_LOADOP_DONT_CARE,
 };
 
 /// A structure specifying the parameters of the graphics pipeline multisample state.
@@ -2994,7 +2994,7 @@ pub const MultisampleState = struct {
     // enable_alpha_to_coverage: bool,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUMultisampleState) MultisampleState {
+    pub fn fromSdl(value: c.SDL_GPUMultisampleState) MultisampleState {
         return .{
             .sample_count = @enumFromInt(value.sample_count),
             .sample_mask = value.sample_mask,
@@ -3004,7 +3004,7 @@ pub const MultisampleState = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: MultisampleState) C.SDL_GPUMultisampleState {
+    pub fn toSdl(self: MultisampleState) c.SDL_GPUMultisampleState {
         return .{
             .sample_count = @intFromEnum(self.sample_count),
             .sample_mask = self.sample_mask,
@@ -3030,15 +3030,15 @@ pub const PresentMode = enum(c_uint) {
     /// No tearing is possible.
     /// If there is a pending image to present, the new image is enqueued for presentation.
     /// Disallows tearing at the cost of visual latency.
-    vsync = C.SDL_GPU_PRESENTMODE_VSYNC,
+    vsync = c.SDL_GPU_PRESENTMODE_VSYNC,
     /// Immediately presents.
     /// Lowest latency option, but tearing may occur.
-    immediate = C.SDL_GPU_PRESENTMODE_IMMEDIATE,
+    immediate = c.SDL_GPU_PRESENTMODE_IMMEDIATE,
     /// Waits for vblank before presenting.
     /// No tearing is possible.
     /// If there is a pending image to present, the pending image is replaced by the new image.
     /// Similar to `gpu.PresentMode.vsync`, but with reduced visual latency.
-    mailbox = C.SDL_GPU_PRESENTMODE_MAILBOX,
+    mailbox = c.SDL_GPU_PRESENTMODE_MAILBOX,
 };
 
 /// Specifies the primitive topology of a graphics pipeline.
@@ -3058,15 +3058,15 @@ pub const PresentMode = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const PrimitiveType = enum(c_uint) {
     /// A series of separate triangles.
-    triangle_list = C.SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
+    triangle_list = c.SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
     /// A series of connected triangles.
-    triangle_strip = C.SDL_GPU_PRIMITIVETYPE_TRIANGLESTRIP,
+    triangle_strip = c.SDL_GPU_PRIMITIVETYPE_TRIANGLESTRIP,
     /// A series of separate lines.
-    line_list = C.SDL_GPU_PRIMITIVETYPE_LINELIST,
+    line_list = c.SDL_GPU_PRIMITIVETYPE_LINELIST,
     /// A series of connected lines.
-    line_strip = C.SDL_GPU_PRIMITIVETYPE_LINESTRIP,
+    line_strip = c.SDL_GPU_PRIMITIVETYPE_LINESTRIP,
     /// A series of separate points.
-    point_list = C.SDL_GPU_PRIMITIVETYPE_POINTLIST,
+    point_list = c.SDL_GPU_PRIMITIVETYPE_POINTLIST,
 };
 
 /// A structure specifying the parameters of the graphics pipeline rasterizer state.
@@ -3099,7 +3099,7 @@ pub const RasterizerState = struct {
     enable_depth_clip: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPURasterizerState) RasterizerState {
+    pub fn fromSdl(value: c.SDL_GPURasterizerState) RasterizerState {
         return .{
             .fill_mode = @enumFromInt(value.fill_mode),
             .cull_mode = @enumFromInt(value.cull_mode),
@@ -3113,7 +3113,7 @@ pub const RasterizerState = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: RasterizerState) C.SDL_GPURasterizerState {
+    pub fn toSdl(self: RasterizerState) c.SDL_GPURasterizerState {
         return .{
             .fill_mode = @intFromEnum(self.fill_mode),
             .cull_mode = @intFromEnum(self.cull_mode),
@@ -3135,7 +3135,7 @@ pub const RasterizerState = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const RenderPass = packed struct {
-    value: *C.SDL_GPURenderPass,
+    value: *c.SDL_GPURenderPass,
 
     /// Binds texture-sampler pairs for use on the fragment shader.
     ///
@@ -3156,7 +3156,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         texture_sampler_bindings: []const TextureSamplerBinding,
     ) void {
-        C.SDL_BindGPUFragmentSamplers(
+        c.SDL_BindGPUFragmentSamplers(
             self.value,
             first_slot,
             @ptrCast(texture_sampler_bindings.ptr),
@@ -3183,7 +3183,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         storage_buffers: []const Buffer,
     ) void {
-        C.SDL_BindGPUFragmentStorageBuffers(
+        c.SDL_BindGPUFragmentStorageBuffers(
             self.value,
             first_slot,
             @ptrCast(storage_buffers.ptr),
@@ -3210,7 +3210,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         storage_textures: []const Texture,
     ) void {
-        C.SDL_BindGPUFragmentStorageTextures(
+        c.SDL_BindGPUFragmentStorageTextures(
             self.value,
             first_slot,
             @ptrCast(storage_textures.ptr),
@@ -3233,7 +3233,7 @@ pub const RenderPass = packed struct {
         self: RenderPass,
         graphics_pipeline: GraphicsPipeline,
     ) void {
-        C.SDL_BindGPUGraphicsPipeline(
+        c.SDL_BindGPUGraphicsPipeline(
             self.value,
             graphics_pipeline.value,
         );
@@ -3253,7 +3253,7 @@ pub const RenderPass = packed struct {
         binding: BufferBinding,
         index_element_size: IndexElementSize,
     ) void {
-        C.SDL_BindGPUIndexBuffer(
+        c.SDL_BindGPUIndexBuffer(
             self.value,
             @ptrCast(&binding),
             @intFromEnum(index_element_size),
@@ -3274,7 +3274,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         bindings: []const BufferBinding,
     ) void {
-        C.SDL_BindGPUVertexBuffers(
+        c.SDL_BindGPUVertexBuffers(
             self.value,
             first_slot,
             @ptrCast(bindings.ptr),
@@ -3301,7 +3301,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         texture_sampler_bindings: []const TextureSamplerBinding,
     ) void {
-        C.SDL_BindGPUVertexSamplers(
+        c.SDL_BindGPUVertexSamplers(
             self.value,
             first_slot,
             @ptrCast(texture_sampler_bindings.ptr),
@@ -3328,7 +3328,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         storage_buffers: []const Buffer,
     ) void {
-        C.SDL_BindGPUVertexStorageBuffers(
+        c.SDL_BindGPUVertexStorageBuffers(
             self.value,
             first_slot,
             @ptrCast(storage_buffers.ptr),
@@ -3355,7 +3355,7 @@ pub const RenderPass = packed struct {
         first_slot: u32,
         storage_textures: []const Texture,
     ) void {
-        C.SDL_BindGPUVertexStorageTextures(
+        c.SDL_BindGPUVertexStorageTextures(
             self.value,
             first_slot,
             @ptrCast(storage_textures.ptr),
@@ -3390,7 +3390,7 @@ pub const RenderPass = packed struct {
         vertex_offset: i32,
         first_instance: u32,
     ) void {
-        C.SDL_DrawGPUIndexedPrimitives(
+        c.SDL_DrawGPUIndexedPrimitives(
             self.value,
             num_indices,
             num_instances,
@@ -3420,7 +3420,7 @@ pub const RenderPass = packed struct {
         offset: u32,
         draw_count: u32,
     ) void {
-        C.SDL_DrawGPUIndexedPrimitivesIndirect(
+        c.SDL_DrawGPUIndexedPrimitivesIndirect(
             self.value,
             buffer.value,
             offset,
@@ -3453,7 +3453,7 @@ pub const RenderPass = packed struct {
         first_vertex: u32,
         first_instance: u32,
     ) void {
-        C.SDL_DrawGPUPrimitives(
+        c.SDL_DrawGPUPrimitives(
             self.value,
             num_vertices,
             num_instances,
@@ -3482,7 +3482,7 @@ pub const RenderPass = packed struct {
         offset: u32,
         draw_count: u32,
     ) void {
-        C.SDL_DrawGPUPrimitivesIndirect(
+        c.SDL_DrawGPUPrimitivesIndirect(
             self.value,
             buffer.value,
             offset,
@@ -3504,7 +3504,7 @@ pub const RenderPass = packed struct {
     pub fn end(
         self: RenderPass,
     ) void {
-        C.SDL_EndGPURenderPass(
+        c.SDL_EndGPURenderPass(
             self.value,
         );
     }
@@ -3521,7 +3521,7 @@ pub const RenderPass = packed struct {
         self: RenderPass,
         blend_constants: pixels.FColor,
     ) void {
-        C.SDL_SetGPUBlendConstants(
+        c.SDL_SetGPUBlendConstants(
             self.value,
             blend_constants,
         );
@@ -3539,7 +3539,7 @@ pub const RenderPass = packed struct {
         self: RenderPass,
         scissor: rect.IRect,
     ) void {
-        C.SDL_SetGPUScissor(
+        c.SDL_SetGPUScissor(
             self.value,
             @ptrCast(&scissor),
         );
@@ -3557,7 +3557,7 @@ pub const RenderPass = packed struct {
         self: RenderPass,
         reference: u8,
     ) void {
-        C.SDL_SetGPUStencilReference(
+        c.SDL_SetGPUStencilReference(
             self.value,
             reference,
         );
@@ -3576,7 +3576,7 @@ pub const RenderPass = packed struct {
         viewport: Viewport,
     ) void {
         const viewport_sdl = viewport.toSdl();
-        C.SDL_SetGPUViewport(
+        c.SDL_SetGPUViewport(
             self.value,
             &viewport_sdl,
         );
@@ -3592,10 +3592,10 @@ pub const RenderPass = packed struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const SampleCount = enum(c_uint) {
-    no_multisampling = C.SDL_GPU_SAMPLECOUNT_1,
-    msaa_2x = C.SDL_GPU_SAMPLECOUNT_2,
-    msaa_4x = C.SDL_GPU_SAMPLECOUNT_4,
-    msaa_8x = C.SDL_GPU_SAMPLECOUNT_8,
+    no_multisampling = c.SDL_GPU_SAMPLECOUNT_1,
+    msaa_2x = c.SDL_GPU_SAMPLECOUNT_2,
+    msaa_4x = c.SDL_GPU_SAMPLECOUNT_4,
+    msaa_8x = c.SDL_GPU_SAMPLECOUNT_8,
 };
 
 /// An opaque handle representing a sampler.
@@ -3603,7 +3603,7 @@ pub const SampleCount = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Sampler = packed struct {
-    value: *C.SDL_GPUSampler,
+    value: *c.SDL_GPUSampler,
 };
 
 /// Specifies behavior of texture sampling when the coordinates exceed the 0-1 range.
@@ -3612,11 +3612,11 @@ pub const Sampler = packed struct {
 /// This enum is available since SDL 3.2.0.
 pub const SamplerAddressMode = enum(c_uint) {
     /// Specifies that the coordinates will wrap around.
-    repeat = C.SDL_GPU_SAMPLERADDRESSMODE_REPEAT,
+    repeat = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT,
     /// Specifies that the coordinates will wrap around mirrored.
-    mirrored_repeat = C.SDL_GPU_SAMPLERADDRESSMODE_MIRRORED_REPEAT,
+    mirrored_repeat = c.SDL_GPU_SAMPLERADDRESSMODE_MIRRORED_REPEAT,
     /// Specifies that the coordinates will clamp to the 0-1 range.
-    clamp_to_edge = C.SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE,
+    clamp_to_edge = c.SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE,
 };
 
 /// A structure specifying the parameters of a sampler.
@@ -3654,7 +3654,7 @@ pub const SamplerCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUSamplerCreateInfo) SamplerCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUSamplerCreateInfo) SamplerCreateInfo {
         return .{
             .min_filter = @enumFromInt(value.min_filter),
             .mag_filter = @enumFromInt(value.mag_filter),
@@ -3672,7 +3672,7 @@ pub const SamplerCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: SamplerCreateInfo) C.SDL_GPUSamplerCreateInfo {
+    pub fn toSdl(self: SamplerCreateInfo) c.SDL_GPUSamplerCreateInfo {
         return .{
             .min_filter = @intFromEnum(self.min_filter),
             .mag_filter = @intFromEnum(self.mag_filter),
@@ -3698,9 +3698,9 @@ pub const SamplerCreateInfo = struct {
 /// This enum is available since SDL 3.2.0.
 pub const SamplerMipmapMode = enum(c_uint) {
     /// Point filtering.
-    nearest = C.SDL_GPU_SAMPLERMIPMAPMODE_NEAREST,
+    nearest = c.SDL_GPU_SAMPLERMIPMAPMODE_NEAREST,
     /// Linear filtering.
-    linear = C.SDL_GPU_SAMPLERMIPMAPMODE_LINEAR,
+    linear = c.SDL_GPU_SAMPLERMIPMAPMODE_LINEAR,
 };
 
 /// An opaque handle representing a compiled shader object.
@@ -3708,7 +3708,7 @@ pub const SamplerMipmapMode = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Shader = packed struct {
-    value: *C.SDL_GPUShader,
+    value: *c.SDL_GPUShader,
 };
 
 /// A structure specifying code and metadata for creating a shader object.
@@ -3736,7 +3736,7 @@ pub const ShaderCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUShaderCreateInfo) ShaderCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUShaderCreateInfo) ShaderCreateInfo {
         return .{
             .code = value.code[0..value.code_size],
             .entry_point = std.mem.span(value.entrypoint),
@@ -3751,7 +3751,7 @@ pub const ShaderCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ShaderCreateInfo) C.SDL_GPUShaderCreateInfo {
+    pub fn toSdl(self: ShaderCreateInfo) c.SDL_GPUShaderCreateInfo {
         return .{
             .code = self.code.ptr,
             .code_size = self.code.len,
@@ -3789,38 +3789,38 @@ pub const ShaderFormatFlags = struct {
     metal_lib: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUShaderFormat) ?ShaderFormatFlags {
-        if (value == C.SDL_GPU_SHADERFORMAT_INVALID)
+    pub fn fromSdl(value: c.SDL_GPUShaderFormat) ?ShaderFormatFlags {
+        if (value == c.SDL_GPU_SHADERFORMAT_INVALID)
             return null;
         return .{
-            .private = value & C.SDL_GPU_SHADERFORMAT_PRIVATE > 0,
-            .spirv = value & C.SDL_GPU_SHADERFORMAT_SPIRV > 0,
-            .dxbc = value & C.SDL_GPU_SHADERFORMAT_DXBC > 0,
-            .dxil = value & C.SDL_GPU_SHADERFORMAT_DXIL > 0,
-            .msl = value & C.SDL_GPU_SHADERFORMAT_MSL > 0,
-            .metal_lib = value & C.SDL_GPU_SHADERFORMAT_METALLIB > 0,
+            .private = value & c.SDL_GPU_SHADERFORMAT_PRIVATE > 0,
+            .spirv = value & c.SDL_GPU_SHADERFORMAT_SPIRV > 0,
+            .dxbc = value & c.SDL_GPU_SHADERFORMAT_DXBC > 0,
+            .dxil = value & c.SDL_GPU_SHADERFORMAT_DXIL > 0,
+            .msl = value & c.SDL_GPU_SHADERFORMAT_MSL > 0,
+            .metal_lib = value & c.SDL_GPU_SHADERFORMAT_METALLIB > 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?ShaderFormatFlags) C.SDL_GPUShaderFormat {
+    pub fn toSdl(self: ?ShaderFormatFlags) c.SDL_GPUShaderFormat {
         if (self) |val| {
-            var ret: C.SDL_GPUShaderFormat = 0;
+            var ret: c.SDL_GPUShaderFormat = 0;
             if (val.private)
-                ret |= C.SDL_GPU_SHADERFORMAT_PRIVATE;
+                ret |= c.SDL_GPU_SHADERFORMAT_PRIVATE;
             if (val.spirv)
-                ret |= C.SDL_GPU_SHADERFORMAT_SPIRV;
+                ret |= c.SDL_GPU_SHADERFORMAT_SPIRV;
             if (val.dxbc)
-                ret |= C.SDL_GPU_SHADERFORMAT_DXBC;
+                ret |= c.SDL_GPU_SHADERFORMAT_DXBC;
             if (val.dxil)
-                ret |= C.SDL_GPU_SHADERFORMAT_DXIL;
+                ret |= c.SDL_GPU_SHADERFORMAT_DXIL;
             if (val.msl)
-                ret |= C.SDL_GPU_SHADERFORMAT_MSL;
+                ret |= c.SDL_GPU_SHADERFORMAT_MSL;
             if (val.metal_lib)
-                ret |= C.SDL_GPU_SHADERFORMAT_METALLIB;
+                ret |= c.SDL_GPU_SHADERFORMAT_METALLIB;
             return ret;
         }
-        return C.SDL_GPU_SHADERFORMAT_INVALID;
+        return c.SDL_GPU_SHADERFORMAT_INVALID;
     }
 
     /// Checks for GPU runtime support.
@@ -3838,7 +3838,7 @@ pub const ShaderFormatFlags = struct {
         self: ShaderFormatFlags,
         name: ?[:0]const u8,
     ) bool {
-        return C.SDL_GPUSupportsShaderFormats(
+        return c.SDL_GPUSupportsShaderFormats(
             ShaderFormatFlags.toSdl(self),
             if (name) |val| val.ptr else null,
         );
@@ -3850,8 +3850,8 @@ pub const ShaderFormatFlags = struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const ShaderStage = enum(c_uint) {
-    vertex = C.SDL_GPU_SHADERSTAGE_VERTEX,
-    fragment = C.SDL_GPU_SHADERSTAGE_FRAGMENT,
+    vertex = c.SDL_GPU_SHADERSTAGE_VERTEX,
+    fragment = c.SDL_GPU_SHADERSTAGE_FRAGMENT,
 };
 
 /// Specifies what happens to a stored stencil value if stencil tests fail or pass.
@@ -3860,36 +3860,36 @@ pub const ShaderStage = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const StencilOperation = enum(c_uint) {
     /// Keeps the current value.
-    keep = C.SDL_GPU_STENCILOP_KEEP,
+    keep = c.SDL_GPU_STENCILOP_KEEP,
     /// Sets the value to 0.
-    zero = C.SDL_GPU_STENCILOP_ZERO,
+    zero = c.SDL_GPU_STENCILOP_ZERO,
     /// Sets the value to reference.
-    replace = C.SDL_GPU_STENCILOP_REPLACE,
+    replace = c.SDL_GPU_STENCILOP_REPLACE,
     /// Increments the current value and clamps to the maximum value.
-    increment_and_clamp = C.SDL_GPU_STENCILOP_INCREMENT_AND_CLAMP,
+    increment_and_clamp = c.SDL_GPU_STENCILOP_INCREMENT_AND_CLAMP,
     /// Decrements the current value and clamps to 0.
-    decrement_and_clamp = C.SDL_GPU_STENCILOP_DECREMENT_AND_CLAMP,
+    decrement_and_clamp = c.SDL_GPU_STENCILOP_DECREMENT_AND_CLAMP,
     /// Bitwise-inverts the current value.
-    invert = C.SDL_GPU_STENCILOP_INVERT,
+    invert = c.SDL_GPU_STENCILOP_INVERT,
     /// Increments the current value and wraps back to 0.
-    increment_and_wrap = C.SDL_GPU_STENCILOP_INCREMENT_AND_WRAP,
+    increment_and_wrap = c.SDL_GPU_STENCILOP_INCREMENT_AND_WRAP,
     /// Decrements the current value and wraps to the maximum value.
-    decrement_and_wrap = C.SDL_GPU_STENCILOP_DECREMENT_AND_WRAP,
+    decrement_and_wrap = c.SDL_GPU_STENCILOP_DECREMENT_AND_WRAP,
 
     /// Create from SDL.
-    pub fn fromSdl(val: C.SDL_GPUStencilOp) ?StencilOperation {
-        if (val == C.SDL_GPU_STENCILOP_INVALID) {
+    pub fn fromSdl(val: c.SDL_GPUStencilOp) ?StencilOperation {
+        if (val == c.SDL_GPU_STENCILOP_INVALID) {
             return null;
         }
         return @enumFromInt(val);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(val: ?StencilOperation) C.SDL_GPUStencilOp {
+    pub fn toSdl(val: ?StencilOperation) c.SDL_GPUStencilOp {
         if (val) |tmp| {
             return @intFromEnum(tmp);
         }
-        return C.SDL_GPU_STENCILOP_INVALID;
+        return c.SDL_GPU_STENCILOP_INVALID;
     }
 };
 
@@ -3908,7 +3908,7 @@ pub const StencilOperationState = struct {
     compare: CompareOperation = .never,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUStencilOpState) StencilOperationState {
+    pub fn fromSdl(value: c.SDL_GPUStencilOpState) StencilOperationState {
         return .{
             .fail = StencilOperation.fromSdl(value.fail_op).?,
             .pass = StencilOperation.fromSdl(value.pass_op).?,
@@ -3918,7 +3918,7 @@ pub const StencilOperationState = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: StencilOperationState) C.SDL_GPUStencilOpState {
+    pub fn toSdl(self: StencilOperationState) c.SDL_GPUStencilOpState {
         return .{
             .fail_op = StencilOperation.toSdl(self.fail),
             .pass_op = StencilOperation.toSdl(self.pass),
@@ -3944,11 +3944,11 @@ pub const StorageBufferReadWriteBinding = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUStorageBufferReadWriteBinding) == @sizeOf(StorageBufferReadWriteBinding));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUStorageBufferReadWriteBinding, "buffer")) == @sizeOf(@FieldType(StorageBufferReadWriteBinding, "buffer")));
-        std.debug.assert(@offsetOf(C.SDL_GPUStorageBufferReadWriteBinding, "buffer") == @offsetOf(StorageBufferReadWriteBinding, "buffer"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUStorageBufferReadWriteBinding, "cycle")) == @sizeOf(@FieldType(StorageBufferReadWriteBinding, "cycle")));
-        std.debug.assert(@offsetOf(C.SDL_GPUStorageBufferReadWriteBinding, "cycle") == @offsetOf(StorageBufferReadWriteBinding, "cycle"));
+        std.debug.assert(@sizeOf(c.SDL_GPUStorageBufferReadWriteBinding) == @sizeOf(StorageBufferReadWriteBinding));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUStorageBufferReadWriteBinding, "buffer")) == @sizeOf(@FieldType(StorageBufferReadWriteBinding, "buffer")));
+        std.debug.assert(@offsetOf(c.SDL_GPUStorageBufferReadWriteBinding, "buffer") == @offsetOf(StorageBufferReadWriteBinding, "buffer"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUStorageBufferReadWriteBinding, "cycle")) == @sizeOf(@FieldType(StorageBufferReadWriteBinding, "cycle")));
+        std.debug.assert(@offsetOf(c.SDL_GPUStorageBufferReadWriteBinding, "cycle") == @offsetOf(StorageBufferReadWriteBinding, "cycle"));
     }
 };
 
@@ -3971,15 +3971,15 @@ pub const StorageTextureReadWriteBinding = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUStorageTextureReadWriteBinding) == @sizeOf(StorageTextureReadWriteBinding));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUStorageTextureReadWriteBinding, "texture")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "texture")));
-        std.debug.assert(@offsetOf(C.SDL_GPUStorageTextureReadWriteBinding, "texture") == @offsetOf(StorageTextureReadWriteBinding, "texture"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUStorageTextureReadWriteBinding, "mip_level")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "mip_level")));
-        std.debug.assert(@offsetOf(C.SDL_GPUStorageTextureReadWriteBinding, "mip_level") == @offsetOf(StorageTextureReadWriteBinding, "mip_level"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUStorageTextureReadWriteBinding, "layer")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "layer")));
-        std.debug.assert(@offsetOf(C.SDL_GPUStorageTextureReadWriteBinding, "layer") == @offsetOf(StorageTextureReadWriteBinding, "layer"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUStorageTextureReadWriteBinding, "cycle")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "cycle")));
-        std.debug.assert(@offsetOf(C.SDL_GPUStorageTextureReadWriteBinding, "cycle") == @offsetOf(StorageTextureReadWriteBinding, "cycle"));
+        std.debug.assert(@sizeOf(c.SDL_GPUStorageTextureReadWriteBinding) == @sizeOf(StorageTextureReadWriteBinding));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUStorageTextureReadWriteBinding, "texture")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "texture")));
+        std.debug.assert(@offsetOf(c.SDL_GPUStorageTextureReadWriteBinding, "texture") == @offsetOf(StorageTextureReadWriteBinding, "texture"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUStorageTextureReadWriteBinding, "mip_level")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "mip_level")));
+        std.debug.assert(@offsetOf(c.SDL_GPUStorageTextureReadWriteBinding, "mip_level") == @offsetOf(StorageTextureReadWriteBinding, "mip_level"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUStorageTextureReadWriteBinding, "layer")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "layer")));
+        std.debug.assert(@offsetOf(c.SDL_GPUStorageTextureReadWriteBinding, "layer") == @offsetOf(StorageTextureReadWriteBinding, "layer"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUStorageTextureReadWriteBinding, "cycle")) == @sizeOf(@FieldType(StorageTextureReadWriteBinding, "cycle")));
+        std.debug.assert(@offsetOf(c.SDL_GPUStorageTextureReadWriteBinding, "cycle") == @offsetOf(StorageTextureReadWriteBinding, "cycle"));
     }
 };
 
@@ -3989,16 +3989,16 @@ pub const StorageTextureReadWriteBinding = extern struct {
 /// This enum is available since SDL 3.2.0.
 pub const StoreOperation = enum(c_uint) {
     /// The contents generated during the render pass will be written to memory.
-    store = C.SDL_GPU_STOREOP_STORE,
+    store = c.SDL_GPU_STOREOP_STORE,
     /// The contents generated during the render pass are not needed and may be discarded.
     /// The contents will be undefined.
-    do_not_care = C.SDL_GPU_STOREOP_DONT_CARE,
+    do_not_care = c.SDL_GPU_STOREOP_DONT_CARE,
     /// The multisample contents generated during the render pass will be resolved to a non-multisample texture.
     /// The contents in the multisample texture may then be discarded and will be undefined.
-    resolve = C.SDL_GPU_STOREOP_RESOLVE,
+    resolve = c.SDL_GPU_STOREOP_RESOLVE,
     /// The multisample contents generated during the render pass will be resolved to a non-multisample texture.
     /// The contents in the multisample texture will be written to memory.
-    resolve_and_store = C.SDL_GPU_STOREOP_RESOLVE_AND_STORE,
+    resolve_and_store = c.SDL_GPU_STOREOP_RESOLVE_AND_STORE,
 };
 
 /// Specifies the texture format and colorspace of the swapchain textures.
@@ -4012,16 +4012,16 @@ pub const StoreOperation = enum(c_uint) {
 pub const SwapchainComposition = enum(c_uint) {
     /// B8G8R8A8 or R8G8B8A8 swapchain.
     /// Pixel values are in sRGB encoding.
-    sdr = C.SDL_GPU_SWAPCHAINCOMPOSITION_SDR,
+    sdr = c.SDL_GPU_SWAPCHAINCOMPOSITION_SDR,
     /// B8G8R8A8_SRGB or R8G8B8A8_SRGB swapchain.
     /// Pixel values are stored in memory in sRGB encoding but accessed in shaders in "linear sRGB" encoding which is sRGB but with a linear transfer function.
-    sdr_linear = C.SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR,
+    sdr_linear = c.SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR,
     /// R16G16B16A16_FLOAT swapchain.
     /// Pixel values are in extended linear sRGB encoding and permits values outside of the [0, 1] range.
-    hdr_extended_linear = C.SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR,
+    hdr_extended_linear = c.SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR,
     /// A2R10G10B10 or A2B10G10R10 swapchain.
     /// Pixel values are in BT.2020 ST2084 (PQ) encoding.
-    hdr10_st2084 = C.SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084,
+    hdr10_st2084 = c.SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084,
 };
 
 /// An opaque handle representing a texture.
@@ -4029,7 +4029,7 @@ pub const SwapchainComposition = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Texture = packed struct {
-    value: *C.SDL_GPUTexture,
+    value: *c.SDL_GPUTexture,
 };
 
 /// A structure specifying the parameters of a texture.
@@ -4063,7 +4063,7 @@ pub const TextureCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUTextureCreateInfo) TextureCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUTextureCreateInfo) TextureCreateInfo {
         return .{
             .texture_type = @enumFromInt(value.type),
             .format = @enumFromInt(value.format),
@@ -4078,7 +4078,7 @@ pub const TextureCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: TextureCreateInfo) C.SDL_GPUTextureCreateInfo {
+    pub fn toSdl(self: TextureCreateInfo) c.SDL_GPUTextureCreateInfo {
         return .{
             .type = @intFromEnum(self.texture_type),
             .format = @intFromEnum(self.format),
@@ -4166,110 +4166,110 @@ pub const TextureCreateInfo = struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const TextureFormat = enum(c_uint) {
-    a8_unorm = C.SDL_GPU_TEXTUREFORMAT_A8_UNORM,
-    r8_unorm = C.SDL_GPU_TEXTUREFORMAT_R8_UNORM,
-    r8g8_unorm = C.SDL_GPU_TEXTUREFORMAT_R8G8_UNORM,
-    r8g8b8a8_unorm = C.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM,
-    r16_unorm = C.SDL_GPU_TEXTUREFORMAT_R16_UNORM,
-    r16g16_unorm = C.SDL_GPU_TEXTUREFORMAT_R16G16_UNORM,
-    r16g16b16a16_unorm = C.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_UNORM,
-    r10g10b10a2_unorm = C.SDL_GPU_TEXTUREFORMAT_R10G10B10A2_UNORM,
-    b5g6r5_unorm = C.SDL_GPU_TEXTUREFORMAT_B5G6R5_UNORM,
-    b5g5r5a1_unorm = C.SDL_GPU_TEXTUREFORMAT_B5G5R5A1_UNORM,
-    b4g4r4a4_unorm = C.SDL_GPU_TEXTUREFORMAT_B4G4R4A4_UNORM,
-    b8g8r8a8_unorm = C.SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM,
-    bc1_rgba_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_BC1_RGBA_UNORM,
-    bc2_rgba_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_BC2_RGBA_UNORM,
-    bc3_rgba_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_BC3_RGBA_UNORM,
-    bc4_r_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_BC4_R_UNORM,
-    bc5_rg_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_BC5_RG_UNORM,
-    bc7_rgba_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_BC7_RGBA_UNORM,
-    bc6h_rgb_float_compressed = C.SDL_GPU_TEXTUREFORMAT_BC6H_RGB_FLOAT,
-    bc6h_rgb_ufloat_compressed = C.SDL_GPU_TEXTUREFORMAT_BC6H_RGB_UFLOAT,
-    r8_snorm = C.SDL_GPU_TEXTUREFORMAT_R8_SNORM,
-    r8g8_snorm = C.SDL_GPU_TEXTUREFORMAT_R8G8_SNORM,
-    r8g8b8a8_snorm = C.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_SNORM,
-    r16_snorm = C.SDL_GPU_TEXTUREFORMAT_R16_SNORM,
-    r16g16_snorm = C.SDL_GPU_TEXTUREFORMAT_R16G16_SNORM,
-    r16g16b16a16_snorm = C.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_SNORM,
-    r16_float = C.SDL_GPU_TEXTUREFORMAT_R16_FLOAT,
-    r16g16_float = C.SDL_GPU_TEXTUREFORMAT_R16G16_FLOAT,
-    r16g16b16a16_float = C.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT,
-    r32_float = C.SDL_GPU_TEXTUREFORMAT_R32_FLOAT,
-    r32g32_float = C.SDL_GPU_TEXTUREFORMAT_R32G32_FLOAT,
-    r32g32b32a32_float = C.SDL_GPU_TEXTUREFORMAT_R32G32B32A32_FLOAT,
-    r11g11b10_ufloat = C.SDL_GPU_TEXTUREFORMAT_R11G11B10_UFLOAT,
-    r8_uint = C.SDL_GPU_TEXTUREFORMAT_R8_UINT,
-    r8g8_uint = C.SDL_GPU_TEXTUREFORMAT_R8G8_UINT,
-    r8g8b8a8_uint = C.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UINT,
-    r16_uint = C.SDL_GPU_TEXTUREFORMAT_R16_UINT,
-    r16g16_uint = C.SDL_GPU_TEXTUREFORMAT_R16G16_UINT,
-    r16g16b16a16_uint = C.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_UINT,
-    r32_uint = C.SDL_GPU_TEXTUREFORMAT_R32_UINT,
-    r32g32_uint = C.SDL_GPU_TEXTUREFORMAT_R32G32_UINT,
-    r32g32b32a32_uint = C.SDL_GPU_TEXTUREFORMAT_R32G32B32A32_UINT,
-    r8_int = C.SDL_GPU_TEXTUREFORMAT_R8_INT,
-    r8g8_int = C.SDL_GPU_TEXTUREFORMAT_R8G8_INT,
-    r8g8b8a8_int = C.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_INT,
-    r16_int = C.SDL_GPU_TEXTUREFORMAT_R16_INT,
-    r16g16_int = C.SDL_GPU_TEXTUREFORMAT_R16G16_INT,
-    r16g16b16a16_int = C.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_INT,
-    r32_int = C.SDL_GPU_TEXTUREFORMAT_R32_INT,
-    r32g32_int = C.SDL_GPU_TEXTUREFORMAT_R32G32_INT,
-    r32g32b32a32_int = C.SDL_GPU_TEXTUREFORMAT_R32G32B32A32_INT,
-    r8g8b8a8_unorm_srgb = C.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM_SRGB,
-    b8g8r8a8_unorm_srgb = C.SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM_SRGB,
-    bc1_rgba_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_BC1_RGBA_UNORM_SRGB,
-    bc2_rgba_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_BC2_RGBA_UNORM_SRGB,
-    bc3_rgba_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_BC3_RGBA_UNORM_SRGB,
-    bc7_rgba_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_BC7_RGBA_UNORM_SRGB,
-    depth16_unorm = C.SDL_GPU_TEXTUREFORMAT_D16_UNORM,
-    depth24_unorm = C.SDL_GPU_TEXTUREFORMAT_D24_UNORM,
-    depth32_float = C.SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
-    depth24_unorm_s8_uint = C.SDL_GPU_TEXTUREFORMAT_D24_UNORM_S8_UINT,
-    depth32_float_s8_uint = C.SDL_GPU_TEXTUREFORMAT_D32_FLOAT_S8_UINT,
-    astc_4x4_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_4x4_UNORM,
-    astc_5x4_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_5x4_UNORM,
-    astc_5x5_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_5x5_UNORM,
-    astc_6x5_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_6x5_UNORM,
-    astc_6x6_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_6x6_UNORM,
-    astc_8x5_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x5_UNORM,
-    astc_8x6_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x6_UNORM,
-    astc_8x8_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x8_UNORM,
-    astc_10x5_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x5_UNORM,
-    astc_10x6_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x6_UNORM,
-    astc_10x8_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x8_UNORM,
-    astc_10x10_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x10_UNORM,
-    astc_12x10_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_12x10_UNORM,
-    astc_12x12_unorm_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_12x12_UNORM,
-    astc_4x4_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_4x4_UNORM_SRGB,
-    astc_5x4_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_5x4_UNORM_SRGB,
-    astc_5x5_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_5x5_UNORM_SRGB,
-    astc_6x5_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_6x5_UNORM_SRGB,
-    astc_6x6_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_6x6_UNORM_SRGB,
-    astc_8x5_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x5_UNORM_SRGB,
-    astc_8x6_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x6_UNORM_SRGB,
-    astc_8x8_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x8_UNORM_SRGB,
-    astc_10x5_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x5_UNORM_SRGB,
-    astc_10x6_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x6_UNORM_SRGB,
-    astc_10x8_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x8_UNORM_SRGB,
-    astc_10x10_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x10_UNORM_SRGB,
-    astc_12x10_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_12x10_UNORM_SRGB,
-    astc_12x12_unorm_srgb_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_12x12_UNORM_SRGB,
-    astc_4x4_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_4x4_FLOAT,
-    astc_5x4_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_5x4_FLOAT,
-    astc_5x5_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_5x5_FLOAT,
-    astc_6x5_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_6x5_FLOAT,
-    astc_6x6_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_6x6_FLOAT,
-    astc_8x5_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x5_FLOAT,
-    astc_8x6_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x6_FLOAT,
-    astc_8x8_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_8x8_FLOAT,
-    astc_10x5_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x5_FLOAT,
-    astc_10x6_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x6_FLOAT,
-    astc_10x8_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x8_FLOAT,
-    astc_10x10_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_10x10_FLOAT,
-    astc_12x10_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_12x10_FLOAT,
-    astc_12x12_float_compressed = C.SDL_GPU_TEXTUREFORMAT_ASTC_12x12_FLOAT,
+    a8_unorm = c.SDL_GPU_TEXTUREFORMAT_A8_UNORM,
+    r8_unorm = c.SDL_GPU_TEXTUREFORMAT_R8_UNORM,
+    r8g8_unorm = c.SDL_GPU_TEXTUREFORMAT_R8G8_UNORM,
+    r8g8b8a8_unorm = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM,
+    r16_unorm = c.SDL_GPU_TEXTUREFORMAT_R16_UNORM,
+    r16g16_unorm = c.SDL_GPU_TEXTUREFORMAT_R16G16_UNORM,
+    r16g16b16a16_unorm = c.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_UNORM,
+    r10g10b10a2_unorm = c.SDL_GPU_TEXTUREFORMAT_R10G10B10A2_UNORM,
+    b5g6r5_unorm = c.SDL_GPU_TEXTUREFORMAT_B5G6R5_UNORM,
+    b5g5r5a1_unorm = c.SDL_GPU_TEXTUREFORMAT_B5G5R5A1_UNORM,
+    b4g4r4a4_unorm = c.SDL_GPU_TEXTUREFORMAT_B4G4R4A4_UNORM,
+    b8g8r8a8_unorm = c.SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM,
+    bc1_rgba_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_BC1_RGBA_UNORM,
+    bc2_rgba_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_BC2_RGBA_UNORM,
+    bc3_rgba_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_BC3_RGBA_UNORM,
+    bc4_r_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_BC4_R_UNORM,
+    bc5_rg_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_BC5_RG_UNORM,
+    bc7_rgba_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_BC7_RGBA_UNORM,
+    bc6h_rgb_float_compressed = c.SDL_GPU_TEXTUREFORMAT_BC6H_RGB_FLOAT,
+    bc6h_rgb_ufloat_compressed = c.SDL_GPU_TEXTUREFORMAT_BC6H_RGB_UFLOAT,
+    r8_snorm = c.SDL_GPU_TEXTUREFORMAT_R8_SNORM,
+    r8g8_snorm = c.SDL_GPU_TEXTUREFORMAT_R8G8_SNORM,
+    r8g8b8a8_snorm = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_SNORM,
+    r16_snorm = c.SDL_GPU_TEXTUREFORMAT_R16_SNORM,
+    r16g16_snorm = c.SDL_GPU_TEXTUREFORMAT_R16G16_SNORM,
+    r16g16b16a16_snorm = c.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_SNORM,
+    r16_float = c.SDL_GPU_TEXTUREFORMAT_R16_FLOAT,
+    r16g16_float = c.SDL_GPU_TEXTUREFORMAT_R16G16_FLOAT,
+    r16g16b16a16_float = c.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT,
+    r32_float = c.SDL_GPU_TEXTUREFORMAT_R32_FLOAT,
+    r32g32_float = c.SDL_GPU_TEXTUREFORMAT_R32G32_FLOAT,
+    r32g32b32a32_float = c.SDL_GPU_TEXTUREFORMAT_R32G32B32A32_FLOAT,
+    r11g11b10_ufloat = c.SDL_GPU_TEXTUREFORMAT_R11G11B10_UFLOAT,
+    r8_uint = c.SDL_GPU_TEXTUREFORMAT_R8_UINT,
+    r8g8_uint = c.SDL_GPU_TEXTUREFORMAT_R8G8_UINT,
+    r8g8b8a8_uint = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UINT,
+    r16_uint = c.SDL_GPU_TEXTUREFORMAT_R16_UINT,
+    r16g16_uint = c.SDL_GPU_TEXTUREFORMAT_R16G16_UINT,
+    r16g16b16a16_uint = c.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_UINT,
+    r32_uint = c.SDL_GPU_TEXTUREFORMAT_R32_UINT,
+    r32g32_uint = c.SDL_GPU_TEXTUREFORMAT_R32G32_UINT,
+    r32g32b32a32_uint = c.SDL_GPU_TEXTUREFORMAT_R32G32B32A32_UINT,
+    r8_int = c.SDL_GPU_TEXTUREFORMAT_R8_INT,
+    r8g8_int = c.SDL_GPU_TEXTUREFORMAT_R8G8_INT,
+    r8g8b8a8_int = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_INT,
+    r16_int = c.SDL_GPU_TEXTUREFORMAT_R16_INT,
+    r16g16_int = c.SDL_GPU_TEXTUREFORMAT_R16G16_INT,
+    r16g16b16a16_int = c.SDL_GPU_TEXTUREFORMAT_R16G16B16A16_INT,
+    r32_int = c.SDL_GPU_TEXTUREFORMAT_R32_INT,
+    r32g32_int = c.SDL_GPU_TEXTUREFORMAT_R32G32_INT,
+    r32g32b32a32_int = c.SDL_GPU_TEXTUREFORMAT_R32G32B32A32_INT,
+    r8g8b8a8_unorm_srgb = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM_SRGB,
+    b8g8r8a8_unorm_srgb = c.SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM_SRGB,
+    bc1_rgba_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_BC1_RGBA_UNORM_SRGB,
+    bc2_rgba_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_BC2_RGBA_UNORM_SRGB,
+    bc3_rgba_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_BC3_RGBA_UNORM_SRGB,
+    bc7_rgba_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_BC7_RGBA_UNORM_SRGB,
+    depth16_unorm = c.SDL_GPU_TEXTUREFORMAT_D16_UNORM,
+    depth24_unorm = c.SDL_GPU_TEXTUREFORMAT_D24_UNORM,
+    depth32_float = c.SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
+    depth24_unorm_s8_uint = c.SDL_GPU_TEXTUREFORMAT_D24_UNORM_S8_UINT,
+    depth32_float_s8_uint = c.SDL_GPU_TEXTUREFORMAT_D32_FLOAT_S8_UINT,
+    astc_4x4_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_4x4_UNORM,
+    astc_5x4_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_5x4_UNORM,
+    astc_5x5_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_5x5_UNORM,
+    astc_6x5_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_6x5_UNORM,
+    astc_6x6_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_6x6_UNORM,
+    astc_8x5_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x5_UNORM,
+    astc_8x6_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x6_UNORM,
+    astc_8x8_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x8_UNORM,
+    astc_10x5_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x5_UNORM,
+    astc_10x6_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x6_UNORM,
+    astc_10x8_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x8_UNORM,
+    astc_10x10_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x10_UNORM,
+    astc_12x10_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_12x10_UNORM,
+    astc_12x12_unorm_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_12x12_UNORM,
+    astc_4x4_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_4x4_UNORM_SRGB,
+    astc_5x4_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_5x4_UNORM_SRGB,
+    astc_5x5_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_5x5_UNORM_SRGB,
+    astc_6x5_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_6x5_UNORM_SRGB,
+    astc_6x6_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_6x6_UNORM_SRGB,
+    astc_8x5_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x5_UNORM_SRGB,
+    astc_8x6_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x6_UNORM_SRGB,
+    astc_8x8_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x8_UNORM_SRGB,
+    astc_10x5_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x5_UNORM_SRGB,
+    astc_10x6_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x6_UNORM_SRGB,
+    astc_10x8_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x8_UNORM_SRGB,
+    astc_10x10_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x10_UNORM_SRGB,
+    astc_12x10_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_12x10_UNORM_SRGB,
+    astc_12x12_unorm_srgb_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_12x12_UNORM_SRGB,
+    astc_4x4_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_4x4_FLOAT,
+    astc_5x4_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_5x4_FLOAT,
+    astc_5x5_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_5x5_FLOAT,
+    astc_6x5_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_6x5_FLOAT,
+    astc_6x6_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_6x6_FLOAT,
+    astc_8x5_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x5_FLOAT,
+    astc_8x6_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x6_FLOAT,
+    astc_8x8_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_8x8_FLOAT,
+    astc_10x5_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x5_FLOAT,
+    astc_10x6_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x6_FLOAT,
+    astc_10x8_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x8_FLOAT,
+    astc_10x10_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_10x10_FLOAT,
+    astc_12x10_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_12x10_FLOAT,
+    astc_12x12_float_compressed = c.SDL_GPU_TEXTUREFORMAT_ASTC_12x12_FLOAT,
 
     /// Calculate the size in bytes of a texture format with dimensions.
     ///
@@ -4290,7 +4290,7 @@ pub const TextureFormat = enum(c_uint) {
         height: u32,
         depth_or_layer_count: u32,
     ) u32 {
-        return C.SDL_CalculateGPUTextureFormatSize(
+        return c.SDL_CalculateGPUTextureFormatSize(
             @intFromEnum(self),
             width,
             height,
@@ -4311,7 +4311,7 @@ pub const TextureFormat = enum(c_uint) {
     pub fn texelSize(
         self: TextureFormat,
     ) u32 {
-        return C.SDL_GPUTextureFormatTexelBlockSize(
+        return c.SDL_GPUTextureFormatTexelBlockSize(
             @intFromEnum(self),
         );
     }
@@ -4340,7 +4340,7 @@ pub const TextureLocation = struct {
 
     /// Convert from an SDL value.
     pub fn fromSdl(
-        value: C.SDL_GPUTextureLocation,
+        value: c.SDL_GPUTextureLocation,
     ) TextureLocation {
         return .{
             .texture = .{ .value = value.texture.? },
@@ -4355,7 +4355,7 @@ pub const TextureLocation = struct {
     /// Convert to an SDL value.
     pub fn toSdl(
         self: TextureLocation,
-    ) C.SDL_GPUTextureLocation {
+    ) c.SDL_GPUTextureLocation {
         return .{
             .texture = self.texture.value,
             .mip_level = self.mip_level,
@@ -4395,7 +4395,7 @@ pub const TextureRegion = struct {
     depth: u32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUTextureRegion) TextureRegion {
+    pub fn fromSdl(value: c.SDL_GPUTextureRegion) TextureRegion {
         return .{
             .texture = .{ .value = value.texture.? },
             .mip_level = value.mip_level,
@@ -4410,7 +4410,7 @@ pub const TextureRegion = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: TextureRegion) C.SDL_GPUTextureRegion {
+    pub fn toSdl(self: TextureRegion) c.SDL_GPUTextureRegion {
         return .{
             .texture = self.texture.value,
             .mip_level = self.mip_level,
@@ -4438,11 +4438,11 @@ pub const TextureSamplerBinding = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUTextureSamplerBinding) == @sizeOf(TextureSamplerBinding));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUTextureSamplerBinding, "texture")) == @sizeOf(@FieldType(TextureSamplerBinding, "texture")));
-        std.debug.assert(@offsetOf(C.SDL_GPUTextureSamplerBinding, "texture") == @offsetOf(TextureSamplerBinding, "texture"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUTextureSamplerBinding, "sampler")) == @sizeOf(@FieldType(TextureSamplerBinding, "sampler")));
-        std.debug.assert(@offsetOf(C.SDL_GPUTextureSamplerBinding, "sampler") == @offsetOf(TextureSamplerBinding, "sampler"));
+        std.debug.assert(@sizeOf(c.SDL_GPUTextureSamplerBinding) == @sizeOf(TextureSamplerBinding));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUTextureSamplerBinding, "texture")) == @sizeOf(@FieldType(TextureSamplerBinding, "texture")));
+        std.debug.assert(@offsetOf(c.SDL_GPUTextureSamplerBinding, "texture") == @offsetOf(TextureSamplerBinding, "texture"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUTextureSamplerBinding, "sampler")) == @sizeOf(@FieldType(TextureSamplerBinding, "sampler")));
+        std.debug.assert(@offsetOf(c.SDL_GPUTextureSamplerBinding, "sampler") == @offsetOf(TextureSamplerBinding, "sampler"));
     }
 };
 
@@ -4469,7 +4469,7 @@ pub const TextureTransferInfo = struct {
     rows_per_layer: u32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUTextureTransferInfo) TextureTransferInfo {
+    pub fn fromSdl(value: c.SDL_GPUTextureTransferInfo) TextureTransferInfo {
         return .{
             .transfer_buffer = .{ .value = value.transfer_buffer.? },
             .offset = value.offset,
@@ -4479,7 +4479,7 @@ pub const TextureTransferInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: TextureTransferInfo) C.SDL_GPUTextureTransferInfo {
+    pub fn toSdl(self: TextureTransferInfo) c.SDL_GPUTextureTransferInfo {
         return .{
             .transfer_buffer = self.transfer_buffer.value,
             .offset = self.offset,
@@ -4495,15 +4495,15 @@ pub const TextureTransferInfo = struct {
 /// This enum is available since SDL 3.2.0.
 pub const TextureType = enum(c_uint) {
     /// The texture is a 2-dimensional image.
-    two_dimensional = C.SDL_GPU_TEXTURETYPE_2D,
+    two_dimensional = c.SDL_GPU_TEXTURETYPE_2D,
     /// The texture is a 2-dimensional array image.
-    two_dimensional_array = C.SDL_GPU_TEXTURETYPE_2D_ARRAY,
+    two_dimensional_array = c.SDL_GPU_TEXTURETYPE_2D_ARRAY,
     /// The texture is a 3-dimensional image.
-    three_dimensional = C.SDL_GPU_TEXTURETYPE_3D,
+    three_dimensional = c.SDL_GPU_TEXTURETYPE_3D,
     /// The texture is a cube image.
-    cube = C.SDL_GPU_TEXTURETYPE_CUBE,
+    cube = c.SDL_GPU_TEXTURETYPE_CUBE,
     /// The texture is a cube array image.
-    cube_array = C.SDL_GPU_TEXTURETYPE_CUBE_ARRAY,
+    cube_array = c.SDL_GPU_TEXTURETYPE_CUBE_ARRAY,
 };
 
 /// Specifies how a texture is intended to be used by the client.
@@ -4538,35 +4538,35 @@ pub const TextureUsageFlags = struct {
     compute_storage_simultaneous_read_write: bool = false,
 
     /// Convert from SDL.
-    pub fn fromSdl(value: C.SDL_GPUTextureUsageFlags) TextureUsageFlags {
+    pub fn fromSdl(value: c.SDL_GPUTextureUsageFlags) TextureUsageFlags {
         return .{
-            .sampler = value & C.SDL_GPU_TEXTUREUSAGE_SAMPLER > 0,
-            .color_target = value & C.SDL_GPU_TEXTUREUSAGE_COLOR_TARGET > 0,
-            .depth_stencil_target = value & C.SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET > 0,
-            .graphics_storage_read = value & C.SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ > 0,
-            .compute_storage_read = value & C.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ > 0,
-            .compute_storage_write = value & C.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE > 0,
-            .compute_storage_simultaneous_read_write = value & C.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE > 0,
+            .sampler = value & c.SDL_GPU_TEXTUREUSAGE_SAMPLER > 0,
+            .color_target = value & c.SDL_GPU_TEXTUREUSAGE_COLOR_TARGET > 0,
+            .depth_stencil_target = value & c.SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET > 0,
+            .graphics_storage_read = value & c.SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ > 0,
+            .compute_storage_read = value & c.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ > 0,
+            .compute_storage_write = value & c.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE > 0,
+            .compute_storage_simultaneous_read_write = value & c.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE > 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: TextureUsageFlags) C.SDL_GPUTextureUsageFlags {
-        var ret: C.SDL_GPUTextureUsageFlags = 0;
+    pub fn toSdl(self: TextureUsageFlags) c.SDL_GPUTextureUsageFlags {
+        var ret: c.SDL_GPUTextureUsageFlags = 0;
         if (self.sampler)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_SAMPLER;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_SAMPLER;
         if (self.color_target)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
         if (self.depth_stencil_target)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
         if (self.graphics_storage_read)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ;
         if (self.compute_storage_read)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ;
         if (self.compute_storage_write)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE;
         if (self.compute_storage_simultaneous_read_write)
-            ret |= C.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE;
+            ret |= c.SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE;
         return ret;
     }
 };
@@ -4579,7 +4579,7 @@ pub const TextureUsageFlags = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const TransferBuffer = struct {
-    value: *C.SDL_GPUTransferBuffer,
+    value: *c.SDL_GPUTransferBuffer,
 };
 
 /// A structure specifying the parameters of a transfer buffer.
@@ -4595,7 +4595,7 @@ pub const TransferBufferCreateInfo = struct {
     props: ?properties.Group = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUTransferBufferCreateInfo) TransferBufferCreateInfo {
+    pub fn fromSdl(value: c.SDL_GPUTransferBufferCreateInfo) TransferBufferCreateInfo {
         return .{
             .usage = @enumFromInt(value.usage),
             .size = value.size,
@@ -4604,7 +4604,7 @@ pub const TransferBufferCreateInfo = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: TransferBufferCreateInfo) C.SDL_GPUTransferBufferCreateInfo {
+    pub fn toSdl(self: TransferBufferCreateInfo) c.SDL_GPUTransferBufferCreateInfo {
         return .{
             .usage = @intFromEnum(self.usage),
             .size = self.size,
@@ -4627,7 +4627,7 @@ pub const TransferBufferLocation = struct {
     offset: u32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUTransferBufferLocation) TransferBufferLocation {
+    pub fn fromSdl(value: c.SDL_GPUTransferBufferLocation) TransferBufferLocation {
         return .{
             .transfer_buffer = .{ .value = value.transfer_buffer.? },
             .offset = value.offset,
@@ -4635,7 +4635,7 @@ pub const TransferBufferLocation = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: TransferBufferLocation) C.SDL_GPUTransferBufferLocation {
+    pub fn toSdl(self: TransferBufferLocation) c.SDL_GPUTransferBufferLocation {
         return .{
             .transfer_buffer = self.transfer_buffer.value,
             .offset = self.offset,
@@ -4651,8 +4651,8 @@ pub const TransferBufferLocation = struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const TransferBufferUsage = enum(c_uint) {
-    upload = C.SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD,
-    download = C.SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD,
+    upload = c.SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD,
+    download = c.SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD,
 };
 
 /// A structure specifying a vertex attribute.
@@ -4674,15 +4674,15 @@ pub const VertexAttribute = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUVertexAttribute) == @sizeOf(VertexAttribute));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexAttribute, "location")) == @sizeOf(@FieldType(VertexAttribute, "location")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexAttribute, "location") == @offsetOf(VertexAttribute, "location"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexAttribute, "buffer_slot")) == @sizeOf(@FieldType(VertexAttribute, "buffer_slot")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexAttribute, "buffer_slot") == @offsetOf(VertexAttribute, "buffer_slot"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexAttribute, "format")) == @sizeOf(@FieldType(VertexAttribute, "format")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexAttribute, "format") == @offsetOf(VertexAttribute, "format"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexAttribute, "offset")) == @sizeOf(@FieldType(VertexAttribute, "offset")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexAttribute, "offset") == @offsetOf(VertexAttribute, "offset"));
+        std.debug.assert(@sizeOf(c.SDL_GPUVertexAttribute) == @sizeOf(VertexAttribute));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexAttribute, "location")) == @sizeOf(@FieldType(VertexAttribute, "location")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexAttribute, "location") == @offsetOf(VertexAttribute, "location"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexAttribute, "buffer_slot")) == @sizeOf(@FieldType(VertexAttribute, "buffer_slot")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexAttribute, "buffer_slot") == @offsetOf(VertexAttribute, "buffer_slot"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexAttribute, "format")) == @sizeOf(@FieldType(VertexAttribute, "format")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexAttribute, "format") == @offsetOf(VertexAttribute, "format"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexAttribute, "offset")) == @sizeOf(@FieldType(VertexAttribute, "offset")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexAttribute, "offset") == @offsetOf(VertexAttribute, "offset"));
     }
 };
 
@@ -4710,15 +4710,15 @@ pub const VertexBufferDescription = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_GPUVertexBufferDescription) == @sizeOf(VertexBufferDescription));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexBufferDescription, "slot")) == @sizeOf(@FieldType(VertexBufferDescription, "slot")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexBufferDescription, "slot") == @offsetOf(VertexBufferDescription, "slot"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexBufferDescription, "pitch")) == @sizeOf(@FieldType(VertexBufferDescription, "pitch")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexBufferDescription, "pitch") == @offsetOf(VertexBufferDescription, "pitch"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexBufferDescription, "input_rate")) == @sizeOf(@FieldType(VertexBufferDescription, "input_rate")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexBufferDescription, "input_rate") == @offsetOf(VertexBufferDescription, "input_rate"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_GPUVertexBufferDescription, "instance_step_rate")) == @sizeOf(@FieldType(VertexBufferDescription, "instance_step_rate")));
-        std.debug.assert(@offsetOf(C.SDL_GPUVertexBufferDescription, "instance_step_rate") == @offsetOf(VertexBufferDescription, "instance_step_rate"));
+        std.debug.assert(@sizeOf(c.SDL_GPUVertexBufferDescription) == @sizeOf(VertexBufferDescription));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexBufferDescription, "slot")) == @sizeOf(@FieldType(VertexBufferDescription, "slot")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexBufferDescription, "slot") == @offsetOf(VertexBufferDescription, "slot"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexBufferDescription, "pitch")) == @sizeOf(@FieldType(VertexBufferDescription, "pitch")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexBufferDescription, "pitch") == @offsetOf(VertexBufferDescription, "pitch"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexBufferDescription, "input_rate")) == @sizeOf(@FieldType(VertexBufferDescription, "input_rate")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexBufferDescription, "input_rate") == @offsetOf(VertexBufferDescription, "input_rate"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_GPUVertexBufferDescription, "instance_step_rate")) == @sizeOf(@FieldType(VertexBufferDescription, "instance_step_rate")));
+        std.debug.assert(@offsetOf(c.SDL_GPUVertexBufferDescription, "instance_step_rate") == @offsetOf(VertexBufferDescription, "instance_step_rate"));
     }
 };
 
@@ -4730,51 +4730,51 @@ pub const VertexBufferDescription = extern struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const VertexElementFormat = enum(c_uint) {
-    i32x1 = C.SDL_GPU_VERTEXELEMENTFORMAT_INT,
-    i32x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_INT2,
-    i32x3 = C.SDL_GPU_VERTEXELEMENTFORMAT_INT3,
-    i32x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_INT4,
-    u32x1 = C.SDL_GPU_VERTEXELEMENTFORMAT_UINT,
-    u32x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_UINT2,
-    u32x3 = C.SDL_GPU_VERTEXELEMENTFORMAT_UINT3,
-    u32x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_UINT4,
-    f32x1 = C.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT,
-    f32x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2,
-    f32x3 = C.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3,
-    f32x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4,
-    i8x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_BYTE2,
-    i8x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_BYTE4,
-    u8x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE2,
-    u8x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE4,
-    i8x2_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_BYTE2_NORM,
-    i8x4_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_BYTE4_NORM,
-    u8x2_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE2_NORM,
-    u8x4_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE4_NORM,
-    i16x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_SHORT2,
-    i16x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_SHORT4,
-    u16x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_USHORT2,
-    u16x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_USHORT4,
-    i16x2_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_SHORT2_NORM,
-    i16x4_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_SHORT4_NORM,
-    u16x2_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_USHORT2_NORM,
-    u16x4_normalized = C.SDL_GPU_VERTEXELEMENTFORMAT_USHORT4_NORM,
-    f16x2 = C.SDL_GPU_VERTEXELEMENTFORMAT_HALF2,
-    f16x4 = C.SDL_GPU_VERTEXELEMENTFORMAT_HALF4,
+    i32x1 = c.SDL_GPU_VERTEXELEMENTFORMAT_INT,
+    i32x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_INT2,
+    i32x3 = c.SDL_GPU_VERTEXELEMENTFORMAT_INT3,
+    i32x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_INT4,
+    u32x1 = c.SDL_GPU_VERTEXELEMENTFORMAT_UINT,
+    u32x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_UINT2,
+    u32x3 = c.SDL_GPU_VERTEXELEMENTFORMAT_UINT3,
+    u32x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_UINT4,
+    f32x1 = c.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT,
+    f32x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2,
+    f32x3 = c.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3,
+    f32x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4,
+    i8x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_BYTE2,
+    i8x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_BYTE4,
+    u8x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE2,
+    u8x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE4,
+    i8x2_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_BYTE2_NORM,
+    i8x4_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_BYTE4_NORM,
+    u8x2_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE2_NORM,
+    u8x4_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_UBYTE4_NORM,
+    i16x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_SHORT2,
+    i16x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_SHORT4,
+    u16x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_USHORT2,
+    u16x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_USHORT4,
+    i16x2_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_SHORT2_NORM,
+    i16x4_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_SHORT4_NORM,
+    u16x2_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_USHORT2_NORM,
+    u16x4_normalized = c.SDL_GPU_VERTEXELEMENTFORMAT_USHORT4_NORM,
+    f16x2 = c.SDL_GPU_VERTEXELEMENTFORMAT_HALF2,
+    f16x4 = c.SDL_GPU_VERTEXELEMENTFORMAT_HALF4,
 
     /// Create from SDL.
-    pub fn fromSdl(val: C.SDL_GPUVertexElementFormat) ?VertexElementFormat {
-        if (val == C.SDL_GPU_VERTEXELEMENTFORMAT_INVALID) {
+    pub fn fromSdl(val: c.SDL_GPUVertexElementFormat) ?VertexElementFormat {
+        if (val == c.SDL_GPU_VERTEXELEMENTFORMAT_INVALID) {
             return null;
         }
         return @enumFromInt(val);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(val: ?VertexElementFormat) C.SDL_GPUVertexElementFormat {
+    pub fn toSdl(val: ?VertexElementFormat) c.SDL_GPUVertexElementFormat {
         if (val) |tmp| {
             return @intFromEnum(tmp);
         }
-        return C.SDL_GPU_VERTEXELEMENTFORMAT_INVALID;
+        return c.SDL_GPU_VERTEXELEMENTFORMAT_INVALID;
     }
 };
 
@@ -4784,9 +4784,9 @@ pub const VertexElementFormat = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const VertexInputRate = enum(c_uint) {
     /// Attribute addressing is a function of the vertex index.
-    vertex = C.SDL_GPU_VERTEXINPUTRATE_VERTEX,
+    vertex = c.SDL_GPU_VERTEXINPUTRATE_VERTEX,
     /// Attribute addressing is a function of the instance index.
-    instance = C.SDL_GPU_VERTEXINPUTRATE_INSTANCE,
+    instance = c.SDL_GPU_VERTEXINPUTRATE_INSTANCE,
 };
 
 /// A structure specifying the parameters of a graphics pipeline vertex input state.
@@ -4800,7 +4800,7 @@ pub const VertexInputState = struct {
     vertex_attributes: []const VertexAttribute = &.{},
 
     /// From an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUVertexInputState) VertexInputState {
+    pub fn fromSdl(value: c.SDL_GPUVertexInputState) VertexInputState {
         return .{
             .vertex_buffer_descriptions = @as([*]const VertexBufferDescription, @ptrCast(value.vertex_buffer_descriptions))[0..@intCast(value.num_vertex_buffers)],
             .vertex_attributes = @as([*]const VertexAttribute, @ptrCast(value.vertex_attributes))[0..@intCast(value.num_vertex_attributes)],
@@ -4808,7 +4808,7 @@ pub const VertexInputState = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: VertexInputState) C.SDL_GPUVertexInputState {
+    pub fn toSdl(self: VertexInputState) c.SDL_GPUVertexInputState {
         return .{
             .vertex_buffer_descriptions = @ptrCast(self.vertex_buffer_descriptions.ptr),
             .num_vertex_buffers = @intCast(self.vertex_buffer_descriptions.len),
@@ -4831,7 +4831,7 @@ pub const Viewport = struct {
     max_depth: f32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_GPUViewport) Viewport {
+    pub fn fromSdl(value: c.SDL_GPUViewport) Viewport {
         return .{
             .region = .{
                 .x = value.x,
@@ -4845,7 +4845,7 @@ pub const Viewport = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Viewport) C.SDL_GPUViewport {
+    pub fn toSdl(self: Viewport) c.SDL_GPUViewport {
         return .{
             .x = self.region.x,
             .y = self.region.y,
@@ -4876,7 +4876,7 @@ pub const Viewport = struct {
 pub fn getDriverName(
     index: usize,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetGPUDriver(@intCast(index));
+    const ret = c.SDL_GetGPUDriver(@intCast(index));
     return std.mem.span(ret);
 }
 
@@ -4888,7 +4888,7 @@ pub fn getDriverName(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getNumDrivers() usize {
-    return @intCast(C.SDL_GetNumGPUDrivers());
+    return @intCast(c.SDL_GetNumGPUDrivers());
 }
 
 /// Checks for GPU runtime support.
@@ -4904,7 +4904,7 @@ pub fn getNumDrivers() usize {
 pub fn supportsProperties(
     props: properties.Group,
 ) bool {
-    return C.SDL_GPUSupportsProperties(
+    return c.SDL_GPUSupportsProperties(
         props.value,
     );
 }

--- a/src/guid.zig
+++ b/src/guid.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// A `GUID` is a 128-bit identifier for an input device that identifies that device across runs of SDL programs on the same platform.
@@ -14,7 +14,7 @@ const std = @import("std");
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const GUID = struct {
-    value: C.SDL_GUID,
+    value: c.SDL_GUID,
 
     /// Convert a GUID string into a GUID structure.
     ///
@@ -36,7 +36,7 @@ pub const GUID = struct {
     pub fn fromString(
         str: [:0]const u8,
     ) GUID {
-        const ret = C.SDL_StringToGUID(
+        const ret = c.SDL_StringToGUID(
             str,
         );
         return GUID{ .value = ret };
@@ -57,7 +57,7 @@ pub const GUID = struct {
         self: GUID,
         str: *[33:0]u8,
     ) void {
-        const ret = C.SDL_GUIDToString(
+        const ret = c.SDL_GUIDToString(
             self.value,
             str,
             @intCast(str.len),

--- a/src/hid_api.zig
+++ b/src/hid_api.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -8,18 +8,18 @@ const std = @import("std");
 /// This enum is available since SDL 3.2.0.
 pub const BusType = enum(c_uint) {
     /// An unknown bus type.
-    unknown = C.SDL_HID_API_BUS_UNKNOWN,
+    unknown = c.SDL_HID_API_BUS_UNKNOWN,
     /// USB bus Specifications: https://usb.org/hid.
-    usb = C.SDL_HID_API_BUS_USB,
+    usb = c.SDL_HID_API_BUS_USB,
     /// Bluetooth or Bluetooth LE bus Specifications:
     /// https://www.bluetooth.com/specifications/specs/human-interface-device-profile-1-1-1/
     /// https://www.bluetooth.com/specifications/specs/hid-service-1-0/
     /// https://www.bluetooth.com/specifications/specs/hid-over-gatt-profile-1-0/
-    bluetooth = C.SDL_HID_API_BUS_BLUETOOTH,
+    bluetooth = c.SDL_HID_API_BUS_BLUETOOTH,
     /// I2C bus Specifications: https://docs.microsoft.com/previous-versions/windows/hardware/design/dn642101(v=vs.85)
-    i2c = C.SDL_HID_API_BUS_I2C,
+    i2c = c.SDL_HID_API_BUS_I2C,
     /// SPI bus Specifications: https://www.microsoft.com/download/details.aspx?id=103325
-    spi = C.SDL_HID_API_BUS_SPI,
+    spi = c.SDL_HID_API_BUS_SPI,
 };
 
 /// An opaque handle representing an open HID device.
@@ -27,7 +27,7 @@ pub const BusType = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Device = struct {
-    value: *C.SDL_hid_device,
+    value: *c.SDL_hid_device,
 
     /// Close a HID device.
     ///
@@ -39,7 +39,7 @@ pub const Device = struct {
     pub fn deinit(
         self: Device,
     ) !void {
-        const ret = C.SDL_hid_close(self.value);
+        const ret = c.SDL_hid_close(self.value);
         if (ret != 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -59,7 +59,7 @@ pub const Device = struct {
     pub fn getDeviceInfo(
         self: Device,
     ) !DeviceInfo {
-        return @as(*DeviceInfo, @ptrCast(try errors.wrapNull(*C.SDL_hid_device_info, C.SDL_hid_get_device_info(self.value)))).*;
+        return @as(*DeviceInfo, @ptrCast(try errors.wrapNull(*c.SDL_hid_device_info, c.SDL_hid_get_device_info(self.value)))).*;
     }
 
     /// Get a feature report from a HID device.
@@ -82,7 +82,7 @@ pub const Device = struct {
         self: Device,
         data: []u8,
     ) ![]u8 {
-        const ret: usize = @intCast(try errors.wrapCall(c_int, C.SDL_hid_get_feature_report(
+        const ret: usize = @intCast(try errors.wrapCall(c_int, c.SDL_hid_get_feature_report(
             self.value,
             data.ptr,
             data.len,
@@ -104,7 +104,7 @@ pub const Device = struct {
         index: c_int,
         buf: [:0]c_int,
     ) !void {
-        const ret = C.SDL_hid_get_indexed_string(self.value, index, buf.ptr, buf.len);
+        const ret = c.SDL_hid_get_indexed_string(self.value, index, buf.ptr, buf.len);
         if (ret != 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -131,7 +131,7 @@ pub const Device = struct {
         self: Device,
         data: []u8,
     ) ![]u8 {
-        const ret: usize = @intCast(try errors.wrapCall(c_int, C.SDL_hid_get_input_report(
+        const ret: usize = @intCast(try errors.wrapCall(c_int, c.SDL_hid_get_input_report(
             self.value,
             data.ptr,
             data.len,
@@ -151,7 +151,7 @@ pub const Device = struct {
         self: Device,
         buf: [:0]c_int,
     ) !void {
-        const ret = C.SDL_hid_get_manufacturer_string(self.value, buf.ptr, buf.len);
+        const ret = c.SDL_hid_get_manufacturer_string(self.value, buf.ptr, buf.len);
         if (ret != 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -170,7 +170,7 @@ pub const Device = struct {
         self: Device,
         buf: [:0]c_int,
     ) !void {
-        const ret = C.SDL_hid_get_product_string(self.value, buf.ptr, buf.len);
+        const ret = c.SDL_hid_get_product_string(self.value, buf.ptr, buf.len);
         if (ret != 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -196,7 +196,7 @@ pub const Device = struct {
         self: Device,
         data: []u8,
     ) ![]u8 {
-        const ret: usize = @intCast(try errors.wrapCall(c_int, C.SDL_hid_get_report_descriptor(
+        const ret: usize = @intCast(try errors.wrapCall(c_int, c.SDL_hid_get_report_descriptor(
             self.value,
             data.ptr,
             data.len,
@@ -216,7 +216,7 @@ pub const Device = struct {
         self: Device,
         buf: [:0]c_int,
     ) !void {
-        const ret = C.SDL_hid_get_serial_number_string(self.value, buf.ptr, buf.len);
+        const ret = c.SDL_hid_get_serial_number_string(self.value, buf.ptr, buf.len);
         if (ret != 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -244,7 +244,7 @@ pub const Device = struct {
         serial_num: ?[:0]c_int,
     ) !Device {
         return .{
-            .value = try errors.wrapNull(*C.SDL_hid_device, C.SDL_hid_open(vendor_id, product_id, if (serial_num) |val| val.ptr else null)),
+            .value = try errors.wrapNull(*c.SDL_hid_device, c.SDL_hid_open(vendor_id, product_id, if (serial_num) |val| val.ptr else null)),
         };
     }
 
@@ -265,7 +265,7 @@ pub const Device = struct {
         path: [:0]const u8,
     ) !Device {
         return .{
-            .value = try errors.wrapNull(*C.SDL_hid_device, C.SDL_hid_open_path(path.ptr)),
+            .value = try errors.wrapNull(*c.SDL_hid_device, c.SDL_hid_open_path(path.ptr)),
         };
     }
 
@@ -289,7 +289,7 @@ pub const Device = struct {
         self: Device,
         data: []u8,
     ) !?[]u8 {
-        const ret: usize = @intCast(try errors.wrapCall(c_int, C.SDL_hid_read(
+        const ret: usize = @intCast(try errors.wrapCall(c_int, c.SDL_hid_read(
             self.value,
             data.ptr,
             data.len,
@@ -321,7 +321,7 @@ pub const Device = struct {
         data: []u8,
         timeout_milliseconds: ?usize,
     ) !?[]u8 {
-        const ret: usize = @intCast(try errors.wrapCall(c_int, C.SDL_hid_read_timeout(
+        const ret: usize = @intCast(try errors.wrapCall(c_int, c.SDL_hid_read_timeout(
             self.value,
             data.ptr,
             data.len,
@@ -360,7 +360,7 @@ pub const Device = struct {
         self: Device,
         data: []const u8,
     ) !usize {
-        return @intCast(try errors.wrapCall(c_int, C.SDL_hid_send_feature_report(
+        return @intCast(try errors.wrapCall(c_int, c.SDL_hid_send_feature_report(
             self.value,
             data.ptr,
             data.len,
@@ -385,7 +385,7 @@ pub const Device = struct {
         self: Device,
         non_block: bool,
     ) !void {
-        const ret = C.SDL_hid_set_nonblocking(self.value, if (non_block) 1 else 0);
+        const ret = c.SDL_hid_set_nonblocking(self.value, if (non_block) 1 else 0);
         if (ret != 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -419,7 +419,7 @@ pub const Device = struct {
         self: Device,
         data: []const u8,
     ) !usize {
-        return @intCast(try errors.wrapCall(c_int, C.SDL_hid_write(
+        return @intCast(try errors.wrapCall(c_int, c.SDL_hid_write(
             self.value,
             data.ptr,
             data.len,
@@ -466,7 +466,7 @@ pub const DeviceInfo = extern struct {
 
     // Size checks.
     comptime {
-        errors.assertStructsEqual(DeviceInfo, C.SDL_hid_device_info);
+        errors.assertStructsEqual(DeviceInfo, c.SDL_hid_device_info);
     }
 };
 
@@ -480,7 +480,7 @@ pub const DeviceInfo = extern struct {
 pub fn bleScan(
     active: bool,
 ) void {
-    C.SDL_hid_ble_scan(
+    c.SDL_hid_ble_scan(
         active,
     );
 }
@@ -494,7 +494,7 @@ pub fn bleScan(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn deinit() !void {
-    const ret = C.SDL_hid_exit();
+    const ret = c.SDL_hid_exit();
     if (ret != 0) {
         errors.callErrorCallback();
         return error.SdlError;
@@ -515,7 +515,7 @@ pub fn deinit() !void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn deviceChangeCount() usize {
-    return @intCast(C.SDL_hid_device_change_count());
+    return @intCast(c.SDL_hid_device_change_count());
 }
 
 /// Enumerate the HID Devices.
@@ -543,7 +543,7 @@ pub fn enumerate(
     vendor_id: ?c_ushort,
     product_id: ?c_ushort,
 ) !*DeviceInfo {
-    return @ptrCast(try errors.wrapNull(*C.SDL_hid_device_info, C.SDL_hid_enumerate(
+    return @ptrCast(try errors.wrapNull(*c.SDL_hid_device_info, c.SDL_hid_enumerate(
         if (vendor_id) |val| val else 0,
         if (product_id) |val| val else 0,
     )));
@@ -562,7 +562,7 @@ pub fn enumerate(
 pub fn freeEnumeration(
     devs: *DeviceInfo,
 ) void {
-    C.SDL_hid_free_enumeration(@ptrCast(devs));
+    c.SDL_hid_free_enumeration(@ptrCast(devs));
 }
 
 /// Initialize the HIDAPI library.
@@ -577,7 +577,7 @@ pub fn freeEnumeration(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn init() !void {
-    const ret = C.SDL_hid_init();
+    const ret = c.SDL_hid_init();
     if (ret != 0) {
         errors.callErrorCallback();
         return error.SdlError;

--- a/src/hints.zig
+++ b/src/hints.zig
@@ -23,7 +23,7 @@ pub const Callback = *const fn (
     name: [*c]const u8,
     old_value: [*c]const u8,
     new_value: [*c]const u8,
-) callconv(.C) void;
+) callconv(.c) void;
 
 /// An enumeration of hint priorities.
 ///
@@ -389,7 +389,7 @@ pub fn setWithPriority(
     return errors.wrapCallBool(ret);
 }
 
-fn testHintCb(user_data: ?*anyopaque, name: [*c]const u8, old_value: [*c]const u8, new_value: [*c]const u8) callconv(.C) void {
+fn testHintCb(user_data: ?*anyopaque, name: [*c]const u8, old_value: [*c]const u8, new_value: [*c]const u8) callconv(.c) void {
     const ctr_ptr: *i32 = @ptrCast(@alignCast(user_data));
     _ = name;
     _ = old_value;

--- a/src/hints.zig
+++ b/src/hints.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -30,9 +30,9 @@ pub const Callback = *const fn (
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Priority = enum(c_uint) {
-    Default = C.SDL_HINT_DEFAULT,
-    Normal = C.SDL_HINT_NORMAL,
-    Override = C.SDL_HINT_OVERRIDE,
+    Default = c.SDL_HINT_DEFAULT,
+    Normal = c.SDL_HINT_NORMAL,
+    Override = c.SDL_HINT_OVERRIDE,
 };
 
 /// Configuration hints for the library. May or may not be useful depending on the platform.
@@ -165,21 +165,21 @@ pub const Type = enum {
 
     /// Convert from an SDL string.
     pub fn fromSdl(val: [:0]const u8) Type {
-        if (std.mem.eql(u8, C.SDL_HINT_ALLOW_ALT_TAB_WHILE_GRABBED, val))
+        if (std.mem.eql(u8, c.SDL_HINT_ALLOW_ALT_TAB_WHILE_GRABBED, val))
             return .AllowAltTabWhileGrabbed;
-        if (std.mem.eql(u8, C.SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY, val))
+        if (std.mem.eql(u8, c.SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY, val))
             return .AndroidAllowRecreateActivity;
-        if (std.mem.eql(u8, C.SDL_HINT_ANDROID_BLOCK_ON_PAUSE, val))
+        if (std.mem.eql(u8, c.SDL_HINT_ANDROID_BLOCK_ON_PAUSE, val))
             return .AndroidBlockOnPause;
-        if (std.mem.eql(u8, C.SDL_HINT_ANDROID_LOW_LATENCY_AUDIO, val))
+        if (std.mem.eql(u8, c.SDL_HINT_ANDROID_LOW_LATENCY_AUDIO, val))
             return .AndroidLowLatencyAudio;
-        if (std.mem.eql(u8, C.SDL_HINT_ANDROID_TRAP_BACK_BUTTON, val))
+        if (std.mem.eql(u8, c.SDL_HINT_ANDROID_TRAP_BACK_BUTTON, val))
             return .AndroidTrapBackButton;
-        if (std.mem.eql(u8, C.SDL_HINT_APP_ID, val))
+        if (std.mem.eql(u8, c.SDL_HINT_APP_ID, val))
             return .AppID;
-        if (std.mem.eql(u8, C.SDL_HINT_APP_NAME, val))
+        if (std.mem.eql(u8, c.SDL_HINT_APP_NAME, val))
             return .AppName;
-        if (std.mem.eql(u8, C.SDL_HINT_APPLE_TV_CONTROLLER_UI_EVENTS, val))
+        if (std.mem.eql(u8, c.SDL_HINT_APPLE_TV_CONTROLLER_UI_EVENTS, val))
             return .AppleTvControllerUiEvents;
         return .AllowAltTabWhileGrabbed;
     }
@@ -187,14 +187,14 @@ pub const Type = enum {
     /// Convert to an SDL string.
     pub fn toSdl(self: Type) [:0]const u8 {
         return switch (self) {
-            .AllowAltTabWhileGrabbed => C.SDL_HINT_ALLOW_ALT_TAB_WHILE_GRABBED,
-            .AndroidAllowRecreateActivity => C.SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY,
-            .AndroidBlockOnPause => C.SDL_HINT_ANDROID_BLOCK_ON_PAUSE,
-            .AndroidLowLatencyAudio => C.SDL_HINT_ANDROID_LOW_LATENCY_AUDIO,
-            .AndroidTrapBackButton => C.SDL_HINT_ANDROID_TRAP_BACK_BUTTON,
-            .AppID => C.SDL_HINT_APP_ID,
-            .AppName => C.SDL_HINT_APP_NAME,
-            .AppleTvControllerUiEvents => C.SDL_HINT_APPLE_TV_CONTROLLER_UI_EVENTS,
+            .AllowAltTabWhileGrabbed => c.SDL_HINT_ALLOW_ALT_TAB_WHILE_GRABBED,
+            .AndroidAllowRecreateActivity => c.SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY,
+            .AndroidBlockOnPause => c.SDL_HINT_ANDROID_BLOCK_ON_PAUSE,
+            .AndroidLowLatencyAudio => c.SDL_HINT_ANDROID_LOW_LATENCY_AUDIO,
+            .AndroidTrapBackButton => c.SDL_HINT_ANDROID_TRAP_BACK_BUTTON,
+            .AppID => c.SDL_HINT_APP_ID,
+            .AppName => c.SDL_HINT_APP_NAME,
+            .AppleTvControllerUiEvents => c.SDL_HINT_APPLE_TV_CONTROLLER_UI_EVENTS,
         };
     }
 };
@@ -219,7 +219,7 @@ pub fn addCallback(
     callback: Callback,
     user_data: ?*anyopaque,
 ) !void {
-    const ret = C.SDL_AddHintCallback(
+    const ret = c.SDL_AddHintCallback(
         hint.toSdl(),
         callback,
         user_data,
@@ -245,7 +245,7 @@ pub fn addCallback(
 pub fn get(
     hint: Type,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetHint(
+    const ret = c.SDL_GetHint(
         hint.toSdl(),
     );
     if (ret == null)
@@ -269,7 +269,7 @@ pub fn get(
 pub fn getBoolean(
     hint: Type,
 ) ?bool {
-    const ret = C.SDL_GetHintBoolean(
+    const ret = c.SDL_GetHintBoolean(
         hint.toSdl(),
         false,
     );
@@ -294,7 +294,7 @@ pub fn removeCallback(
     callback: Callback,
     user_data: ?*anyopaque,
 ) void {
-    C.SDL_RemoveHintCallback(
+    c.SDL_RemoveHintCallback(
         hint.toSdl(),
         callback,
         user_data,
@@ -318,7 +318,7 @@ pub fn removeCallback(
 pub fn reset(
     hint: Type,
 ) !void {
-    const ret = C.SDL_ResetHint(
+    const ret = c.SDL_ResetHint(
         hint.toSdl(),
     );
     return errors.wrapCallBool(ret);
@@ -336,7 +336,7 @@ pub fn reset(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn resetAll() void {
-    C.SDL_ResetHints();
+    c.SDL_ResetHints();
 }
 
 /// Set a hint with normal priority.
@@ -352,7 +352,7 @@ pub fn set(
     hint: Type,
     value: [:0]const u8,
 ) !void {
-    const ret = C.SDL_SetHint(
+    const ret = c.SDL_SetHint(
         hint.toSdl(),
         value.ptr,
     );
@@ -381,7 +381,7 @@ pub fn setWithPriority(
     value: [:0]const u8,
     priority: Priority,
 ) !void {
-    const ret = C.SDL_SetHintWithPriority(
+    const ret = c.SDL_SetHintWithPriority(
         hint.toSdl(),
         value.ptr,
         @intFromEnum(priority),

--- a/src/image.zig
+++ b/src/image.zig
@@ -1,175 +1,175 @@
 // This file was generated using `zig build bindings`. Do not manually edit!
 
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// SDL image version information.
 pub const Version = struct {
-	value: c_int,
-	/// SDL version compiled against.
-	pub const compiled_against = Version{ .value = C.SDL_IMAGE_VERSION };
+    value: c_int,
+    /// SDL version compiled against.
+    pub const compiled_against = Version{ .value = c.SDL_IMAGE_VERSION };
 
-	/// Create an SDL image version number.
-	pub fn make(
-		major: u32,
-		minor: u32,
-		micro: u32,
-	) Version {
-		const ret = C.SDL_VERSIONNUM(
-			@intCast(major),
-			@intCast(minor),
-			@intCast(micro),
-		);
-		return Version{ .value = ret };
-	}
+    /// Create an SDL image version number.
+    pub fn make(
+        major: u32,
+        minor: u32,
+        micro: u32,
+    ) Version {
+        const ret = c.SDL_VERSIONNUM(
+            @intCast(major),
+            @intCast(minor),
+            @intCast(micro),
+        );
+        return Version{ .value = ret };
+    }
 
-	/// Major version number.
-	pub fn getMajor(
-		self: version.Version,
-	) u32 {
-		const ret = C.SDL_VERSIONNUM_MAJOR(
-			self.value,
-		);
-		return @intCast(ret);
-	}
+    /// Major version number.
+    pub fn getMajor(
+        self: version.Version,
+    ) u32 {
+        const ret = c.SDL_VERSIONNUM_MAJOR(
+            self.value,
+        );
+        return @intCast(ret);
+    }
 
-	/// Minor version number.
-	pub fn getMinor(
-		self: version.Version,
-	) u32 {
-		const ret = C.SDL_VERSIONNUM_MINOR(
-			self.value,
-		);
-		return @intCast(ret);
-	}
+    /// Minor version number.
+    pub fn getMinor(
+        self: version.Version,
+    ) u32 {
+        const ret = c.SDL_VERSIONNUM_MINOR(
+            self.value,
+        );
+        return @intCast(ret);
+    }
 
-	/// Micro version number.
-	pub fn getMicro(
-		self: version.Version,
-	) u32 {
-		const ret = C.SDL_VERSIONNUM_MICRO(
-			self.value,
-		);
-		return @intCast(ret);
-	}
+    /// Micro version number.
+    pub fn getMicro(
+        self: version.Version,
+    ) u32 {
+        const ret = c.SDL_VERSIONNUM_MICRO(
+            self.value,
+        );
+        return @intCast(ret);
+    }
 
-	/// Check if the SDL image version is at least greater than the given one.
-	pub fn atLeast(
-		major: u32,
-		minor: u32,
-		micro: u32,
-	) bool {
-		const ret = C.SDL_IMAGE_VERSION_ATLEAST(
-			@intCast(major),
-			@intCast(minor),
-			@intCast(micro),
-		);
-		return ret;
-	}
+    /// Check if the SDL image version is at least greater than the given one.
+    pub fn atLeast(
+        major: u32,
+        minor: u32,
+        micro: u32,
+    ) bool {
+        const ret = c.SDL_IMAGE_VERSION_ATLEAST(
+            @intCast(major),
+            @intCast(minor),
+            @intCast(micro),
+        );
+        return ret;
+    }
 
-	/// Get the version of SDL image that is linked against your program. Possibly different than the compiled against version.
-	pub fn get() Version {
-		const ret = C.IMG_Version();
-		return Version{ .value = ret };
-	}
+    /// Get the version of SDL image that is linked against your program. Possibly different than the compiled against version.
+    pub fn get() Version {
+        const ret = c.IMG_Version();
+        return Version{ .value = ret };
+    }
 };
 
 /// Animated image support.
 pub const Animation = struct {
-	value: C.IMG_Animation,
+    value: c.IMG_Animation,
 
-	/// Load an animation from a file.
-	pub fn init(
-		file: [:0]const u8,
-	) !Animation {
-		const ret = C.IMG_LoadAnimation(
-			file,
-		);
-		if (ret == null)
-			return error.SdlError;
-		return Animation{ .value = ret };
-	}
+    /// Load an animation from a file.
+    pub fn init(
+        file: [:0]const u8,
+    ) !Animation {
+        const ret = c.IMG_LoadAnimation(
+            file,
+        );
+        if (ret == null)
+            return error.SdlError;
+        return Animation{ .value = ret };
+    }
 
-	/// Load an animation from an SDL_IOStream.
-	pub fn initFromIo(
-		source: io_stream.Stream,
-		close_when_done: bool,
-	) !Animation {
-		const ret = C.IMG_LoadAnimation_IO(
-			source.value,
-			close_when_done,
-		);
-		if (ret == null)
-			return error.SdlError;
-		return Animation{ .value = ret };
-	}
+    /// Load an animation from an SDL_IOStream.
+    pub fn initFromIo(
+        source: io_stream.Stream,
+        close_when_done: bool,
+    ) !Animation {
+        const ret = c.IMG_LoadAnimation_IO(
+            source.value,
+            close_when_done,
+        );
+        if (ret == null)
+            return error.SdlError;
+        return Animation{ .value = ret };
+    }
 
-	/// Load an animation from an SDL datasource.
-	pub fn initFromTypedIo(
-		source: io_stream.Stream,
-		close_when_done: bool,
-		file_type: [:0]const u8,
-	) !Animation {
-		const ret = C.IMG_LoadAnimationTyped_IO(
-			source.value,
-			close_when_done,
-			file_type,
-		);
-		if (ret == null)
-			return error.SdlError;
-		return Animation{ .value = ret };
-	}
+    /// Load an animation from an SDL datasource.
+    pub fn initFromTypedIo(
+        source: io_stream.Stream,
+        close_when_done: bool,
+        file_type: [:0]const u8,
+    ) !Animation {
+        const ret = c.IMG_LoadAnimationTyped_IO(
+            source.value,
+            close_when_done,
+            file_type,
+        );
+        if (ret == null)
+            return error.SdlError;
+        return Animation{ .value = ret };
+    }
 
-	/// Dispose of an IMG_Animation and free its resources.
-	pub fn deinit(
-		self: Animation,
-	) void {
-		const ret = C.IMG_FreeAnimation(
-			self.value,
-		);
-		_ = ret;
-	}
+    /// Dispose of an IMG_Animation and free its resources.
+    pub fn deinit(
+        self: Animation,
+    ) void {
+        const ret = c.IMG_FreeAnimation(
+            self.value,
+        );
+        _ = ret;
+    }
 
-	/// Load a GIF animation directly.
-	pub fn initFromGifIo(
-		source: io_stream.Stream,
-	) !Animation {
-		const ret = C.IMG_LoadGIFAnimation_IO(
-			source.value,
-		);
-		if (ret == null)
-			return error.SdlError;
-		return Animation{ .value = ret };
-	}
+    /// Load a GIF animation directly.
+    pub fn initFromGifIo(
+        source: io_stream.Stream,
+    ) !Animation {
+        const ret = c.IMG_LoadGIFAnimation_IO(
+            source.value,
+        );
+        if (ret == null)
+            return error.SdlError;
+        return Animation{ .value = ret };
+    }
 
-	/// Load a WEBP animation directly.
-	pub fn initFromWebpIo(
-		source: io_stream.Stream,
-	) !Animation {
-		const ret = C.IMG_LoadWEBPAnimation_IO(
-			source.value,
-		);
-		if (ret == null)
-			return error.SdlError;
-		return Animation{ .value = ret };
-	}
+    /// Load a WEBP animation directly.
+    pub fn initFromWebpIo(
+        source: io_stream.Stream,
+    ) !Animation {
+        const ret = c.IMG_LoadWEBPAnimation_IO(
+            source.value,
+        );
+        if (ret == null)
+            return error.SdlError;
+        return Animation{ .value = ret };
+    }
 
-	/// Get the width of an animation.
+    /// Get the width of an animation.
     pub fn getWidth(self: Animation) usize {
         return @intCast(self.value.w);
     }
 
-	/// Get the height of an animation.
+    /// Get the height of an animation.
     pub fn getHeight(self: Animation) usize {
         return @intCast(self.value.h);
     }
 
-	/// Get number of frames of an animation.
+    /// Get number of frames of an animation.
     pub fn getNumFrames(self: Animation) usize {
         return @intCast(self.value.count);
     }
 
-	/// Get a frame of animation. Returns null if out of bounds.
+    /// Get a frame of animation. Returns null if out of bounds.
     pub fn getFrame(self: Animation, index: usize) ?struct { frame: surface.Surface, delay: usize } {
         if (index >= self.getNumFrames())
             return null;
@@ -182,632 +182,632 @@ pub const Animation = struct {
 
 /// Load an image from an SDL data source into a software surface.
 pub fn loadTypedIo(
-	source: io_stream.Stream,
-	close_when_done: bool,
-	file_type: [:0]const u8,
+    source: io_stream.Stream,
+    close_when_done: bool,
+    file_type: [:0]const u8,
 ) !surface.Surface {
-	const ret = C.IMG_LoadTyped_IO(
-		source.value,
-		close_when_done,
-		file_type,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadTyped_IO(
+        source.value,
+        close_when_done,
+        file_type,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load an image from a filesystem path into a software surface.
 pub fn loadFile(
-	path: [:0]const u8,
+    path: [:0]const u8,
 ) !surface.Surface {
-	const ret = C.IMG_Load(
-		path,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_Load(
+        path,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load an image from an SDL data source into a software surface.
 pub fn loadIo(
-	source: io_stream.Stream,
-	close_when_done: bool,
+    source: io_stream.Stream,
+    close_when_done: bool,
 ) !surface.Surface {
-	const ret = C.IMG_Load_IO(
-		source.value,
-		close_when_done,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_Load_IO(
+        source.value,
+        close_when_done,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load an image from a filesystem path into a GPU texture.
 pub fn loadTexture(
-	renderer: render.Renderer,
-	path: [:0]const u8,
+    renderer: render.Renderer,
+    path: [:0]const u8,
 ) !render.Texture {
-	const ret = C.IMG_LoadTexture(
-		renderer.value,
-		path,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return render.Texture{ .value = ret };
+    const ret = c.IMG_LoadTexture(
+        renderer.value,
+        path,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return render.Texture{ .value = ret };
 }
 
 /// Load an image from an SDL data source into a GPU texture.
 pub fn loadTextureIo(
-	renderer: render.Renderer,
-	source: io_stream.Stream,
-	close_when_done: bool,
+    renderer: render.Renderer,
+    source: io_stream.Stream,
+    close_when_done: bool,
 ) !render.Texture {
-	const ret = C.IMG_LoadTexture_IO(
-		renderer.value,
-		source.value,
-		close_when_done,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return render.Texture{ .value = ret };
+    const ret = c.IMG_LoadTexture_IO(
+        renderer.value,
+        source.value,
+        close_when_done,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return render.Texture{ .value = ret };
 }
 
 /// Load an image from an SDL data source into a GPU texture.
 pub fn loadTextureTypedIo(
-	renderer: render.Renderer,
-	source: io_stream.Stream,
-	close_when_done: bool,
-	file_type: [:0]const u8,
+    renderer: render.Renderer,
+    source: io_stream.Stream,
+    close_when_done: bool,
+    file_type: [:0]const u8,
 ) !render.Texture {
-	const ret = C.IMG_LoadTextureTyped_IO(
-		renderer.value,
-		source.value,
-		close_when_done,
-		file_type,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return render.Texture{ .value = ret };
+    const ret = c.IMG_LoadTextureTyped_IO(
+        renderer.value,
+        source.value,
+        close_when_done,
+        file_type,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return render.Texture{ .value = ret };
 }
 
 /// Detect AVIF image data on a readable/seekable SDL_IOStream.
 pub fn isAvif(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isAVIF(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isAVIF(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect ICO image data on a readable/seekable SDL_IOStream.
 pub fn isIco(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isICO(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isICO(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect CUR image data on a readable/seekable SDL_IOStream.
 pub fn isCur(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isCUR(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isCUR(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect BMP image data on a readable/seekable SDL_IOStream.
 pub fn isBmp(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isBMP(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isBMP(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect GIF image data on a readable/seekable SDL_IOStream.
 pub fn isGif(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isGIF(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isGIF(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect JPG image data on a readable/seekable SDL_IOStream.
 pub fn isJpg(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isJPG(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isJPG(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect JXL image data on a readable/seekable SDL_IOStream.
 pub fn isJxl(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isJXL(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isJXL(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect LBM image data on a readable/seekable SDL_IOStream.
 pub fn isLbm(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isLBM(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isLBM(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect PCX image data on a readable/seekable SDL_IOStream.
 pub fn isPcx(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isPCX(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isPCX(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect PNG image data on a readable/seekable SDL_IOStream.
 pub fn isPng(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isPNG(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isPNG(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect PNM image data on a readable/seekable SDL_IOStream.
 pub fn isPnm(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isPNM(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isPNM(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect SVG image data on a readable/seekable SDL_IOStream.
 pub fn isSvg(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isSVG(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isSVG(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect QOI image data on a readable/seekable SDL_IOStream.
 pub fn isQoi(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isQOI(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isQOI(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect TIF image data on a readable/seekable SDL_IOStream.
 pub fn isTif(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isTIF(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isTIF(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect XCF image data on a readable/seekable SDL_IOStream.
 pub fn isXcf(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isXCF(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isXCF(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect XPM image data on a readable/seekable SDL_IOStream.
 pub fn isXpm(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isXPM(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isXPM(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect XV image data on a readable/seekable SDL_IOStream.
 pub fn isXv(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isXV(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isXV(
+        source.value,
+    );
+    return ret;
 }
 
 /// Detect WEBP image data on a readable/seekable SDL_IOStream.
 pub fn isWebp(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) bool {
-	const ret = C.IMG_isWEBP(
-		source.value,
-	);
-	return ret;
+    const ret = c.IMG_isWEBP(
+        source.value,
+    );
+    return ret;
 }
 
 /// Load a AVIF image directly.
 pub fn loadAvifIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadAVIF_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadAVIF_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a ICO image directly.
 pub fn loadIcoIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadICO_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadICO_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a CUR image directly.
 pub fn loadCurIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadCUR_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadCUR_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a BMP image directly.
 pub fn loadBmpIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadBMP_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadBMP_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a GIF image directly.
 pub fn loadGifIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadGIF_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadGIF_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a JPG image directly.
 pub fn loadJpgIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadJPG_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadJPG_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a JXL image directly.
 pub fn loadJxlIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadJXL_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadJXL_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a LBM image directly.
 pub fn loadLbmIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadLBM_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadLBM_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a PCX image directly.
 pub fn loadPcxIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadPCX_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadPCX_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a PNG image directly.
 pub fn loadPngIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadPNG_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadPNG_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a PNM image directly.
 pub fn loadPnmIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadPNM_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadPNM_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a SVG image directly.
 pub fn loadSvgIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadSVG_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadSVG_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a QOI image directly.
 pub fn loadQoiIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadQOI_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadQOI_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a TGA image directly.
 pub fn loadTgaIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadTGA_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadTGA_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a TIF image directly.
 pub fn loadTifIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadTIF_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadTIF_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a XCF image directly.
 pub fn loadXcfIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadXCF_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadXCF_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a XPM image directly.
 pub fn loadXpmIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadXPM_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadXPM_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a XV image directly.
 pub fn loadXvIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadXV_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadXV_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load a Webp image directly.
 pub fn loadWebpIo(
-	source: io_stream.Stream,
+    source: io_stream.Stream,
 ) !surface.Surface {
-	const ret = C.IMG_LoadWebp_IO(
-		source.value,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadWebp_IO(
+        source.value,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load an SVG image, scaled to a specific size.
 pub fn loadSizedSvgIo(
-	source: io_stream.Stream,
-	width: usize,
-	height: usize,
+    source: io_stream.Stream,
+    width: usize,
+    height: usize,
 ) !surface.Surface {
-	const ret = C.IMG_LoadSizedSVG_IO(
-		source.value,
-		@intCast(width),
-		@intCast(height),
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_LoadSizedSVG_IO(
+        source.value,
+        @intCast(width),
+        @intCast(height),
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load an XPM image from a memory array.
 pub fn readXpmFromArray(
-	xpm: [:0][:0]const u8,
+    xpm: [:0][:0]const u8,
 ) !surface.Surface {
-	const ret = C.IMG_ReadXPMFromArray(
-		xpm.ptr,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_ReadXPMFromArray(
+        xpm.ptr,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Load an XPM image from a memory array.
 pub fn readXpmFromArrayToRgb8888(
-	xpm: [:0][:0]const u8,
+    xpm: [:0][:0]const u8,
 ) !surface.Surface {
-	const ret = C.IMG_ReadXPMFromArrayToRGB888(
-		xpm.ptr,
-	);
-	if (ret == null)
-		return error.SdlError;
-	return surface.Surface{ .value = ret };
+    const ret = c.IMG_ReadXPMFromArrayToRGB888(
+        xpm.ptr,
+    );
+    if (ret == null)
+        return error.SdlError;
+    return surface.Surface{ .value = ret };
 }
 
 /// Save an SDL_Surface into a AVIF image file.
 pub fn saveAvif(
-	source: surface.Surface,
-	file: [:0]const u8,
-	quality: u7,
+    source: surface.Surface,
+    file: [:0]const u8,
+    quality: u7,
 ) !void {
-	const ret = C.IMG_SaveAVIF(
-		source.value,
-		file,
-		@intCast(quality),
-	);
-	if (!ret)
-		return error.SdlError;
+    const ret = c.IMG_SaveAVIF(
+        source.value,
+        file,
+        @intCast(quality),
+    );
+    if (!ret)
+        return error.SdlError;
 }
 
 /// Save an SDL_Surface into AVIF image data, via an SDL_IOStream.
 pub fn saveAvifIo(
-	source: surface.Surface,
-	dst: io_stream.Stream,
-	close_when_done: bool,
-	quality: u7,
+    source: surface.Surface,
+    dst: io_stream.Stream,
+    close_when_done: bool,
+    quality: u7,
 ) !void {
-	const ret = C.IMG_SaveAVIF_IO(
-		source.value,
-		dst.value,
-		close_when_done,
-		@intCast(quality),
-	);
-	if (!ret)
-		return error.SdlError;
+    const ret = c.IMG_SaveAVIF_IO(
+        source.value,
+        dst.value,
+        close_when_done,
+        @intCast(quality),
+    );
+    if (!ret)
+        return error.SdlError;
 }
 
 /// Save an SDL_Surface into a PNG image file.
 pub fn savePng(
-	source: surface.Surface,
-	file: [:0]const u8,
+    source: surface.Surface,
+    file: [:0]const u8,
 ) !void {
-	const ret = C.IMG_SavePNG(
-		source.value,
-		file,
-	);
-	if (!ret)
-		return error.SdlError;
+    const ret = c.IMG_SavePNG(
+        source.value,
+        file,
+    );
+    if (!ret)
+        return error.SdlError;
 }
 
 /// Save an SDL_Surface into PNG image data, via an SDL_IOStream.
 pub fn savePngIo(
-	source: surface.Surface,
-	dst: io_stream.Stream,
-	close_when_done: bool,
+    source: surface.Surface,
+    dst: io_stream.Stream,
+    close_when_done: bool,
 ) !void {
-	const ret = C.IMG_SavePNG_IO(
-		source.value,
-		dst.value,
-		close_when_done,
-	);
-	if (!ret)
-		return error.SdlError;
+    const ret = c.IMG_SavePNG_IO(
+        source.value,
+        dst.value,
+        close_when_done,
+    );
+    if (!ret)
+        return error.SdlError;
 }
 
 /// Save an SDL_Surface into a JPG image file.
 pub fn saveJpg(
-	source: surface.Surface,
-	file: [:0]const u8,
-	quality: u7,
+    source: surface.Surface,
+    file: [:0]const u8,
+    quality: u7,
 ) !void {
-	const ret = C.IMG_SaveJPG(
-		source.value,
-		file,
-		@intCast(quality),
-	);
-	if (!ret)
-		return error.SdlError;
+    const ret = c.IMG_SaveJPG(
+        source.value,
+        file,
+        @intCast(quality),
+    );
+    if (!ret)
+        return error.SdlError;
 }
 
 /// Save an SDL_Surface into JPG image data, via an SDL_IOStream.
 pub fn saveJpgIo(
-	source: surface.Surface,
-	dst: io_stream.Stream,
-	close_when_done: bool,
-	quality: u7,
+    source: surface.Surface,
+    dst: io_stream.Stream,
+    close_when_done: bool,
+    quality: u7,
 ) !void {
-	const ret = C.IMG_SaveJPG_IO(
-		source.value,
-		dst.value,
-		close_when_done,
-		@intCast(quality),
-	);
-	if (!ret)
-		return error.SdlError;
+    const ret = c.IMG_SaveJPG_IO(
+        source.value,
+        dst.value,
+        close_when_done,
+        @intCast(quality),
+    );
+    if (!ret)
+        return error.SdlError;
 }
 
 const io_stream = @import("io_stream.zig");

--- a/src/init.zig
+++ b/src/init.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const stdinc = @import("stdinc.zig");
@@ -49,29 +49,29 @@ pub const Flags = struct {
     };
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_InitFlags) Flags {
+    pub fn fromSdl(flags: c.SDL_InitFlags) Flags {
         return .{
-            .audio = (flags & C.SDL_INIT_AUDIO) != 0,
-            .video = (flags & C.SDL_INIT_VIDEO) != 0,
-            .joystick = (flags & C.SDL_INIT_JOYSTICK) != 0,
-            .haptic = (flags & C.SDL_INIT_HAPTIC) != 0,
-            .gamepad = (flags & C.SDL_INIT_GAMEPAD) != 0,
-            .events = (flags & C.SDL_INIT_EVENTS) != 0,
-            .sensor = (flags & C.SDL_INIT_SENSOR) != 0,
-            .camera = (flags & C.SDL_INIT_CAMERA) != 0,
+            .audio = (flags & c.SDL_INIT_AUDIO) != 0,
+            .video = (flags & c.SDL_INIT_VIDEO) != 0,
+            .joystick = (flags & c.SDL_INIT_JOYSTICK) != 0,
+            .haptic = (flags & c.SDL_INIT_HAPTIC) != 0,
+            .gamepad = (flags & c.SDL_INIT_GAMEPAD) != 0,
+            .events = (flags & c.SDL_INIT_EVENTS) != 0,
+            .sensor = (flags & c.SDL_INIT_SENSOR) != 0,
+            .camera = (flags & c.SDL_INIT_CAMERA) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Flags) C.SDL_InitFlags {
-        return (if (self.audio) @as(C.SDL_InitFlags, C.SDL_INIT_AUDIO) else 0) |
-            (if (self.video) @as(C.SDL_InitFlags, C.SDL_INIT_VIDEO) else 0) |
-            (if (self.joystick) @as(C.SDL_InitFlags, C.SDL_INIT_JOYSTICK) else 0) |
-            (if (self.haptic) @as(C.SDL_InitFlags, C.SDL_INIT_HAPTIC) else 0) |
-            (if (self.gamepad) @as(C.SDL_InitFlags, C.SDL_INIT_GAMEPAD) else 0) |
-            (if (self.events) @as(C.SDL_InitFlags, C.SDL_INIT_EVENTS) else 0) |
-            (if (self.sensor) @as(C.SDL_InitFlags, C.SDL_INIT_SENSOR) else 0) |
-            (if (self.camera) @as(C.SDL_InitFlags, C.SDL_INIT_CAMERA) else 0) |
+    pub fn toSdl(self: Flags) c.SDL_InitFlags {
+        return (if (self.audio) @as(c.SDL_InitFlags, c.SDL_INIT_AUDIO) else 0) |
+            (if (self.video) @as(c.SDL_InitFlags, c.SDL_INIT_VIDEO) else 0) |
+            (if (self.joystick) @as(c.SDL_InitFlags, c.SDL_INIT_JOYSTICK) else 0) |
+            (if (self.haptic) @as(c.SDL_InitFlags, c.SDL_INIT_HAPTIC) else 0) |
+            (if (self.gamepad) @as(c.SDL_InitFlags, c.SDL_INIT_GAMEPAD) else 0) |
+            (if (self.events) @as(c.SDL_InitFlags, c.SDL_INIT_EVENTS) else 0) |
+            (if (self.sensor) @as(c.SDL_InitFlags, c.SDL_INIT_SENSOR) else 0) |
+            (if (self.camera) @as(c.SDL_InitFlags, c.SDL_INIT_CAMERA) else 0) |
             0;
     }
 };
@@ -112,19 +112,19 @@ pub const AppMetadataProperty = enum {
 
     /// Convert from an SDL string.
     pub fn fromSdl(val: [:0]const u8) AppMetadataProperty {
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_NAME_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_NAME_STRING, val))
             return .name;
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_VERSION_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_VERSION_STRING, val))
             return .version;
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_IDENTIFIER_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_IDENTIFIER_STRING, val))
             return .identifier;
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_CREATOR_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_CREATOR_STRING, val))
             return .creator;
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_COPYRIGHT_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_COPYRIGHT_STRING, val))
             return .copyright;
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_URL_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_URL_STRING, val))
             return .url;
-        if (std.mem.eql(u8, C.SDL_PROP_APP_METADATA_TYPE_STRING, val))
+        if (std.mem.eql(u8, c.SDL_PROP_APP_METADATA_TYPE_STRING, val))
             return .program_type;
         return .name;
     }
@@ -132,13 +132,13 @@ pub const AppMetadataProperty = enum {
     /// Convert to an SDL string.
     pub fn toSdl(self: AppMetadataProperty) [:0]const u8 {
         return switch (self) {
-            .name => C.SDL_PROP_APP_METADATA_NAME_STRING,
-            .version => C.SDL_PROP_APP_METADATA_VERSION_STRING,
-            .identifier => C.SDL_PROP_APP_METADATA_IDENTIFIER_STRING,
-            .creator => C.SDL_PROP_APP_METADATA_CREATOR_STRING,
-            .copyright => C.SDL_PROP_APP_METADATA_COPYRIGHT_STRING,
-            .url => C.SDL_PROP_APP_METADATA_URL_STRING,
-            .program_type => C.SDL_PROP_APP_METADATA_TYPE_STRING,
+            .name => c.SDL_PROP_APP_METADATA_NAME_STRING,
+            .version => c.SDL_PROP_APP_METADATA_VERSION_STRING,
+            .identifier => c.SDL_PROP_APP_METADATA_IDENTIFIER_STRING,
+            .creator => c.SDL_PROP_APP_METADATA_CREATOR_STRING,
+            .copyright => c.SDL_PROP_APP_METADATA_COPYRIGHT_STRING,
+            .url => c.SDL_PROP_APP_METADATA_URL_STRING,
+            .program_type => c.SDL_PROP_APP_METADATA_TYPE_STRING,
         };
     }
 };
@@ -166,7 +166,7 @@ pub const AppMetadataProperty = enum {
 pub fn init(
     flags: Flags,
 ) !void {
-    const ret = C.SDL_Init(
+    const ret = c.SDL_Init(
         flags.toSdl(),
     );
     return errors.wrapCallBool(ret);
@@ -186,7 +186,7 @@ pub fn init(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn isMainThread() bool {
-    return C.SDL_IsMainThread();
+    return c.SDL_IsMainThread();
 }
 
 /// Shut down specific SDL subsystems.
@@ -202,7 +202,7 @@ pub fn isMainThread() bool {
 pub fn quit(
     flags: Flags,
 ) void {
-    C.SDL_QuitSubSystem(
+    c.SDL_QuitSubSystem(
         flags.toSdl(),
     );
 }
@@ -231,7 +231,7 @@ pub fn runOnMainThread(
     user_data: ?*anyopaque,
     wait_complete: bool,
 ) !void {
-    const ret = C.SDL_RunOnMainThread(callback, user_data, wait_complete);
+    const ret = c.SDL_RunOnMainThread(callback, user_data, wait_complete);
     return errors.wrapCallBool(ret);
 }
 
@@ -247,7 +247,7 @@ pub fn runOnMainThread(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn shutdown() void {
-    C.SDL_Quit();
+    c.SDL_Quit();
 }
 
 /// Specify basic metadata about your app.
@@ -282,7 +282,7 @@ pub fn setAppMetadata(
     app_version: ?[:0]const u8,
     app_identifier: ?[:0]const u8,
 ) !void {
-    const ret = C.SDL_SetAppMetadata(
+    const ret = c.SDL_SetAppMetadata(
         if (app_name) |str_capture| str_capture.ptr else null,
         if (app_version) |str_capture| str_capture.ptr else null,
         if (app_identifier) |str_capture| str_capture.ptr else null,
@@ -317,7 +317,7 @@ pub fn setAppMetadataProperty(
     property: AppMetadataProperty,
     value: ?[:0]const u8,
 ) !void {
-    const ret = C.SDL_SetAppMetadataProperty(
+    const ret = c.SDL_SetAppMetadataProperty(
         property.toSdl(),
         if (value) |str_capture| str_capture.ptr else null,
     );
@@ -345,7 +345,7 @@ pub fn setAppMetadataProperty(
 pub fn getAppMetadataProperty(
     property: AppMetadataProperty,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetAppMetadataProperty(
+    const ret = c.SDL_GetAppMetadataProperty(
         property.toSdl(),
     );
     if (ret == null)
@@ -366,7 +366,7 @@ pub fn getAppMetadataProperty(
 pub fn wasInit(
     flags: Flags,
 ) Flags {
-    const ret = C.SDL_WasInit(
+    const ret = c.SDL_WasInit(
         flags.toSdl(),
     );
     return Flags.fromSdl(ret);

--- a/src/init.zig
+++ b/src/init.zig
@@ -12,7 +12,7 @@ const stdinc = @import("stdinc.zig");
 /// This datatype is available since SDL 3.2.0.
 pub const MainThreadCallback = *const fn (
     user_data: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 /// These are the flags which may be passed to `init.init()`.
 ///
@@ -372,7 +372,7 @@ pub fn wasInit(
     return Flags.fromSdl(ret);
 }
 
-fn testRunOnMainThreadCb(user_data: ?*anyopaque) callconv(.C) void {
+fn testRunOnMainThreadCb(user_data: ?*anyopaque) callconv(.c) void {
     const ptr: *i32 = @ptrCast(@alignCast(user_data.?));
     ptr.* = -1;
 }

--- a/src/intrin.zig
+++ b/src/intrin.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// True if (and only if) the compiler supports PowerPC Altivec intrinsics.
@@ -8,7 +8,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const altivec = @hasDecl(C, "SDL_ALTIVEC_INTRINSICS");
+pub const altivec = @hasDecl(c, "SDL_ALTIVEC_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel AVX intrinsics.
 ///
@@ -17,7 +17,7 @@ pub const altivec = @hasDecl(C, "SDL_ALTIVEC_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const avx = @hasDecl(C, "SDL_AVX_INTRINSICS");
+pub const avx = @hasDecl(c, "SDL_AVX_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel AVX2 intrinsics.
 ///
@@ -26,7 +26,7 @@ pub const avx = @hasDecl(C, "SDL_AVX_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const avx2 = @hasDecl(C, "SDL_AVX2_INTRINSICS");
+pub const avx2 = @hasDecl(c, "SDL_AVX2_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel AVX-512F intrinsics.
 ///
@@ -37,7 +37,7 @@ pub const avx2 = @hasDecl(C, "SDL_AVX2_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const avx512f = @hasDecl(C, "SDL_AVX512F_INTRINSICS");
+pub const avx512f = @hasDecl(c, "SDL_AVX512F_INTRINSICS");
 
 /// True if (and only if) the compiler supports Loongarch LSX intrinsics.
 ///
@@ -46,7 +46,7 @@ pub const avx512f = @hasDecl(C, "SDL_AVX512F_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const lasx = @hasDecl(C, "SDL_LASX_INTRINSICS");
+pub const lasx = @hasDecl(c, "SDL_LASX_INTRINSICS");
 
 /// True if (and only if) the compiler supports Loongarch LSX intrinsics.
 ///
@@ -55,7 +55,7 @@ pub const lasx = @hasDecl(C, "SDL_LASX_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const lsx = @hasDecl(C, "SDL_LSX_INTRINSICS");
+pub const lsx = @hasDecl(c, "SDL_LSX_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel MMX intrinsics.
 ///
@@ -64,7 +64,7 @@ pub const lsx = @hasDecl(C, "SDL_LSX_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const mmx = @hasDecl(C, "SDL_MMX_INTRINSICS");
+pub const mmx = @hasDecl(c, "SDL_MMX_INTRINSICS");
 
 /// True if (and only if) the compiler supports ARM NEON intrinsics.
 ///
@@ -73,7 +73,7 @@ pub const mmx = @hasDecl(C, "SDL_MMX_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const neon = @hasDecl(C, "SDL_NEON_INTRINSICS");
+pub const neon = @hasDecl(c, "SDL_NEON_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel SSE intrinsics.
 ///
@@ -82,7 +82,7 @@ pub const neon = @hasDecl(C, "SDL_NEON_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const sse = @hasDecl(C, "SDL_SSE_INTRINSICS");
+pub const sse = @hasDecl(c, "SDL_SSE_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel SSE2 intrinsics.
 ///
@@ -91,7 +91,7 @@ pub const sse = @hasDecl(C, "SDL_SSE_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const sse2 = @hasDecl(C, "SDL_SSE2_INTRINSICS");
+pub const sse2 = @hasDecl(c, "SDL_SSE2_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel SSE3 intrinsics.
 ///
@@ -100,7 +100,7 @@ pub const sse2 = @hasDecl(C, "SDL_SSE2_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const sse3 = @hasDecl(C, "SDL_SSE3_INTRINSICS");
+pub const sse3 = @hasDecl(c, "SDL_SSE3_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel SSE4.1 intrinsics.
 ///
@@ -109,7 +109,7 @@ pub const sse3 = @hasDecl(C, "SDL_SSE3_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const sse41 = @hasDecl(C, "SDL_SSE4_1_INTRINSICS");
+pub const sse41 = @hasDecl(c, "SDL_SSE4_1_INTRINSICS");
 
 /// True if (and only if) the compiler supports Intel SSE4.2 intrinsics.
 ///
@@ -118,7 +118,7 @@ pub const sse41 = @hasDecl(C, "SDL_SSE4_1_INTRINSICS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const sse42 = @hasDecl(C, "SDL_SSE4_2_INTRINSICS");
+pub const sse42 = @hasDecl(c, "SDL_SSE4_2_INTRINSICS");
 
 // Targeting does not make sense for this file.
 

--- a/src/io_stream.zig
+++ b/src/io_stream.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const properties = @import("properties.zig");
 const std = @import("std");
@@ -94,7 +94,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The final offset in the data stream, or `-1` on error.
-    seek: *const fn (user_data: ?*anyopaque, offset: i64, whence: C.SDL_IOWhence) callconv(.C) i64,
+    seek: *const fn (user_data: ?*anyopaque, offset: i64, whence: c.SDL_IOWhence) callconv(.C) i64,
     /// Read up to `size` bytes from the data stream to the area pointed at by `ptr`.
     ///
     /// ## Function Parameters
@@ -108,7 +108,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The number of bytes read.
-    read: *const fn (user_data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]C.SDL_IOStatus) callconv(.C) usize,
+    read: *const fn (user_data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c.SDL_IOStatus) callconv(.C) usize,
     /// Write up to `size` bytes to the data stream from the area pointed at by `ptr`.
     ///
     /// ## Function Parameters
@@ -122,7 +122,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The number of bytes written.
-    write: *const fn (user_data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [*c]C.SDL_IOStatus) callconv(.C) usize,
+    write: *const fn (user_data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [*c]c.SDL_IOStatus) callconv(.C) usize,
     /// If the stream is buffering, make sure the data is written out.
     ///
     /// ## Function Parameters
@@ -133,7 +133,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// True if successful.
-    flush: *const fn (user_data: ?*anyopaque, status: [*c]C.SDL_IOStatus) callconv(.C) bool,
+    flush: *const fn (user_data: ?*anyopaque, status: [*c]c.SDL_IOStatus) callconv(.C) bool,
     /// Close and free any allocated resources.
     ///
     /// ## Function Parameters
@@ -148,7 +148,7 @@ pub const Interface = struct {
     close: *const fn (user_data: ?*anyopaque) callconv(.C) bool,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_IOStreamInterface) Interface {
+    pub fn fromSdl(value: c.SDL_IOStreamInterface) Interface {
         return .{
             .size = value.size.?,
             .seek = value.seek.?,
@@ -160,9 +160,9 @@ pub const Interface = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Interface) C.SDL_IOStreamInterface {
+    pub fn toSdl(self: Interface) c.SDL_IOStreamInterface {
         return .{
-            .version = @sizeOf(C.SDL_IOStreamInterface),
+            .version = @sizeOf(c.SDL_IOStreamInterface),
             .size = self.size,
             .seek = self.seek,
             .read = self.read,
@@ -183,7 +183,7 @@ pub const Interface = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Stream = struct {
-    value: *C.SDL_IOStream,
+    value: *c.SDL_IOStream,
 
     /// Properties that can be obtained from a stream.
     ///
@@ -222,51 +222,51 @@ pub const Stream = struct {
         /// Convert from SDL properties.
         pub fn fromProperties(props: properties.Group) Properties {
             return .{
-                .memory = if (props.get(C.SDL_PROP_IOSTREAM_MEMORY_POINTER)) |val|
-                    @as([*]u8, @alignCast(@ptrCast(val.pointer.?)))[0..@intCast(props.get(C.SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER).?.number)]
+                .memory = if (props.get(c.SDL_PROP_IOSTREAM_MEMORY_POINTER)) |val|
+                    @as([*]u8, @alignCast(@ptrCast(val.pointer.?)))[0..@intCast(props.get(c.SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER).?.number)]
                 else
                     null,
-                .dynamic_memory = if (props.get(C.SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER)) |val| .{
+                .dynamic_memory = if (props.get(c.SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER)) |val| .{
                     .ptr = val.pointer,
-                    .chunk_size = if (props.get(C.SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER)) |chunk_size| @intCast(chunk_size.number) else null,
+                    .chunk_size = if (props.get(c.SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER)) |chunk_size| @intCast(chunk_size.number) else null,
                 } else null,
-                .window_handle = if (props.get(C.SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER)) |val| val.pointer.? else null,
-                .stdio_file = if (props.get(C.SDL_PROP_IOSTREAM_STDIO_FILE_POINTER)) |val| val.pointer.? else null,
-                .file_descriptor = if (props.get(C.SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER)) |val| val.number else null,
-                .android_aasset = if (props.get(C.SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER)) |val| val.pointer.? else null,
+                .window_handle = if (props.get(c.SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER)) |val| val.pointer.? else null,
+                .stdio_file = if (props.get(c.SDL_PROP_IOSTREAM_STDIO_FILE_POINTER)) |val| val.pointer.? else null,
+                .file_descriptor = if (props.get(c.SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER)) |val| val.number else null,
+                .android_aasset = if (props.get(c.SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER)) |val| val.pointer.? else null,
             };
         }
 
         /// Set properties.
         pub fn setProperties(self: Properties, props: properties.Group) !void {
             if (self.memory) |val| {
-                try props.set(C.SDL_PROP_IOSTREAM_MEMORY_POINTER, .{ .pointer = val.ptr });
-                try props.set(C.SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER, .{ .number = @intCast(val.len) });
+                try props.set(c.SDL_PROP_IOSTREAM_MEMORY_POINTER, .{ .pointer = val.ptr });
+                try props.set(c.SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER, .{ .number = @intCast(val.len) });
             } else {
-                try props.clear(C.SDL_PROP_IOSTREAM_MEMORY_POINTER);
-                try props.clear(C.SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER);
+                try props.clear(c.SDL_PROP_IOSTREAM_MEMORY_POINTER);
+                try props.clear(c.SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER);
             }
             if (self.dynamic_memory) |val| {
-                try props.set(C.SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER, .{ .pointer = val.ptr });
+                try props.set(c.SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER, .{ .pointer = val.ptr });
                 if (val.chunk_size) |chunk_size| {
-                    try props.set(C.SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER, .{ .number = @intCast(chunk_size) });
+                    try props.set(c.SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER, .{ .number = @intCast(chunk_size) });
                 }
             } else {
-                try props.clear(C.SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER);
-                try props.clear(C.SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER);
+                try props.clear(c.SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER);
+                try props.clear(c.SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER);
             }
             if (self.window_handle) |val| {
-                try props.set(C.SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER, .{ .pointer = val });
-            } else try props.clear(C.SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER);
+                try props.set(c.SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER, .{ .pointer = val });
+            } else try props.clear(c.SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER);
             if (self.stdio_file) |val| {
-                try props.set(C.SDL_PROP_IOSTREAM_STDIO_FILE_POINTER, .{ .pointer = val });
-            } else try props.clear(C.SDL_PROP_IOSTREAM_STDIO_FILE_POINTER);
+                try props.set(c.SDL_PROP_IOSTREAM_STDIO_FILE_POINTER, .{ .pointer = val });
+            } else try props.clear(c.SDL_PROP_IOSTREAM_STDIO_FILE_POINTER);
             if (self.file_descriptor) |val| {
-                try props.set(C.SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER, .{ .number = val });
-            } else try props.clear(C.SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER);
+                try props.set(c.SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER, .{ .number = val });
+            } else try props.clear(c.SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER);
             if (self.android_aasset) |val| {
-                try props.set(C.SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER, .{ .pointer = val });
-            } else try props.clear(C.SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER);
+                try props.set(c.SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER, .{ .pointer = val });
+            } else try props.clear(c.SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER);
         }
     };
 
@@ -296,7 +296,7 @@ pub const Stream = struct {
     pub fn deinit(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_CloseIO(
+        return errors.wrapCallBool(c.SDL_CloseIO(
             self.value,
         ));
     }
@@ -318,7 +318,7 @@ pub const Stream = struct {
     pub fn flush(
         self: Stream,
     ) !void {
-        return errors.wrapCallBool(C.SDL_FlushIO(
+        return errors.wrapCallBool(c.SDL_FlushIO(
             self.value,
         ));
     }
@@ -340,7 +340,7 @@ pub const Stream = struct {
         self: Stream,
     ) !Properties {
         return Properties.fromProperties(.{
-            .value = try errors.wrapCall(C.SDL_PropertiesID, C.SDL_GetIOProperties(
+            .value = try errors.wrapCall(c.SDL_PropertiesID, c.SDL_GetIOProperties(
                 self.value,
             ), 0),
         });
@@ -362,7 +362,7 @@ pub const Stream = struct {
     pub fn getSize(
         self: Stream,
     ) !usize {
-        const ret = C.SDL_GetIOSize(self.value);
+        const ret = c.SDL_GetIOSize(self.value);
         if (ret < 0) {
             errors.callErrorCallback();
             return error.SdlError;
@@ -397,7 +397,7 @@ pub const Stream = struct {
     ) !Stream {
         const interface_sdl = interface.toSdl();
         return .{
-            .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_OpenIO(
+            .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_OpenIO(
                 &interface_sdl,
                 user_data,
             )),
@@ -432,7 +432,7 @@ pub const Stream = struct {
         data: []const u8,
     ) !Stream {
         return .{
-            .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_IOFromConstMem(
+            .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_IOFromConstMem(
                 data.ptr,
                 data.len,
             )),
@@ -454,7 +454,7 @@ pub const Stream = struct {
     /// This function is available since SDL 3.2.0.
     pub fn initFromDynamicMem() !Stream {
         return .{
-            .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_IOFromDynamicMem()),
+            .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_IOFromDynamicMem()),
         };
     }
 
@@ -485,7 +485,7 @@ pub const Stream = struct {
         mode: FileMode,
     ) !Stream {
         return .{
-            .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_IOFromFile(path.ptr, switch (mode) {
+            .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_IOFromFile(path.ptr, switch (mode) {
                 .append_binary => "ab",
                 .append_text => "a",
                 .read_append_binary => "a+b",
@@ -527,7 +527,7 @@ pub const Stream = struct {
         data: []u8,
     ) !Stream {
         return .{
-            .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_IOFromMem(
+            .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_IOFromMem(
                 data.ptr,
                 data.len,
             )),
@@ -554,7 +554,7 @@ pub const Stream = struct {
     pub fn initFromStreamSource(
         source: *std.io.StreamSource,
     ) !Stream {
-        const ret = C.SDL_OpenIO(&stream_source_interface, source);
+        const ret = c.SDL_OpenIO(&stream_source_interface, source);
         if (ret) |val| {
             return .{ .value = val };
         }
@@ -584,7 +584,7 @@ pub const Stream = struct {
         close_io: bool,
     ) ![:0]u8 {
         var len: usize = undefined;
-        return @as([*:0]u8, @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, C.SDL_LoadFile_IO(
+        return @as([*:0]u8, @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, c.SDL_LoadFile_IO(
             self.value,
             &len,
             close_io,
@@ -615,23 +615,23 @@ pub const Stream = struct {
         self: Stream,
         buf: []u8,
     ) !?[]u8 {
-        const ret = C.SDL_ReadIO(self.value, buf.ptr, buf.len);
+        const ret = c.SDL_ReadIO(self.value, buf.ptr, buf.len);
         if (ret == 0) {
-            const status = C.SDL_GetIOStatus(self.value);
+            const status = c.SDL_GetIOStatus(self.value);
             switch (status) {
-                C.SDL_IO_STATUS_ERROR => {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -658,21 +658,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i8 {
         var ret: i8 = undefined;
-        if (!C.SDL_ReadS8(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS8(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -704,21 +704,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i16 {
         var ret: i16 = undefined;
-        if (!C.SDL_ReadS16BE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS16BE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -750,21 +750,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i16 {
         var ret: i16 = undefined;
-        if (!C.SDL_ReadS16LE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS16LE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -796,21 +796,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i32 {
         var ret: i32 = undefined;
-        if (!C.SDL_ReadS32BE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS32BE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -842,21 +842,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i32 {
         var ret: i32 = undefined;
-        if (!C.SDL_ReadS32LE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS32LE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -888,21 +888,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i64 {
         var ret: i64 = undefined;
-        if (!C.SDL_ReadS64BE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS64BE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -934,21 +934,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?i64 {
         var ret: i64 = undefined;
-        if (!C.SDL_ReadS64LE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadS64LE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -977,21 +977,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u8 {
         var ret: u8 = undefined;
-        if (!C.SDL_ReadU8(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU8(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1023,21 +1023,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u16 {
         var ret: u16 = undefined;
-        if (!C.SDL_ReadU16BE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU16BE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1069,21 +1069,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u16 {
         var ret: u16 = undefined;
-        if (!C.SDL_ReadU16LE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU16LE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1115,21 +1115,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u32 {
         var ret: u32 = undefined;
-        if (!C.SDL_ReadU32BE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU32BE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1161,21 +1161,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u32 {
         var ret: u32 = undefined;
-        if (!C.SDL_ReadU32LE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU32LE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1207,21 +1207,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u64 {
         var ret: u64 = undefined;
-        if (!C.SDL_ReadU64BE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU64BE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1253,21 +1253,21 @@ pub const Stream = struct {
         self: Stream,
     ) !?u64 {
         var ret: u64 = undefined;
-        if (!C.SDL_ReadU64LE(self.value, &ret)) {
-            switch (C.SDL_GetIOStatus(self.value)) {
-                C.SDL_IO_STATUS_ERROR => {
+        if (!c.SDL_ReadU64LE(self.value, &ret)) {
+            switch (c.SDL_GetIOStatus(self.value)) {
+                c.SDL_IO_STATUS_ERROR => {
                     errors.callErrorCallback();
                     return error.Err;
                 },
-                C.SDL_IO_STATUS_NOT_READY => {
+                c.SDL_IO_STATUS_NOT_READY => {
                     errors.callErrorCallback();
                     return error.NotReady;
                 },
-                C.SDL_IO_STATUS_READONLY => {
+                c.SDL_IO_STATUS_READONLY => {
                     errors.callErrorCallback();
                     return error.ReadOnly;
                 },
-                C.SDL_IO_STATUS_WRITEONLY => {
+                c.SDL_IO_STATUS_WRITEONLY => {
                     errors.callErrorCallback();
                     return error.WriteOnly;
                 },
@@ -1328,7 +1328,7 @@ pub const Stream = struct {
         data: []const u8,
         close_io: bool,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SaveFile_IO(
+        return errors.wrapCallBool(c.SDL_SaveFile_IO(
             self.value,
             data.ptr,
             data.len,
@@ -1356,7 +1356,7 @@ pub const Stream = struct {
         offset: isize,
         whence: Whence,
     ) !usize {
-        return @intCast(try errors.wrapCall(i64, C.SDL_SeekIO(
+        return @intCast(try errors.wrapCall(i64, c.SDL_SeekIO(
             self.value,
             @intCast(offset),
             @intFromEnum(whence),
@@ -1367,7 +1367,7 @@ pub const Stream = struct {
         self: Stream,
         props: Properties,
     ) !void {
-        const val = try errors.wrapCall(C.SDL_PropertiesID, C.SDL_GetIOProperties(self.value), 0);
+        const val = try errors.wrapCall(c.SDL_PropertiesID, c.SDL_GetIOProperties(self.value), 0);
         const group = properties.Group{ .value = val };
         try props.setProperties(group);
     }
@@ -1392,7 +1392,7 @@ pub const Stream = struct {
     pub fn tell(
         self: Stream,
     ) !usize {
-        const ret = C.SDL_TellIO(
+        const ret = c.SDL_TellIO(
             self.value,
         );
         return @intCast(try errors.wrapCall(i64, ret, -1));
@@ -1421,14 +1421,14 @@ pub const Stream = struct {
         data: []const u8,
         size_written: ?*usize,
     ) !void {
-        const ret = C.SDL_WriteIO(self.value, data.ptr, data.len);
+        const ret = c.SDL_WriteIO(self.value, data.ptr, data.len);
         if (ret != data.len) {
-            const status = C.SDL_GetIOStatus(self.value);
+            const status = c.SDL_GetIOStatus(self.value);
             const err_val: ?Error = switch (status) {
-                C.SDL_IO_STATUS_ERROR => error.Err,
-                C.SDL_IO_STATUS_NOT_READY => error.NotReady,
-                C.SDL_IO_STATUS_READONLY => error.ReadOnly,
-                C.SDL_IO_STATUS_WRITEONLY => error.WriteOnly,
+                c.SDL_IO_STATUS_ERROR => error.Err,
+                c.SDL_IO_STATUS_NOT_READY => error.NotReady,
+                c.SDL_IO_STATUS_READONLY => error.ReadOnly,
+                c.SDL_IO_STATUS_WRITEONLY => error.WriteOnly,
                 else => null,
             };
             if (err_val) |err| {
@@ -1455,7 +1455,7 @@ pub const Stream = struct {
         self: Stream,
         value: i8,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS8(
+        return errors.wrapCallBool(c.SDL_WriteS8(
             self.value,
             value,
         ));
@@ -1479,7 +1479,7 @@ pub const Stream = struct {
         self: Stream,
         value: i16,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS16BE(
+        return errors.wrapCallBool(c.SDL_WriteS16BE(
             self.value,
             value,
         ));
@@ -1503,7 +1503,7 @@ pub const Stream = struct {
         self: Stream,
         value: i16,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS16LE(
+        return errors.wrapCallBool(c.SDL_WriteS16LE(
             self.value,
             value,
         ));
@@ -1527,7 +1527,7 @@ pub const Stream = struct {
         self: Stream,
         value: i32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS32BE(
+        return errors.wrapCallBool(c.SDL_WriteS32BE(
             self.value,
             value,
         ));
@@ -1551,7 +1551,7 @@ pub const Stream = struct {
         self: Stream,
         value: i32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS32LE(
+        return errors.wrapCallBool(c.SDL_WriteS32LE(
             self.value,
             value,
         ));
@@ -1575,7 +1575,7 @@ pub const Stream = struct {
         self: Stream,
         value: i64,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS64BE(
+        return errors.wrapCallBool(c.SDL_WriteS64BE(
             self.value,
             value,
         ));
@@ -1599,7 +1599,7 @@ pub const Stream = struct {
         self: Stream,
         value: i64,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteS64LE(
+        return errors.wrapCallBool(c.SDL_WriteS64LE(
             self.value,
             value,
         ));
@@ -1620,7 +1620,7 @@ pub const Stream = struct {
         self: Stream,
         value: u8,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU8(
+        return errors.wrapCallBool(c.SDL_WriteU8(
             self.value,
             value,
         ));
@@ -1644,7 +1644,7 @@ pub const Stream = struct {
         self: Stream,
         value: u16,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU16BE(
+        return errors.wrapCallBool(c.SDL_WriteU16BE(
             self.value,
             value,
         ));
@@ -1668,7 +1668,7 @@ pub const Stream = struct {
         self: Stream,
         value: u16,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU16LE(
+        return errors.wrapCallBool(c.SDL_WriteU16LE(
             self.value,
             value,
         ));
@@ -1692,7 +1692,7 @@ pub const Stream = struct {
         self: Stream,
         value: u32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU32BE(
+        return errors.wrapCallBool(c.SDL_WriteU32BE(
             self.value,
             value,
         ));
@@ -1716,7 +1716,7 @@ pub const Stream = struct {
         self: Stream,
         value: u32,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU32LE(
+        return errors.wrapCallBool(c.SDL_WriteU32LE(
             self.value,
             value,
         ));
@@ -1740,7 +1740,7 @@ pub const Stream = struct {
         self: Stream,
         value: u64,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU64BE(
+        return errors.wrapCallBool(c.SDL_WriteU64BE(
             self.value,
             value,
         ));
@@ -1764,7 +1764,7 @@ pub const Stream = struct {
         self: Stream,
         value: u64,
     ) !void {
-        return errors.wrapCallBool(C.SDL_WriteU64LE(
+        return errors.wrapCallBool(c.SDL_WriteU64LE(
             self.value,
             value,
         ));
@@ -1810,15 +1810,15 @@ pub const Stream = struct {
 /// This enum is available since SDL 3.2.0.
 pub const Whence = enum(c_uint) {
     /// Seek from the beginning of data.
-    set = C.SDL_IO_SEEK_SET,
+    set = c.SDL_IO_SEEK_SET,
     /// Seek relative to current read point.
-    cur = C.SDL_IO_SEEK_CUR,
+    cur = c.SDL_IO_SEEK_CUR,
     /// Seek relative to the end of data.
-    end = C.SDL_IO_SEEK_END,
+    end = c.SDL_IO_SEEK_END,
 };
 
-const stream_source_interface = C.SDL_IOStreamInterface{
-    .version = @sizeOf(C.SDL_IOStreamInterface),
+const stream_source_interface = c.SDL_IOStreamInterface{
+    .version = @sizeOf(c.SDL_IOStreamInterface),
     .size = streamSize,
     .seek = streamSeek,
     .read = streamRead,
@@ -1836,9 +1836,9 @@ fn streamSize(data: ?*anyopaque) callconv(.C) i64 {
 fn streamSeek(data: ?*anyopaque, offset: i64, whence: c_uint) callconv(.C) i64 {
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     switch (whence) {
-        C.SDL_IO_SEEK_CUR => stream.seekBy(offset) catch return -1,
-        C.SDL_IO_SEEK_SET => stream.seekTo(@intCast(offset)) catch return -1,
-        C.SDL_IO_SEEK_END => {
+        c.SDL_IO_SEEK_CUR => stream.seekBy(offset) catch return -1,
+        c.SDL_IO_SEEK_SET => stream.seekTo(@intCast(offset)) catch return -1,
+        c.SDL_IO_SEEK_END => {
             const end_pos = stream.getEndPos() catch return -1;
             if (offset > end_pos)
                 return -1;
@@ -1854,7 +1854,7 @@ fn streamRead(data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c_ui
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     var dest: [*]u8 = @ptrCast(ptr.?);
     return stream.read(dest[0..size]) catch blk: {
-        status.* = C.SDL_IO_STATUS_ERROR;
+        status.* = c.SDL_IO_STATUS_ERROR;
         break :blk 0;
     };
 }
@@ -1863,7 +1863,7 @@ fn streamWrite(data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     var src: [*]const u8 = @ptrCast(ptr.?);
     return stream.write(src[0..size]) catch blk: {
-        status.* = C.SDL_IO_STATUS_ERROR;
+        status.* = c.SDL_IO_STATUS_ERROR;
         break :blk 0;
     };
 }
@@ -1900,7 +1900,7 @@ pub fn loadFile(
     path: [:0]const u8,
 ) ![:0]u8 {
     var len: usize = undefined;
-    return @as([*:0]u8, @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, C.SDL_LoadFile(
+    return @as([*:0]u8, @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, c.SDL_LoadFile(
         path.ptr,
         &len,
     )))))[0..len :0];
@@ -1921,7 +1921,7 @@ pub fn saveFile(
     path: [:0]const u8,
     data: []const u8,
 ) !void {
-    return errors.wrapCallBool(C.SDL_SaveFile(
+    return errors.wrapCallBool(c.SDL_SaveFile(
         path.ptr,
         data.ptr,
         data.len,

--- a/src/io_stream.zig
+++ b/src/io_stream.zig
@@ -84,7 +84,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The total size of the data stream, or `-1` on error.
-    size: *const fn (user_data: ?*anyopaque) callconv(.C) i64,
+    size: *const fn (user_data: ?*anyopaque) callconv(.c) i64,
     /// Seek to `offset` relative to `whence`.
     ///
     /// ## Function Parameters
@@ -94,7 +94,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The final offset in the data stream, or `-1` on error.
-    seek: *const fn (user_data: ?*anyopaque, offset: i64, whence: c.SDL_IOWhence) callconv(.C) i64,
+    seek: *const fn (user_data: ?*anyopaque, offset: i64, whence: c.SDL_IOWhence) callconv(.c) i64,
     /// Read up to `size` bytes from the data stream to the area pointed at by `ptr`.
     ///
     /// ## Function Parameters
@@ -108,7 +108,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The number of bytes read.
-    read: *const fn (user_data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c.SDL_IOStatus) callconv(.C) usize,
+    read: *const fn (user_data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c.SDL_IOStatus) callconv(.c) usize,
     /// Write up to `size` bytes to the data stream from the area pointed at by `ptr`.
     ///
     /// ## Function Parameters
@@ -122,7 +122,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// The number of bytes written.
-    write: *const fn (user_data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [*c]c.SDL_IOStatus) callconv(.C) usize,
+    write: *const fn (user_data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [*c]c.SDL_IOStatus) callconv(.c) usize,
     /// If the stream is buffering, make sure the data is written out.
     ///
     /// ## Function Parameters
@@ -133,7 +133,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// True if successful.
-    flush: *const fn (user_data: ?*anyopaque, status: [*c]c.SDL_IOStatus) callconv(.C) bool,
+    flush: *const fn (user_data: ?*anyopaque, status: [*c]c.SDL_IOStatus) callconv(.c) bool,
     /// Close and free any allocated resources.
     ///
     /// ## Function Parameters
@@ -145,7 +145,7 @@ pub const Interface = struct {
     ///
     /// ## Return Value
     /// True if successful.
-    close: *const fn (user_data: ?*anyopaque) callconv(.C) bool,
+    close: *const fn (user_data: ?*anyopaque) callconv(.c) bool,
 
     /// Convert from an SDL value.
     pub fn fromSdl(value: c.SDL_IOStreamInterface) Interface {
@@ -1827,13 +1827,13 @@ const stream_source_interface = c.SDL_IOStreamInterface{
     .close = streamClose,
 };
 
-fn streamSize(data: ?*anyopaque) callconv(.C) i64 {
+fn streamSize(data: ?*anyopaque) callconv(.c) i64 {
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     const end_pos = stream.getEndPos() catch return -1;
     return @intCast(end_pos);
 }
 
-fn streamSeek(data: ?*anyopaque, offset: i64, whence: c_uint) callconv(.C) i64 {
+fn streamSeek(data: ?*anyopaque, offset: i64, whence: c_uint) callconv(.c) i64 {
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     switch (whence) {
         c.SDL_IO_SEEK_CUR => stream.seekBy(offset) catch return -1,
@@ -1850,7 +1850,7 @@ fn streamSeek(data: ?*anyopaque, offset: i64, whence: c_uint) callconv(.C) i64 {
     return @as(i64, @intCast(pos));
 }
 
-fn streamRead(data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c_uint) callconv(.C) usize {
+fn streamRead(data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c_uint) callconv(.c) usize {
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     var dest: [*]u8 = @ptrCast(ptr.?);
     return stream.read(dest[0..size]) catch blk: {
@@ -1859,7 +1859,7 @@ fn streamRead(data: ?*anyopaque, ptr: ?*anyopaque, size: usize, status: [*c]c_ui
     };
 }
 
-fn streamWrite(data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [*c]c_uint) callconv(.C) usize {
+fn streamWrite(data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [*c]c_uint) callconv(.c) usize {
     var stream: *std.io.StreamSource = @ptrCast(@alignCast(data.?));
     var src: [*]const u8 = @ptrCast(ptr.?);
     return stream.write(src[0..size]) catch blk: {
@@ -1868,13 +1868,13 @@ fn streamWrite(data: ?*anyopaque, ptr: ?*const anyopaque, size: usize, status: [
     };
 }
 
-fn streamFlush(data: ?*anyopaque, status: [*c]c_uint) callconv(.C) bool {
+fn streamFlush(data: ?*anyopaque, status: [*c]c_uint) callconv(.c) bool {
     _ = data;
     _ = status;
     return true; // No flushing needed, idk.
 }
 
-fn streamClose(data: ?*anyopaque) callconv(.C) bool {
+fn streamClose(data: ?*anyopaque) callconv(.c) bool {
     _ = data;
     return true;
 }

--- a/src/joystick.zig
+++ b/src/joystick.zig
@@ -1428,14 +1428,14 @@ pub const VirtualJoystickDescription = struct {
     user_data: ?*anyopaque = null,
 
     // TODO!!!
-    update: ?*const fn (user_data: ?*anyopaque) callconv(.C) void = null,
-    set_player_index: ?*const fn (user_data: ?*anyopaque, player_index: c_int) callconv(.C) void = null,
-    rumble: ?*const fn (user_data: ?*anyopaque, low_frequency_rumble: u16, high_frequency_rumble: u16) callconv(.C) bool = null,
-    rumble_triggers: ?*const fn (user_data: ?*anyopaque, left_rumble: u16, right_rumble: u16) callconv(.C) bool = null,
-    set_led: ?*const fn (user_data: ?*anyopaque, red: u8, green: u8, blue: u8) callconv(.C) bool = null,
-    send_effect: ?*const fn (user_data: ?*anyopaque, data: ?*const anyopaque, size: c_int) callconv(.C) bool = null,
-    set_sensors_enabled: ?*const fn (user_data: ?*anyopaque, enabled: bool) callconv(.C) bool = null,
-    cleanup: ?*const fn (user_data: ?*anyopaque) callconv(.C) void = null,
+    update: ?*const fn (user_data: ?*anyopaque) callconv(.c) void = null,
+    set_player_index: ?*const fn (user_data: ?*anyopaque, player_index: c_int) callconv(.c) void = null,
+    rumble: ?*const fn (user_data: ?*anyopaque, low_frequency_rumble: u16, high_frequency_rumble: u16) callconv(.c) bool = null,
+    rumble_triggers: ?*const fn (user_data: ?*anyopaque, left_rumble: u16, right_rumble: u16) callconv(.c) bool = null,
+    set_led: ?*const fn (user_data: ?*anyopaque, red: u8, green: u8, blue: u8) callconv(.c) bool = null,
+    send_effect: ?*const fn (user_data: ?*anyopaque, data: ?*const anyopaque, size: c_int) callconv(.c) bool = null,
+    set_sensors_enabled: ?*const fn (user_data: ?*anyopaque, enabled: bool) callconv(.c) bool = null,
+    cleanup: ?*const fn (user_data: ?*anyopaque) callconv(.c) void = null,
 
     /// Convert from an SDL value.
     pub fn fromSdl(value: c.SDL_VirtualJoystickDesc) VirtualJoystickDescription {

--- a/src/joystick.zig
+++ b/src/joystick.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const guid = @import("guid.zig");
 const power = @import("power.zig");
@@ -10,7 +10,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This macro is available since SDL 3.2.0.
-pub const axis_max: i16 = @intCast(C.SDL_JOYSTICK_AXIS_MAX);
+pub const axis_max: i16 = @intCast(c.SDL_JOYSTICK_AXIS_MAX);
 
 /// The smallest value a joystick axis can report.
 ///
@@ -19,7 +19,7 @@ pub const axis_max: i16 = @intCast(C.SDL_JOYSTICK_AXIS_MAX);
 ///
 /// ## Version
 /// This macro is available since SDL 3.2.0.
-pub const axis_min: i16 = @intCast(C.SDL_JOYSTICK_AXIS_MIN);
+pub const axis_min: i16 = @intCast(c.SDL_JOYSTICK_AXIS_MIN);
 
 /// The list of axes available on a gamepad.
 ///
@@ -43,12 +43,12 @@ pub const AxisMask = packed struct(c_uint) {
 
     // Struct tests.
     comptime {
-        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .left_x = true })) == 1 << C.SDL_GAMEPAD_AXIS_LEFTX);
-        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .left_y = true })) == 1 << C.SDL_GAMEPAD_AXIS_LEFTY);
-        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .right_x = true })) == 1 << C.SDL_GAMEPAD_AXIS_RIGHTX);
-        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .right_y = true })) == 1 << C.SDL_GAMEPAD_AXIS_RIGHTY);
-        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .left_trigger = true })) == 1 << C.SDL_GAMEPAD_AXIS_LEFT_TRIGGER);
-        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .right_trigger = true })) == 1 << C.SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
+        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .left_x = true })) == 1 << c.SDL_GAMEPAD_AXIS_LEFTX);
+        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .left_y = true })) == 1 << c.SDL_GAMEPAD_AXIS_LEFTY);
+        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .right_x = true })) == 1 << c.SDL_GAMEPAD_AXIS_RIGHTX);
+        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .right_y = true })) == 1 << c.SDL_GAMEPAD_AXIS_RIGHTY);
+        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .left_trigger = true })) == 1 << c.SDL_GAMEPAD_AXIS_LEFT_TRIGGER);
+        std.debug.assert(@as(c_int, @bitCast(AxisMask{ .right_trigger = true })) == 1 << c.SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
     }
 };
 
@@ -115,32 +115,32 @@ pub const ButtonMask = packed struct(c_uint) {
 
     // Struct tests.
     comptime {
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .south = true })) == 1 << C.SDL_GAMEPAD_BUTTON_SOUTH);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .east = true })) == 1 << C.SDL_GAMEPAD_BUTTON_EAST);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .west = true })) == 1 << C.SDL_GAMEPAD_BUTTON_WEST);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .north = true })) == 1 << C.SDL_GAMEPAD_BUTTON_NORTH);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .back = true })) == 1 << C.SDL_GAMEPAD_BUTTON_BACK);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .guide = true })) == 1 << C.SDL_GAMEPAD_BUTTON_GUIDE);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .start = true })) == 1 << C.SDL_GAMEPAD_BUTTON_START);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_stick = true })) == 1 << C.SDL_GAMEPAD_BUTTON_LEFT_STICK);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_stick = true })) == 1 << C.SDL_GAMEPAD_BUTTON_RIGHT_STICK);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_shoulder = true })) == 1 << C.SDL_GAMEPAD_BUTTON_LEFT_SHOULDER);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_shoulder = true })) == 1 << C.SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_up = true })) == 1 << C.SDL_GAMEPAD_BUTTON_DPAD_UP);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_down = true })) == 1 << C.SDL_GAMEPAD_BUTTON_DPAD_DOWN);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_left = true })) == 1 << C.SDL_GAMEPAD_BUTTON_DPAD_LEFT);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_right = true })) == 1 << C.SDL_GAMEPAD_BUTTON_DPAD_RIGHT);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc1 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_MISC1);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_paddle1 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_paddle1 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_LEFT_PADDLE1);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_paddle2 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_paddle2 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_LEFT_PADDLE2);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .touchpad = true })) == 1 << C.SDL_GAMEPAD_BUTTON_TOUCHPAD);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc2 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_MISC2);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc3 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_MISC3);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc4 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_MISC4);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc5 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_MISC5);
-        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc6 = true })) == 1 << C.SDL_GAMEPAD_BUTTON_MISC6);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .south = true })) == 1 << c.SDL_GAMEPAD_BUTTON_SOUTH);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .east = true })) == 1 << c.SDL_GAMEPAD_BUTTON_EAST);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .west = true })) == 1 << c.SDL_GAMEPAD_BUTTON_WEST);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .north = true })) == 1 << c.SDL_GAMEPAD_BUTTON_NORTH);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .back = true })) == 1 << c.SDL_GAMEPAD_BUTTON_BACK);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .guide = true })) == 1 << c.SDL_GAMEPAD_BUTTON_GUIDE);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .start = true })) == 1 << c.SDL_GAMEPAD_BUTTON_START);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_stick = true })) == 1 << c.SDL_GAMEPAD_BUTTON_LEFT_STICK);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_stick = true })) == 1 << c.SDL_GAMEPAD_BUTTON_RIGHT_STICK);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_shoulder = true })) == 1 << c.SDL_GAMEPAD_BUTTON_LEFT_SHOULDER);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_shoulder = true })) == 1 << c.SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_up = true })) == 1 << c.SDL_GAMEPAD_BUTTON_DPAD_UP);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_down = true })) == 1 << c.SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_left = true })) == 1 << c.SDL_GAMEPAD_BUTTON_DPAD_LEFT);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .dpad_right = true })) == 1 << c.SDL_GAMEPAD_BUTTON_DPAD_RIGHT);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc1 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_MISC1);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_paddle1 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_paddle1 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_LEFT_PADDLE1);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .right_paddle2 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .left_paddle2 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_LEFT_PADDLE2);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .touchpad = true })) == 1 << c.SDL_GAMEPAD_BUTTON_TOUCHPAD);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc2 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_MISC2);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc3 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_MISC3);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc4 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_MISC4);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc5 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_MISC5);
+        std.debug.assert(@as(c_int, @bitCast(ButtonMask{ .misc6 = true })) == 1 << c.SDL_GAMEPAD_BUTTON_MISC6);
     }
 };
 
@@ -152,28 +152,28 @@ pub const ButtonMask = packed struct(c_uint) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const ConnectionState = enum(c_int) {
-    wired = C.SDL_JOYSTICK_CONNECTION_WIRED,
-    wireless = C.SDL_JOYSTICK_CONNECTION_WIRELESS,
+    wired = c.SDL_JOYSTICK_CONNECTION_WIRED,
+    wireless = c.SDL_JOYSTICK_CONNECTION_WIRELESS,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_JoystickConnectionState) !?ConnectionState {
-        if (value == C.SDL_JOYSTICK_CONNECTION_INVALID) {
+    pub fn fromSdl(value: c.SDL_JoystickConnectionState) !?ConnectionState {
+        if (value == c.SDL_JOYSTICK_CONNECTION_INVALID) {
             errors.callErrorCallback();
             return error.SdlError;
         }
-        if (value == C.SDL_JOYSTICK_CONNECTION_UNKNOWN)
+        if (value == c.SDL_JOYSTICK_CONNECTION_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: errors.Error!?ConnectionState) C.SDL_JoystickConnectionState {
+    pub fn toSdl(self: errors.Error!?ConnectionState) c.SDL_JoystickConnectionState {
         if (self) |val| {
             if (val) |num| {
                 return @intFromEnum(num);
             }
-            return C.SDL_JOYSTICK_CONNECTION_UNKNOWN;
-        } else |_| return C.SDL_JOYSTICK_CONNECTION_INVALID;
+            return c.SDL_JOYSTICK_CONNECTION_UNKNOWN;
+        } else |_| return c.SDL_JOYSTICK_CONNECTION_INVALID;
     }
 };
 
@@ -185,11 +185,11 @@ pub const ConnectionState = enum(c_int) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_JoystickID,
+    value: c.SDL_JoystickID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_JoystickID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_JoystickID) == @sizeOf(ID));
     }
 
     /// Detach a virtual joystick.
@@ -202,7 +202,7 @@ pub const ID = packed struct {
     pub fn deinitVirtual(
         self: ID,
     ) !void {
-        return errors.wrapCallBool(C.SDL_DetachVirtualJoystick(self.value));
+        return errors.wrapCallBool(c.SDL_DetachVirtualJoystick(self.value));
     }
 
     /// Attach a new virtual joystick.
@@ -219,7 +219,7 @@ pub const ID = packed struct {
         virtual: VirtualJoystickDescription,
     ) !ID {
         const virtual_sdl = virtual.toSdl();
-        return .{ .value = try errors.wrapCall(C.SDL_JoystickID, C.SDL_AttachVirtualJoystick(&virtual_sdl), 0) };
+        return .{ .value = try errors.wrapCall(c.SDL_JoystickID, c.SDL_AttachVirtualJoystick(&virtual_sdl), 0) };
     }
 
     /// Get the implementation-dependent GUID of a joystick.
@@ -239,7 +239,7 @@ pub const ID = packed struct {
     pub fn getGuid(
         self: ID,
     ) guid.GUID {
-        const ret = C.SDL_GetJoystickGUIDForID(
+        const ret = c.SDL_GetJoystickGUIDForID(
             self.value,
         );
         return .{
@@ -263,7 +263,7 @@ pub const ID = packed struct {
     pub fn getName(
         self: ID,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetJoystickNameForID(
+        const ret = c.SDL_GetJoystickNameForID(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -285,7 +285,7 @@ pub const ID = packed struct {
     pub fn getPath(
         self: ID,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetJoystickPathForID(
+        const ret = c.SDL_GetJoystickPathForID(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -307,7 +307,7 @@ pub const ID = packed struct {
     pub fn getPlayerIndex(
         self: ID,
     ) ?usize {
-        const ret = C.SDL_GetJoystickPlayerIndexForID(
+        const ret = c.SDL_GetJoystickPlayerIndexForID(
             self.value,
         );
         if (ret == -1)
@@ -333,7 +333,7 @@ pub const ID = packed struct {
     pub fn getProduct(
         self: ID,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickProductForID(
+        const ret = c.SDL_GetJoystickProductForID(
             self.value,
         );
         if (ret == 0)
@@ -359,7 +359,7 @@ pub const ID = packed struct {
     pub fn getProductVersion(
         self: ID,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickProductVersionForID(
+        const ret = c.SDL_GetJoystickProductVersionForID(
             self.value,
         );
         if (ret == 0)
@@ -384,7 +384,7 @@ pub const ID = packed struct {
     pub fn getType(
         self: ID,
     ) ?Type {
-        const ret = C.SDL_GetJoystickTypeForID(
+        const ret = c.SDL_GetJoystickTypeForID(
             self.value,
         );
         return Type.fromSdl(ret);
@@ -408,7 +408,7 @@ pub const ID = packed struct {
     pub fn getVendor(
         self: ID,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickVendorForID(
+        const ret = c.SDL_GetJoystickVendorForID(
             self.value,
         );
         if (ret == 0)
@@ -429,7 +429,7 @@ pub const ID = packed struct {
     pub fn isVirtual(
         self: ID,
     ) bool {
-        const ret = C.SDL_IsJoystickVirtual(
+        const ret = c.SDL_IsJoystickVirtual(
             self.value,
         );
         return ret;
@@ -441,15 +441,15 @@ pub const ID = packed struct {
 /// ## Version
 /// This enum is provided by zig-sdl3.
 pub const Hat = enum(u8) {
-    centered = C.SDL_HAT_CENTERED,
-    up = C.SDL_HAT_UP,
-    right = C.SDL_HAT_RIGHT,
-    down = C.SDL_HAT_DOWN,
-    left = C.SDL_HAT_LEFT,
-    right_up = C.SDL_HAT_RIGHTUP,
-    right_down = C.SDL_HAT_RIGHTDOWN,
-    left_up = C.SDL_HAT_LEFTUP,
-    left_down = C.SDL_HAT_LEFTDOWN,
+    centered = c.SDL_HAT_CENTERED,
+    up = c.SDL_HAT_UP,
+    right = c.SDL_HAT_RIGHT,
+    down = c.SDL_HAT_DOWN,
+    left = c.SDL_HAT_LEFT,
+    right_up = c.SDL_HAT_RIGHTUP,
+    right_down = c.SDL_HAT_RIGHTDOWN,
+    left_up = c.SDL_HAT_LEFTUP,
+    left_down = c.SDL_HAT_LEFTDOWN,
 };
 
 /// The joystick structure used to identify an SDL joystick.
@@ -460,7 +460,7 @@ pub const Hat = enum(u8) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Joystick = struct {
-    value: *C.SDL_Joystick,
+    value: *c.SDL_Joystick,
 
     /// Read only properties provided by SDL.
     ///
@@ -481,11 +481,11 @@ pub const Joystick = struct {
         /// Get properties from SDL.
         pub fn fromSdl(value: properties.Group) Properties {
             return .{
-                .mono_led = if (value.get(C.SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN)) |val| val.boolean else null,
-                .rgb_led = if (value.get(C.SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN)) |val| val.boolean else null,
-                .player_led = if (value.get(C.SDL_PROP_JOYSTICK_CAP_PLAYER_LED_BOOLEAN)) |val| val.boolean else null,
-                .rumble = if (value.get(C.SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN)) |val| val.boolean else null,
-                .trigger_rumble = if (value.get(C.SDL_PROP_JOYSTICK_CAP_TRIGGER_RUMBLE_BOOLEAN)) |val| val.boolean else null,
+                .mono_led = if (value.get(c.SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN)) |val| val.boolean else null,
+                .rgb_led = if (value.get(c.SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN)) |val| val.boolean else null,
+                .player_led = if (value.get(c.SDL_PROP_JOYSTICK_CAP_PLAYER_LED_BOOLEAN)) |val| val.boolean else null,
+                .rumble = if (value.get(c.SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN)) |val| val.boolean else null,
+                .trigger_rumble = if (value.get(c.SDL_PROP_JOYSTICK_CAP_TRIGGER_RUMBLE_BOOLEAN)) |val| val.boolean else null,
             };
         }
     };
@@ -500,7 +500,7 @@ pub const Joystick = struct {
     pub fn connected(
         self: Joystick,
     ) !void {
-        const ret = C.SDL_JoystickConnected(
+        const ret = c.SDL_JoystickConnected(
             self.value,
         );
         return errors.wrapCallBool(ret);
@@ -516,7 +516,7 @@ pub const Joystick = struct {
     pub fn deinit(
         self: Joystick,
     ) void {
-        C.SDL_CloseJoystick(
+        c.SDL_CloseJoystick(
             self.value,
         );
     }
@@ -545,7 +545,7 @@ pub const Joystick = struct {
         self: Joystick,
         index: usize,
     ) !i16 {
-        return errors.wrapCall(i16, C.SDL_GetJoystickAxis(self.value, @intCast(index)), 0);
+        return errors.wrapCall(i16, c.SDL_GetJoystickAxis(self.value, @intCast(index)), 0);
     }
 
     /// Get the initial state of an axis control on a joystick.
@@ -568,7 +568,7 @@ pub const Joystick = struct {
         index: usize,
     ) ?i16 {
         var state: i16 = undefined;
-        const ret = C.SDL_GetJoystickAxisInitialState(self.value, @intCast(index), &state);
+        const ret = c.SDL_GetJoystickAxisInitialState(self.value, @intCast(index), &state);
         if (ret)
             return state;
         return null;
@@ -596,7 +596,7 @@ pub const Joystick = struct {
     ) !struct { dx: isize, dy: isize } {
         var dx: c_int = undefined;
         var dy: c_int = undefined;
-        const ret = C.SDL_GetJoystickBall(self.value, @intCast(index), &dx, &dy);
+        const ret = c.SDL_GetJoystickBall(self.value, @intCast(index), &dx, &dy);
         try errors.wrapCallBool(ret);
         return .{ .dx = @intCast(dx), .dy = @intCast(dy) };
     }
@@ -616,7 +616,7 @@ pub const Joystick = struct {
         self: Joystick,
         index: usize,
     ) bool {
-        return C.SDL_GetJoystickButton(self.value, @intCast(index));
+        return c.SDL_GetJoystickButton(self.value, @intCast(index));
     }
 
     /// Get the connection state of a joystick.
@@ -632,7 +632,7 @@ pub const Joystick = struct {
     pub fn getConnectionState(
         self: Joystick,
     ) !?ConnectionState {
-        return ConnectionState.fromSdl(C.SDL_GetJoystickConnectionState(self.value));
+        return ConnectionState.fromSdl(c.SDL_GetJoystickConnectionState(self.value));
     }
 
     /// Get the firmware version of an opened joystick, if available.
@@ -651,7 +651,7 @@ pub const Joystick = struct {
     pub fn getFirmwareVersion(
         self: Joystick,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickFirmwareVersion(
+        const ret = c.SDL_GetJoystickFirmwareVersion(
             self.value,
         );
         if (ret == 0)
@@ -676,7 +676,7 @@ pub const Joystick = struct {
     pub fn getGuid(
         self: Joystick,
     ) guid.GUID {
-        const ret = C.SDL_GetJoystickGUID(
+        const ret = c.SDL_GetJoystickGUID(
             self.value,
         );
         return .{
@@ -699,7 +699,7 @@ pub const Joystick = struct {
         self: Joystick,
         hat_index: usize,
     ) Hat {
-        const ret = C.SDL_GetJoystickHat(
+        const ret = c.SDL_GetJoystickHat(
             self.value,
             @intCast(hat_index),
         );
@@ -719,10 +719,10 @@ pub const Joystick = struct {
     pub fn getId(
         self: Joystick,
     ) !ID {
-        const ret = C.SDL_GetJoystickID(
+        const ret = c.SDL_GetJoystickID(
             self.value,
         );
-        return ID{ .value = try errors.wrapCall(C.SDL_JoystickID, ret, 0) };
+        return ID{ .value = try errors.wrapCall(c.SDL_JoystickID, ret, 0) };
     }
 
     /// Get the implementation dependent name of a joystick.
@@ -738,7 +738,7 @@ pub const Joystick = struct {
     pub fn getName(
         self: Joystick,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetJoystickName(
+        const ret = c.SDL_GetJoystickName(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -760,7 +760,7 @@ pub const Joystick = struct {
     pub fn getNumAxes(
         self: Joystick,
     ) !usize {
-        const ret = C.SDL_GetNumJoystickAxes(
+        const ret = c.SDL_GetNumJoystickAxes(
             self.value,
         );
         return @intCast(try errors.wrapCall(c_int, ret, -1));
@@ -784,7 +784,7 @@ pub const Joystick = struct {
     pub fn getNumBalls(
         self: Joystick,
     ) !usize {
-        const ret = C.SDL_GetNumJoystickBalls(
+        const ret = c.SDL_GetNumJoystickBalls(
             self.value,
         );
         return @intCast(try errors.wrapCall(c_int, ret, -1));
@@ -803,7 +803,7 @@ pub const Joystick = struct {
     pub fn getNumButtons(
         self: Joystick,
     ) !usize {
-        const ret = C.SDL_GetNumJoystickButtons(
+        const ret = c.SDL_GetNumJoystickButtons(
             self.value,
         );
         return @intCast(try errors.wrapCall(c_int, ret, -1));
@@ -822,7 +822,7 @@ pub const Joystick = struct {
     pub fn getNumHats(
         self: Joystick,
     ) !usize {
-        const ret = C.SDL_GetNumJoystickHats(
+        const ret = c.SDL_GetNumJoystickHats(
             self.value,
         );
         return @intCast(try errors.wrapCall(c_int, ret, -1));
@@ -841,7 +841,7 @@ pub const Joystick = struct {
     pub fn getPath(
         self: Joystick,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetJoystickPath(
+        const ret = c.SDL_GetJoystickPath(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -864,7 +864,7 @@ pub const Joystick = struct {
     pub fn getPlayerIndex(
         self: Joystick,
     ) ?usize {
-        const ret = C.SDL_GetJoystickPlayerIndex(
+        const ret = c.SDL_GetJoystickPlayerIndex(
             self.value,
         );
         if (ret == -1)
@@ -891,11 +891,11 @@ pub const Joystick = struct {
         self: Joystick,
     ) !struct { state: power.PowerState, percent: ?u7 } {
         var percent: c_int = undefined;
-        const ret = C.SDL_GetJoystickPowerInfo(
+        const ret = c.SDL_GetJoystickPowerInfo(
             self.value,
             &percent,
         );
-        return .{ .state = @enumFromInt(try errors.wrapCall(c_int, ret, C.SDL_POWERSTATE_ERROR)), .percent = if (percent == -1) null else @intCast(percent) };
+        return .{ .state = @enumFromInt(try errors.wrapCall(c_int, ret, c.SDL_POWERSTATE_ERROR)), .percent = if (percent == -1) null else @intCast(percent) };
     }
 
     /// Get the USB product ID of an opened joystick, if available.
@@ -914,7 +914,7 @@ pub const Joystick = struct {
     pub fn getProduct(
         self: Joystick,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickProduct(
+        const ret = c.SDL_GetJoystickProduct(
             self.value,
         );
         if (ret == 0)
@@ -938,7 +938,7 @@ pub const Joystick = struct {
     pub fn getProductVersion(
         self: Joystick,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickProductVersion(
+        const ret = c.SDL_GetJoystickProductVersion(
             self.value,
         );
         if (ret == 0)
@@ -959,8 +959,8 @@ pub const Joystick = struct {
     pub fn getProperties(
         self: Joystick,
     ) !Properties {
-        const ret = C.SDL_GetJoystickProperties(self.value);
-        return Properties.fromSdl(.{ .value = try errors.wrapCall(C.SDL_PropertiesID, ret, 0) });
+        const ret = c.SDL_GetJoystickProperties(self.value);
+        return Properties.fromSdl(.{ .value = try errors.wrapCall(c.SDL_PropertiesID, ret, 0) });
     }
 
     /// Get the serial number of an opened joystick, if available.
@@ -976,7 +976,7 @@ pub const Joystick = struct {
     pub fn getSerial(
         self: Joystick,
     ) ?[:0]const u8 {
-        const ret = C.SDL_GetJoystickSerial(
+        const ret = c.SDL_GetJoystickSerial(
             self.value,
         );
         if (ret == null)
@@ -997,7 +997,7 @@ pub const Joystick = struct {
     pub fn getType(
         self: Joystick,
     ) ?Type {
-        const ret = C.SDL_GetJoystickType(
+        const ret = c.SDL_GetJoystickType(
             self.value,
         );
         return Type.fromSdl(ret);
@@ -1019,7 +1019,7 @@ pub const Joystick = struct {
     pub fn getVendor(
         self: Joystick,
     ) ?u16 {
-        const ret = C.SDL_GetJoystickVendor(
+        const ret = c.SDL_GetJoystickVendor(
             self.value,
         );
         if (ret == 0)
@@ -1043,10 +1043,10 @@ pub const Joystick = struct {
     pub fn init(
         id: ID,
     ) !Joystick {
-        const ret = C.SDL_OpenJoystick(
+        const ret = c.SDL_OpenJoystick(
             id.value,
         );
-        return Joystick{ .value = try errors.wrapNull(*C.SDL_Joystick, ret) };
+        return Joystick{ .value = try errors.wrapNull(*c.SDL_Joystick, ret) };
     }
 
     /// Start a rumble effect.
@@ -1077,7 +1077,7 @@ pub const Joystick = struct {
         high_frequency_rumble: u16,
         duration_milliseconds: u32,
     ) bool {
-        const ret = C.SDL_RumbleJoystick(
+        const ret = c.SDL_RumbleJoystick(
             self.value,
             low_frequency_rumble,
             high_frequency_rumble,
@@ -1111,7 +1111,7 @@ pub const Joystick = struct {
         right_rumble: u16,
         duration_milliseconds: u32,
     ) !void {
-        const ret = C.SDL_RumbleJoystickTriggers(
+        const ret = c.SDL_RumbleJoystickTriggers(
             self.value,
             left_rumble,
             right_rumble,
@@ -1141,7 +1141,7 @@ pub const Joystick = struct {
         sensor_timestamp_nanoseconds: u64,
         data: []const f32,
     ) !void {
-        const ret = C.SDL_SendJoystickVirtualSensorData(
+        const ret = c.SDL_SendJoystickVirtualSensorData(
             self.value,
             @intFromEnum(sensor_type),
             @intCast(sensor_timestamp_nanoseconds),
@@ -1172,7 +1172,7 @@ pub const Joystick = struct {
         g: u8,
         b: u8,
     ) !void {
-        const ret = C.SDL_SetJoystickLED(
+        const ret = c.SDL_SetJoystickLED(
             self.value,
             @intCast(r),
             @intCast(g),
@@ -1193,7 +1193,7 @@ pub const Joystick = struct {
         self: Joystick,
         player_index: ?usize,
     ) !void {
-        const ret = C.SDL_SetJoystickPlayerIndex(
+        const ret = c.SDL_SetJoystickPlayerIndex(
             self.value,
             if (player_index) |val| @intCast(val) else -1,
         );
@@ -1222,7 +1222,7 @@ pub const Joystick = struct {
         axis_index: usize,
         value: i16,
     ) !void {
-        const ret = C.SDL_SetJoystickVirtualAxis(
+        const ret = c.SDL_SetJoystickVirtualAxis(
             self.value,
             @intCast(axis_index),
             @intCast(value),
@@ -1251,7 +1251,7 @@ pub const Joystick = struct {
         x_rel: i16,
         y_rel: i16,
     ) !void {
-        const ret = C.SDL_SetJoystickVirtualBall(
+        const ret = c.SDL_SetJoystickVirtualBall(
             self.value,
             @intCast(ball_index),
             @intCast(x_rel),
@@ -1279,7 +1279,7 @@ pub const Joystick = struct {
         button_index: usize,
         down: bool,
     ) !void {
-        const ret = C.SDL_SetJoystickVirtualButton(
+        const ret = c.SDL_SetJoystickVirtualButton(
             self.value,
             @intCast(button_index),
             down,
@@ -1306,7 +1306,7 @@ pub const Joystick = struct {
         hat_index: usize,
         value: Hat,
     ) !void {
-        const ret = C.SDL_SetJoystickVirtualHat(
+        const ret = c.SDL_SetJoystickVirtualHat(
             self.value,
             @intCast(hat_index),
             @intFromEnum(value),
@@ -1341,7 +1341,7 @@ pub const Joystick = struct {
         y: f32,
         pressure: f32,
     ) !void {
-        const ret = C.SDL_SetJoystickVirtualTouchpad(
+        const ret = c.SDL_SetJoystickVirtualTouchpad(
             self.value,
             @intCast(touchpad_index),
             @intCast(finger_index),
@@ -1367,28 +1367,28 @@ pub const Joystick = struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Type = enum(c_uint) {
-    gamepad = C.SDL_JOYSTICK_TYPE_GAMEPAD,
-    wheel = C.SDL_JOYSTICK_TYPE_WHEEL,
-    arcade_stick = C.SDL_JOYSTICK_TYPE_ARCADE_STICK,
-    flight_stick = C.SDL_JOYSTICK_TYPE_FLIGHT_STICK,
-    dance_pad = C.SDL_JOYSTICK_TYPE_DANCE_PAD,
-    guitar = C.SDL_JOYSTICK_TYPE_GUITAR,
-    drum_kit = C.SDL_JOYSTICK_TYPE_DRUM_KIT,
-    arcade_pad = C.SDL_JOYSTICK_TYPE_ARCADE_PAD,
-    throttle = C.SDL_JOYSTICK_TYPE_THROTTLE,
+    gamepad = c.SDL_JOYSTICK_TYPE_GAMEPAD,
+    wheel = c.SDL_JOYSTICK_TYPE_WHEEL,
+    arcade_stick = c.SDL_JOYSTICK_TYPE_ARCADE_STICK,
+    flight_stick = c.SDL_JOYSTICK_TYPE_FLIGHT_STICK,
+    dance_pad = c.SDL_JOYSTICK_TYPE_DANCE_PAD,
+    guitar = c.SDL_JOYSTICK_TYPE_GUITAR,
+    drum_kit = c.SDL_JOYSTICK_TYPE_DRUM_KIT,
+    arcade_pad = c.SDL_JOYSTICK_TYPE_ARCADE_PAD,
+    throttle = c.SDL_JOYSTICK_TYPE_THROTTLE,
 
     /// Convert from SDL value.
-    pub fn fromSdl(value: C.SDL_JoystickType) ?Type {
-        if (value == C.SDL_JOYSTICK_TYPE_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_JoystickType) ?Type {
+        if (value == c.SDL_JOYSTICK_TYPE_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?Type) C.SDL_JoystickType {
+    pub fn toSdl(self: ?Type) c.SDL_JoystickType {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_JOYSTICK_TYPE_UNKNOWN;
+        return c.SDL_JOYSTICK_TYPE_UNKNOWN;
     }
 };
 
@@ -1438,7 +1438,7 @@ pub const VirtualJoystickDescription = struct {
     cleanup: ?*const fn (user_data: ?*anyopaque) callconv(.C) void = null,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_VirtualJoystickDesc) VirtualJoystickDescription {
+    pub fn fromSdl(value: c.SDL_VirtualJoystickDesc) VirtualJoystickDescription {
         return .{
             .joystick_type = Type.fromSdl(value.type),
             .vendor_id = value.vendor_id,
@@ -1465,7 +1465,7 @@ pub const VirtualJoystickDescription = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: VirtualJoystickDescription) C.SDL_VirtualJoystickDesc {
+    pub fn toSdl(self: VirtualJoystickDescription) c.SDL_VirtualJoystickDesc {
         return .{
             .type = @intCast(Type.toSdl(self.joystick_type)),
             .vendor_id = self.vendor_id,
@@ -1477,9 +1477,9 @@ pub const VirtualJoystickDescription = struct {
             .button_mask = @bitCast(self.buttons),
             .axis_mask = @bitCast(self.axes),
             .name = if (self.name) |val| val.ptr else null,
-            .touchpads = @as([*c]const C.SDL_VirtualJoystickTouchpadDesc, @ptrCast(self.touchpads.ptr)),
+            .touchpads = @as([*c]const c.SDL_VirtualJoystickTouchpadDesc, @ptrCast(self.touchpads.ptr)),
             .ntouchpads = @intCast(self.touchpads.len),
-            .sensors = @as([*c]const C.SDL_VirtualJoystickSensorDesc, @ptrCast(self.sensors.ptr)),
+            .sensors = @as([*c]const c.SDL_VirtualJoystickSensorDesc, @ptrCast(self.sensors.ptr)),
             .nsensors = @intCast(self.sensors.len),
             .userdata = self.user_data,
             .Update = self.update,
@@ -1490,7 +1490,7 @@ pub const VirtualJoystickDescription = struct {
             .SendEffect = self.send_effect,
             .SetSensorsEnabled = self.set_sensors_enabled,
             .Cleanup = self.cleanup,
-            .version = @sizeOf(C.SDL_VirtualJoystickDesc),
+            .version = @sizeOf(c.SDL_VirtualJoystickDesc),
         };
     }
 };
@@ -1507,7 +1507,7 @@ pub const VirtualJoystickSensorDescription = extern struct {
 
     // Size tests.
     comptime {
-        errors.assertStructsEqual(C.SDL_VirtualJoystickSensorDesc, VirtualJoystickSensorDescription);
+        errors.assertStructsEqual(c.SDL_VirtualJoystickSensorDesc, VirtualJoystickSensorDescription);
     }
 };
 
@@ -1522,7 +1522,7 @@ pub const VirtualJoystickTouchpadDescription = extern struct {
 
     // Size tests.
     comptime {
-        errors.assertStructsEqual(C.SDL_VirtualJoystickTouchpadDesc, VirtualJoystickTouchpadDescription);
+        errors.assertStructsEqual(c.SDL_VirtualJoystickTouchpadDesc, VirtualJoystickTouchpadDescription);
     }
 };
 
@@ -1537,7 +1537,7 @@ pub const VirtualJoystickTouchpadDescription = extern struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn eventsEnabled() bool {
-    return C.SDL_JoystickEventsEnabled();
+    return c.SDL_JoystickEventsEnabled();
 }
 
 /// Get a list of currently connected joysticks.
@@ -1550,8 +1550,8 @@ pub fn eventsEnabled() bool {
 /// This function is available since SDL 3.2.0.
 pub fn get() ![]ID {
     var count: c_int = undefined;
-    const ret = C.SDL_GetJoysticks(&count);
-    return @as([*]ID, @ptrCast(try errors.wrapNull([*]C.SDL_JoystickID, ret)))[0..@intCast(count)];
+    const ret = c.SDL_GetJoysticks(&count);
+    return @as([*]ID, @ptrCast(try errors.wrapNull([*]c.SDL_JoystickID, ret)))[0..@intCast(count)];
 }
 
 /// Get the joystick associated with an instance ID, if it has been opened.
@@ -1567,10 +1567,10 @@ pub fn get() ![]ID {
 pub fn getFromId(
     id: ID,
 ) !Joystick {
-    const ret = C.SDL_GetJoystickFromID(
+    const ret = c.SDL_GetJoystickFromID(
         id.value,
     );
-    return Joystick{ .value = try errors.wrapNull(*C.SDL_Joystick, ret) };
+    return Joystick{ .value = try errors.wrapNull(*c.SDL_Joystick, ret) };
 }
 
 /// Get the joystick with a player index.
@@ -1586,10 +1586,10 @@ pub fn getFromId(
 pub fn getFromIndex(
     index: usize,
 ) !Joystick {
-    const ret = C.SDL_GetJoystickFromPlayerIndex(
+    const ret = c.SDL_GetJoystickFromPlayerIndex(
         @intCast(index),
     );
-    return Joystick{ .value = try errors.wrapNull(*C.SDL_Joystick, ret) };
+    return Joystick{ .value = try errors.wrapNull(*c.SDL_Joystick, ret) };
 }
 
 /// Get the device information encoded in a GUID structure.
@@ -1610,7 +1610,7 @@ pub fn getGuidInfo(
     var product: u16 = undefined;
     var version: u16 = undefined;
     var crc16: u16 = undefined;
-    C.SDL_GetJoystickGUIDInfo(
+    c.SDL_GetJoystickGUIDInfo(
         guid_val.value,
         &vendor,
         &product,
@@ -1633,7 +1633,7 @@ pub fn getGuidInfo(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn has() bool {
-    return C.SDL_HasJoystick();
+    return c.SDL_HasJoystick();
 }
 
 /// Locking for atomic access to the joystick API.
@@ -1645,7 +1645,7 @@ pub fn has() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn lock() void {
-    C.SDL_LockJoysticks();
+    c.SDL_LockJoysticks();
 }
 
 /// Send a joystick specific effect packet.
@@ -1660,7 +1660,7 @@ pub fn sendEffect(
     self: Joystick,
     data: []const u8,
 ) !void {
-    const ret = C.SDL_SendJoystickEffect(
+    const ret = c.SDL_SendJoystickEffect(
         self.value,
         data.ptr,
         @intCast(data.len),
@@ -1681,7 +1681,7 @@ pub fn sendEffect(
 pub fn setEventsEnabled(
     events_enabled: bool,
 ) void {
-    C.SDL_SetJoystickEventsEnabled(
+    c.SDL_SetJoystickEventsEnabled(
         events_enabled,
     );
 }
@@ -1691,7 +1691,7 @@ pub fn setEventsEnabled(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn unlock() void {
-    C.SDL_UnlockJoysticks();
+    c.SDL_UnlockJoysticks();
 }
 
 /// Update the current state of the open joysticks.
@@ -1702,7 +1702,7 @@ pub fn unlock() void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn update() void {
-    C.SDL_UpdateJoysticks();
+    c.SDL_UpdateJoysticks();
 }
 
 // Joystick tests.

--- a/src/keyboard.zig
+++ b/src/keyboard.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const init = @import("init.zig");
 const keycode = @import("keycode.zig");
@@ -20,19 +20,19 @@ pub const Capitalization = enum(c_uint) {
     /// No capitalization will be done.
     none,
     /// The first letter of sentences will be capitalized.
-    sentences = C.SDL_CAPITALIZE_SENTENCES,
+    sentences = c.SDL_CAPITALIZE_SENTENCES,
     /// The first letter of words will be capitalized.
-    words = C.SDL_CAPITALIZE_WORDS,
+    words = c.SDL_CAPITALIZE_WORDS,
     /// All letters will be capitalized.
-    letters = C.SDL_CAPITALIZE_LETTERS,
+    letters = c.SDL_CAPITALIZE_LETTERS,
 
     /// Get from an SDL value.
-    pub fn fromSdl(value: C.SDL_Capitalization) Capitalization {
+    pub fn fromSdl(value: c.SDL_Capitalization) Capitalization {
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Capitalization) C.SDL_Capitalization {
+    pub fn toSdl(self: Capitalization) c.SDL_Capitalization {
         return @intFromEnum(self);
     }
 };
@@ -60,15 +60,15 @@ pub const TextInputProperties = struct {
     pub fn toSdl(self: TextInputProperties) !properties.Group {
         const ret = try properties.Group.init();
         if (self.input_type) |val|
-            try ret.set(C.SDL_PROP_TEXTINPUT_TYPE_NUMBER, .{ .number = @intFromEnum(val) });
+            try ret.set(c.SDL_PROP_TEXTINPUT_TYPE_NUMBER, .{ .number = @intFromEnum(val) });
         if (self.capitalization) |val|
-            try ret.set(C.SDL_PROP_TEXTINPUT_CAPITALIZATION_NUMBER, .{ .number = @intFromEnum(val) });
+            try ret.set(c.SDL_PROP_TEXTINPUT_CAPITALIZATION_NUMBER, .{ .number = @intFromEnum(val) });
         if (self.auto_correct) |val|
-            try ret.set(C.SDL_PROP_TEXTINPUT_AUTOCORRECT_BOOLEAN, .{ .boolean = val });
+            try ret.set(c.SDL_PROP_TEXTINPUT_AUTOCORRECT_BOOLEAN, .{ .boolean = val });
         if (self.multi_line) |val|
-            try ret.set(C.SDL_PROP_TEXTINPUT_MULTILINE_BOOLEAN, .{ .boolean = val });
+            try ret.set(c.SDL_PROP_TEXTINPUT_MULTILINE_BOOLEAN, .{ .boolean = val });
         if (self.android_input_type) |val|
-            try ret.set(C.SDL_PROP_TEXTINPUT_ANDROID_INPUTTYPE_NUMBER, .{ .number = val });
+            try ret.set(c.SDL_PROP_TEXTINPUT_ANDROID_INPUTTYPE_NUMBER, .{ .number = val });
         return ret;
     }
 };
@@ -83,23 +83,23 @@ pub const TextInputProperties = struct {
 /// This enum is available since SDL 3.2.0.
 pub const TextInputType = enum(c_uint) {
     /// The input is text.
-    text = C.SDL_TEXTINPUT_TYPE_TEXT,
+    text = c.SDL_TEXTINPUT_TYPE_TEXT,
     /// The input is a person's name.
-    text_name = C.SDL_TEXTINPUT_TYPE_TEXT_NAME,
+    text_name = c.SDL_TEXTINPUT_TYPE_TEXT_NAME,
     /// The input is an e-mail address.
-    text_email = C.SDL_TEXTINPUT_TYPE_TEXT_EMAIL,
+    text_email = c.SDL_TEXTINPUT_TYPE_TEXT_EMAIL,
     /// The input is a username.
-    text_username = C.SDL_TEXTINPUT_TYPE_TEXT_USERNAME,
+    text_username = c.SDL_TEXTINPUT_TYPE_TEXT_USERNAME,
     /// he input is a secure password that is hidden.
-    text_password_hidden = C.SDL_TEXTINPUT_TYPE_TEXT_PASSWORD_HIDDEN,
+    text_password_hidden = c.SDL_TEXTINPUT_TYPE_TEXT_PASSWORD_HIDDEN,
     /// The input is a secure password that is visible.
-    text_password_visible = C.SDL_TEXTINPUT_TYPE_TEXT_PASSWORD_VISIBLE,
+    text_password_visible = c.SDL_TEXTINPUT_TYPE_TEXT_PASSWORD_VISIBLE,
     /// The input is a number.
-    number = C.SDL_TEXTINPUT_TYPE_NUMBER,
+    number = c.SDL_TEXTINPUT_TYPE_NUMBER,
     /// The input is a secure PIN that is hidden.
-    number_password_hidden = C.SDL_TEXTINPUT_TYPE_NUMBER_PASSWORD_HIDDEN,
+    number_password_hidden = c.SDL_TEXTINPUT_TYPE_NUMBER_PASSWORD_HIDDEN,
     /// The input is a secure PIN that is visible.
-    number_password_visible = C.SDL_TEXTINPUT_TYPE_NUMBER_PASSWORD_VISIBLE,
+    number_password_visible = c.SDL_TEXTINPUT_TYPE_NUMBER_PASSWORD_VISIBLE,
 };
 
 /// This is a unique ID for a keyboard for the time it is connected to the system, and is never reused for the lifetime of the application.
@@ -110,11 +110,11 @@ pub const TextInputType = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_KeyboardID,
+    value: c.SDL_KeyboardID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_KeyboardID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_KeyboardID) == @sizeOf(ID));
     }
 
     /// Get the name of a keyboard.
@@ -136,7 +136,7 @@ pub const ID = packed struct {
     pub fn getName(
         self: ID,
     ) !?[:0]const u8 {
-        const ret = try errors.wrapCallCString(C.SDL_GetKeyboardNameForID(
+        const ret = try errors.wrapCallCString(c.SDL_GetKeyboardNameForID(
             self.value,
         ));
         if (std.mem.eql(u8, ret, ""))
@@ -158,7 +158,7 @@ pub const ID = packed struct {
 pub fn clearComposition(
     window: video.Window,
 ) !void {
-    const ret = C.SDL_ClearComposition(
+    const ret = c.SDL_ClearComposition(
         window.value,
     );
     return errors.wrapCallBool(ret);
@@ -175,7 +175,7 @@ pub fn clearComposition(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getFocus() ?video.Window {
-    const ret = C.SDL_GetKeyboardFocus();
+    const ret = c.SDL_GetKeyboardFocus();
     if (ret) |val|
         return video.Window{ .value = val };
     return null;
@@ -198,7 +198,7 @@ pub fn getFocus() ?video.Window {
 /// This function is available since SDL 3.2.0.
 pub fn getKeyboards() ![]ID {
     var count: c_int = undefined;
-    const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(C.SDL_KeyboardID, C.SDL_GetKeyboards(
+    const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(c.SDL_KeyboardID, c.SDL_GetKeyboards(
         &count,
     )));
     return ret[0..@intCast(count)];
@@ -220,10 +220,10 @@ pub fn getKeyboards() ![]ID {
 pub fn getKeyFromName(
     name: [:0]const u8,
 ) !?keycode.Keycode {
-    const ret = C.SDL_GetKeyFromName(
+    const ret = c.SDL_GetKeyFromName(
         name,
     );
-    return keycode.Keycode.fromSdl(try errors.wrapCall(C.SDL_Keycode, ret, C.SDLK_UNKNOWN));
+    return keycode.Keycode.fromSdl(try errors.wrapCall(c.SDL_Keycode, ret, c.SDLK_UNKNOWN));
 }
 
 /// Get the key code corresponding to the given scancode according to the current keyboard layout.
@@ -251,12 +251,12 @@ pub fn getKeyFromScancode(
     modifier: keycode.KeyModifier,
     used_in_key_events: bool,
 ) ?keycode.Keycode {
-    const ret = C.SDL_GetKeyFromScancode(
+    const ret = c.SDL_GetKeyFromScancode(
         code.toSdl(),
         modifier.toSdl(),
         used_in_key_events,
     );
-    if (ret == C.SDLK_UNKNOWN)
+    if (ret == c.SDLK_UNKNOWN)
         return null;
     return keycode.Keycode.fromSdl(ret);
 }
@@ -282,7 +282,7 @@ pub fn getKeyFromScancode(
 pub fn getKeyName(
     key: keycode.Keycode,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetKeyName(
+    const ret = c.SDL_GetKeyName(
         key.toSdl(),
     );
     const converted_ret = std.mem.span(ret);
@@ -302,7 +302,7 @@ pub fn getKeyName(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getModState() keycode.KeyModifier {
-    const ret = C.SDL_GetModState();
+    const ret = c.SDL_GetModState();
     return keycode.KeyModifier.fromSdl(ret);
 }
 
@@ -326,12 +326,12 @@ pub fn getModState() keycode.KeyModifier {
 pub fn getScancodeFromKey(
     key: keycode.Keycode,
 ) ?struct { code: scancode.Scancode, key_mod: keycode.KeyModifier } {
-    var key_mod: C.SDL_Keymod = undefined;
-    const ret = C.SDL_GetScancodeFromKey(
+    var key_mod: c.SDL_Keymod = undefined;
+    const ret = c.SDL_GetScancodeFromKey(
         key.toSdl(),
         &key_mod,
     );
-    if (ret == C.SDL_SCANCODE_UNKNOWN)
+    if (ret == c.SDL_SCANCODE_UNKNOWN)
         return null;
     return .{ .code = scancode.Scancode.fromSdl(@intCast(ret)), .key_mod = keycode.KeyModifier.fromSdl(key_mod) };
 }
@@ -352,10 +352,10 @@ pub fn getScancodeFromKey(
 pub fn getScancodeFromName(
     name: [:0]const u8,
 ) !scancode.Scancode {
-    const ret = C.SDL_GetScancodeFromName(
+    const ret = c.SDL_GetScancodeFromName(
         name,
     );
-    return scancode.Scancode.fromSdl(@intCast(try errors.wrapCall(C.SDL_Scancode, ret, C.SDL_SCANCODE_UNKNOWN)));
+    return scancode.Scancode.fromSdl(@intCast(try errors.wrapCall(c.SDL_Scancode, ret, c.SDL_SCANCODE_UNKNOWN)));
 }
 
 /// Get a human-readable name for a scancode.
@@ -381,7 +381,7 @@ pub fn getScancodeFromName(
 pub fn getScancodeName(
     code: scancode.Scancode,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetScancodeName(
+    const ret = c.SDL_GetScancodeName(
         code.toSdl(),
     );
     const converted_ret = std.mem.span(ret);
@@ -416,7 +416,7 @@ pub fn getScancodeName(
 /// This function is available since SDL 3.2.0.
 pub fn getState() []const bool {
     var num_keys: c_int = undefined;
-    const ret = C.SDL_GetKeyboardState(
+    const ret = c.SDL_GetKeyboardState(
         &num_keys,
     );
     return ret[0..@intCast(num_keys)];
@@ -441,9 +441,9 @@ pub fn getState() []const bool {
 pub fn getTextInputArea(
     window: video.Window,
 ) !struct { input_area: rect.IRect, cursor_offset: i32 } {
-    var input_area: C.SDL_Rect = undefined;
+    var input_area: c.SDL_Rect = undefined;
     var cursor_offset: c_int = undefined;
-    const ret = C.SDL_GetTextInputArea(
+    const ret = c.SDL_GetTextInputArea(
         window.value,
         &input_area,
         &cursor_offset,
@@ -463,7 +463,7 @@ pub fn getTextInputArea(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasKeyboard() bool {
-    return C.SDL_HasKeyboard();
+    return c.SDL_HasKeyboard();
 }
 
 /// Check whether the platform has screen keyboard support.
@@ -477,7 +477,7 @@ pub fn hasKeyboard() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hasScreenSupport() bool {
-    return C.SDL_HasScreenKeyboardSupport();
+    return c.SDL_HasScreenKeyboardSupport();
 }
 
 /// Clear the state of the keyboard.
@@ -491,7 +491,7 @@ pub fn hasScreenSupport() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn reset() void {
-    C.SDL_ResetKeyboard();
+    c.SDL_ResetKeyboard();
 }
 
 /// Set the current key modifier state for the keyboard.
@@ -513,7 +513,7 @@ pub fn reset() void {
 pub fn setModState(
     modifiers: keycode.KeyModifier,
 ) void {
-    C.SDL_SetModState(
+    c.SDL_SetModState(
         modifiers.toSdl(),
     );
 }
@@ -533,7 +533,7 @@ pub fn setScancodeName(
     code: scancode.Scancode,
     name: [:0]const u8,
 ) !void {
-    const ret = C.SDL_SetScancodeName(
+    const ret = c.SDL_SetScancodeName(
         code.toSdl(),
         name,
     );
@@ -560,8 +560,8 @@ pub fn setTextInputArea(
     input_area: ?rect.IRect,
     cursor: i32,
 ) !void {
-    const input_area_sdl: ?C.SDL_Rect = if (input_area == null) null else input_area.?.toSdl();
-    const ret = C.SDL_SetTextInputArea(
+    const input_area_sdl: ?c.SDL_Rect = if (input_area == null) null else input_area.?.toSdl();
+    const ret = c.SDL_SetTextInputArea(
         window.value,
         if (input_area_sdl == null) null else &(input_area_sdl.?),
         @intCast(cursor),
@@ -585,7 +585,7 @@ pub fn setTextInputArea(
 pub fn shownOnScreen(
     window: video.Window,
 ) bool {
-    const ret = C.SDL_ScreenKeyboardShown(
+    const ret = c.SDL_ScreenKeyboardShown(
         window.value,
     );
     return ret;
@@ -612,7 +612,7 @@ pub fn shownOnScreen(
 pub fn startTextInput(
     window: video.Window,
 ) !void {
-    const ret = C.SDL_StartTextInput(
+    const ret = c.SDL_StartTextInput(
         window.value,
     );
     return errors.wrapCallBool(ret);
@@ -643,7 +643,7 @@ pub fn startTextInputWithProperties(
 ) !void {
     const input_properties = try props.toSdl();
     defer input_properties.deinit();
-    const ret = C.SDL_StartTextInputWithProperties(
+    const ret = c.SDL_StartTextInputWithProperties(
         window.value,
         input_properties.value,
     );
@@ -666,7 +666,7 @@ pub fn startTextInputWithProperties(
 pub fn stopTextInput(
     window: video.Window,
 ) !void {
-    const ret = C.SDL_StopTextInput(
+    const ret = c.SDL_StopTextInput(
         window.value,
     );
     return errors.wrapCallBool(ret);
@@ -688,7 +688,7 @@ pub fn stopTextInput(
 pub fn textInputActive(
     window: video.Window,
 ) bool {
-    const ret = C.SDL_TextInputActive(
+    const ret = c.SDL_TextInputActive(
         window.value,
     );
     return ret;

--- a/src/keycode.zig
+++ b/src/keycode.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const scancode = @import("scancode.zig");
 const std = @import("std");
 
@@ -14,262 +14,262 @@ const std = @import("std");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const Keycode = enum(C.SDL_Keycode) {
-    return_key = C.SDLK_RETURN,
-    escape = C.SDLK_ESCAPE,
-    backspace = C.SDLK_BACKSPACE,
-    tab = C.SDLK_TAB,
-    space = C.SDLK_SPACE,
-    exclaim = C.SDLK_EXCLAIM,
-    dblapostrophe = C.SDLK_DBLAPOSTROPHE,
-    hash = C.SDLK_HASH,
-    dollar = C.SDLK_DOLLAR,
-    percent = C.SDLK_PERCENT,
-    ampersand = C.SDLK_AMPERSAND,
-    apostrophe = C.SDLK_APOSTROPHE,
-    left_paren = C.SDLK_LEFTPAREN,
-    right_paren = C.SDLK_RIGHTPAREN,
-    asterisk = C.SDLK_ASTERISK,
-    plus = C.SDLK_PLUS,
-    comma = C.SDLK_COMMA,
-    minus = C.SDLK_MINUS,
-    period = C.SDLK_PERIOD,
-    slash = C.SDLK_SLASH,
-    zero = C.SDLK_0,
-    one = C.SDLK_1,
-    two = C.SDLK_2,
-    three = C.SDLK_3,
-    four = C.SDLK_4,
-    five = C.SDLK_5,
-    six = C.SDLK_6,
-    seven = C.SDLK_7,
-    eight = C.SDLK_8,
-    nine = C.SDLK_9,
-    colon = C.SDLK_COLON,
-    semicolon = C.SDLK_SEMICOLON,
-    less = C.SDLK_LESS,
-    equals = C.SDLK_EQUALS,
-    greater = C.SDLK_GREATER,
-    question = C.SDLK_QUESTION,
-    at = C.SDLK_AT,
-    left_bracket = C.SDLK_LEFTBRACKET,
-    backslash = C.SDLK_BACKSLASH,
-    right_bracket = C.SDLK_RIGHTBRACKET,
-    caret = C.SDLK_CARET,
-    underscore = C.SDLK_UNDERSCORE,
-    grave = C.SDLK_GRAVE,
-    a = C.SDLK_A,
-    b = C.SDLK_B,
-    c = C.SDLK_C,
-    d = C.SDLK_D,
-    e = C.SDLK_E,
-    f = C.SDLK_F,
-    g = C.SDLK_G,
-    h = C.SDLK_H,
-    i = C.SDLK_I,
-    j = C.SDLK_J,
-    k = C.SDLK_K,
-    l = C.SDLK_L,
-    m = C.SDLK_M,
-    n = C.SDLK_N,
-    o = C.SDLK_O,
-    p = C.SDLK_P,
-    q = C.SDLK_Q,
-    r = C.SDLK_R,
-    s = C.SDLK_S,
-    t = C.SDLK_T,
-    u = C.SDLK_U,
-    v = C.SDLK_V,
-    w = C.SDLK_W,
-    x = C.SDLK_X,
-    y = C.SDLK_Y,
-    z = C.SDLK_Z,
-    left_brace = C.SDLK_LEFTBRACE,
-    pipe = C.SDLK_PIPE,
-    right_brace = C.SDLK_RIGHTBRACE,
-    tilde = C.SDLK_TILDE,
-    delete = C.SDLK_DELETE,
-    plus_minus = C.SDLK_PLUSMINUS,
-    caps_lock = C.SDLK_CAPSLOCK,
-    func1 = C.SDLK_F1,
-    func2 = C.SDLK_F2,
-    func3 = C.SDLK_F3,
-    func4 = C.SDLK_F4,
-    func5 = C.SDLK_F5,
-    func6 = C.SDLK_F6,
-    func7 = C.SDLK_F7,
-    func8 = C.SDLK_F8,
-    func9 = C.SDLK_F9,
-    func10 = C.SDLK_F10,
-    func11 = C.SDLK_F11,
-    func12 = C.SDLK_F12,
-    print_screen = C.SDLK_PRINTSCREEN,
-    scroll_lock = C.SDLK_SCROLLLOCK,
-    pause = C.SDLK_PAUSE,
-    insert = C.SDLK_INSERT,
-    home = C.SDLK_HOME,
-    page_up = C.SDLK_PAGEUP,
-    end = C.SDLK_END,
-    page_down = C.SDLK_PAGEDOWN,
-    right = C.SDLK_RIGHT,
-    left = C.SDLK_LEFT,
-    down = C.SDLK_DOWN,
-    up = C.SDLK_UP,
-    num_lock_clear = C.SDLK_NUMLOCKCLEAR,
-    kp_divide = C.SDLK_KP_DIVIDE,
-    kp_multiply = C.SDLK_KP_MULTIPLY,
-    kp_minus = C.SDLK_KP_MINUS,
-    kp_plus = C.SDLK_KP_PLUS,
-    kp_enter = C.SDLK_KP_ENTER,
-    kp_1 = C.SDLK_KP_1,
-    kp_2 = C.SDLK_KP_2,
-    kp_3 = C.SDLK_KP_3,
-    kp_4 = C.SDLK_KP_4,
-    kp_5 = C.SDLK_KP_5,
-    kp_6 = C.SDLK_KP_6,
-    kp_7 = C.SDLK_KP_7,
-    kp_8 = C.SDLK_KP_8,
-    kp_9 = C.SDLK_KP_9,
-    kp_0 = C.SDLK_KP_0,
-    kp_period = C.SDLK_KP_PERIOD,
-    application = C.SDLK_APPLICATION,
-    power = C.SDLK_POWER,
-    kp_equals = C.SDLK_KP_EQUALS,
-    func13 = C.SDLK_F13,
-    func14 = C.SDLK_F14,
-    func15 = C.SDLK_F15,
-    func16 = C.SDLK_F16,
-    func17 = C.SDLK_F17,
-    func18 = C.SDLK_F18,
-    func19 = C.SDLK_F19,
-    func20 = C.SDLK_F20,
-    func21 = C.SDLK_F21,
-    func22 = C.SDLK_F22,
-    func23 = C.SDLK_F23,
-    func24 = C.SDLK_F24,
-    execute = C.SDLK_EXECUTE,
-    help = C.SDLK_HELP,
-    menu = C.SDLK_MENU,
-    select = C.SDLK_SELECT,
-    stop = C.SDLK_STOP,
-    again = C.SDLK_AGAIN,
-    undo = C.SDLK_UNDO,
-    cut = C.SDLK_CUT,
-    copy = C.SDLK_COPY,
-    paste = C.SDLK_PASTE,
-    find = C.SDLK_FIND,
-    mute = C.SDLK_MUTE,
-    volume_up = C.SDLK_VOLUMEUP,
-    volume_down = C.SDLK_VOLUMEDOWN,
-    kp_comma = C.SDLK_KP_COMMA,
-    kp_equals_as_400 = C.SDLK_KP_EQUALSAS400,
-    alt_erase = C.SDLK_ALTERASE,
-    sysreq = C.SDLK_SYSREQ,
-    cancel = C.SDLK_CANCEL,
-    clear = C.SDLK_CLEAR,
-    prior = C.SDLK_PRIOR,
-    return_key2 = C.SDLK_RETURN2,
-    separator = C.SDLK_SEPARATOR,
-    out = C.SDLK_OUT,
-    oper = C.SDLK_OPER,
-    clear_again = C.SDLK_CLEARAGAIN,
-    cr_sel = C.SDLK_CRSEL,
-    ex_sel = C.SDLK_EXSEL,
-    kp_00 = C.SDLK_KP_00,
-    kp_000 = C.SDLK_KP_000,
-    thousands_separator = C.SDLK_THOUSANDSSEPARATOR,
-    decimal_separator = C.SDLK_DECIMALSEPARATOR,
-    currency_unit = C.SDLK_CURRENCYUNIT,
-    currency_subunit = C.SDLK_CURRENCYSUBUNIT,
-    kp_left_paren = C.SDLK_KP_LEFTPAREN,
-    kp_right_paren = C.SDLK_KP_RIGHTPAREN,
-    kp_left_brace = C.SDLK_KP_LEFTBRACE,
-    kp_right_brace = C.SDLK_KP_RIGHTBRACE,
-    kp_tab = C.SDLK_KP_TAB,
-    kp_backspace = C.SDLK_KP_BACKSPACE,
-    kp_a = C.SDLK_KP_A,
-    kp_b = C.SDLK_KP_B,
-    kp_c = C.SDLK_KP_C,
-    kp_d = C.SDLK_KP_D,
-    kp_e = C.SDLK_KP_E,
-    kp_f = C.SDLK_KP_F,
-    kp_xor = C.SDLK_KP_XOR,
-    kp_power = C.SDLK_KP_POWER,
-    kp_percent = C.SDLK_KP_PERCENT,
-    kp_less = C.SDLK_KP_LESS,
-    kp_greater = C.SDLK_KP_GREATER,
-    kp_ampersand = C.SDLK_KP_AMPERSAND,
-    kp_dblampersand = C.SDLK_KP_DBLAMPERSAND,
-    kp_verticalbar = C.SDLK_KP_VERTICALBAR,
-    kp_dbl_vertical_bar = C.SDLK_KP_DBLVERTICALBAR,
-    kp_colon = C.SDLK_KP_COLON,
-    kp_hash = C.SDLK_KP_HASH,
-    kp_space = C.SDLK_KP_SPACE,
-    kp_at = C.SDLK_KP_AT,
-    kp_exclam = C.SDLK_KP_EXCLAM,
-    kp_mem_store = C.SDLK_KP_MEMSTORE,
-    kp_mem_recall = C.SDLK_KP_MEMRECALL,
-    kp_mem_clear = C.SDLK_KP_MEMCLEAR,
-    kp_mem_add = C.SDLK_KP_MEMADD,
-    kp_mem_subtract = C.SDLK_KP_MEMSUBTRACT,
-    kp_mem_multiply = C.SDLK_KP_MEMMULTIPLY,
-    kp_mem_divide = C.SDLK_KP_MEMDIVIDE,
-    kp_plus_minus = C.SDLK_KP_PLUSMINUS,
-    kp_clear = C.SDLK_KP_CLEAR,
-    kp_clear_entry = C.SDLK_KP_CLEARENTRY,
-    kp_binary = C.SDLK_KP_BINARY,
-    kp_octal = C.SDLK_KP_OCTAL,
-    kp_decimal = C.SDLK_KP_DECIMAL,
-    kp_hexadecimal = C.SDLK_KP_HEXADECIMAL,
-    left_ctrl = C.SDLK_LCTRL,
-    left_shift = C.SDLK_LSHIFT,
-    left_alt = C.SDLK_LALT,
-    left_gui = C.SDLK_LGUI,
-    right_ctrl = C.SDLK_RCTRL,
-    right_shift = C.SDLK_RSHIFT,
-    right_alt = C.SDLK_RALT,
-    right_gui = C.SDLK_RGUI,
-    mode = C.SDLK_MODE,
-    sleep = C.SDLK_SLEEP,
-    wake = C.SDLK_WAKE,
-    channel_increment = C.SDLK_CHANNEL_INCREMENT,
-    channel_decrement = C.SDLK_CHANNEL_DECREMENT,
-    media_play = C.SDLK_MEDIA_PLAY,
-    media_pause = C.SDLK_MEDIA_PAUSE,
-    media_record = C.SDLK_MEDIA_RECORD,
-    media_fast_forward = C.SDLK_MEDIA_FAST_FORWARD,
-    media_rewind = C.SDLK_MEDIA_REWIND,
-    media_next_track = C.SDLK_MEDIA_NEXT_TRACK,
-    media_previous_track = C.SDLK_MEDIA_PREVIOUS_TRACK,
-    media_stop = C.SDLK_MEDIA_STOP,
-    media_eject = C.SDLK_MEDIA_EJECT,
-    media_play_pause = C.SDLK_MEDIA_PLAY_PAUSE,
-    media_select = C.SDLK_MEDIA_SELECT,
-    ac_new = C.SDLK_AC_NEW,
-    ac_open = C.SDLK_AC_OPEN,
-    ac_close = C.SDLK_AC_CLOSE,
-    ac_exit = C.SDLK_AC_EXIT,
-    ac_save = C.SDLK_AC_SAVE,
-    ac_print = C.SDLK_AC_PRINT,
-    ac_properties = C.SDLK_AC_PROPERTIES,
-    ac_search = C.SDLK_AC_SEARCH,
-    ac_home = C.SDLK_AC_HOME,
-    ac_back = C.SDLK_AC_BACK,
-    ac_forward = C.SDLK_AC_FORWARD,
-    ac_stop = C.SDLK_AC_STOP,
-    ac_refresh = C.SDLK_AC_REFRESH,
-    ac_bookmarks = C.SDLK_AC_BOOKMARKS,
-    soft_left = C.SDLK_SOFTLEFT,
-    soft_right = C.SDLK_SOFTRIGHT,
-    call = C.SDLK_CALL,
-    end_call = C.SDLK_ENDCALL,
-    left_tab = C.SDLK_LEFT_TAB,
-    level5_shift = C.SDLK_LEVEL5_SHIFT,
-    multi_key_compose = C.SDLK_MULTI_KEY_COMPOSE,
-    left_meta = C.SDLK_LMETA,
-    right_meta = C.SDLK_RMETA,
-    left_hyper = C.SDLK_LHYPER,
-    right_hyper = C.SDLK_RHYPER,
+pub const Keycode = enum(c.SDL_Keycode) {
+    return_key = c.SDLK_RETURN,
+    escape = c.SDLK_ESCAPE,
+    backspace = c.SDLK_BACKSPACE,
+    tab = c.SDLK_TAB,
+    space = c.SDLK_SPACE,
+    exclaim = c.SDLK_EXCLAIM,
+    dblapostrophe = c.SDLK_DBLAPOSTROPHE,
+    hash = c.SDLK_HASH,
+    dollar = c.SDLK_DOLLAR,
+    percent = c.SDLK_PERCENT,
+    ampersand = c.SDLK_AMPERSAND,
+    apostrophe = c.SDLK_APOSTROPHE,
+    left_paren = c.SDLK_LEFTPAREN,
+    right_paren = c.SDLK_RIGHTPAREN,
+    asterisk = c.SDLK_ASTERISK,
+    plus = c.SDLK_PLUS,
+    comma = c.SDLK_COMMA,
+    minus = c.SDLK_MINUS,
+    period = c.SDLK_PERIOD,
+    slash = c.SDLK_SLASH,
+    zero = c.SDLK_0,
+    one = c.SDLK_1,
+    two = c.SDLK_2,
+    three = c.SDLK_3,
+    four = c.SDLK_4,
+    five = c.SDLK_5,
+    six = c.SDLK_6,
+    seven = c.SDLK_7,
+    eight = c.SDLK_8,
+    nine = c.SDLK_9,
+    colon = c.SDLK_COLON,
+    semicolon = c.SDLK_SEMICOLON,
+    less = c.SDLK_LESS,
+    equals = c.SDLK_EQUALS,
+    greater = c.SDLK_GREATER,
+    question = c.SDLK_QUESTION,
+    at = c.SDLK_AT,
+    left_bracket = c.SDLK_LEFTBRACKET,
+    backslash = c.SDLK_BACKSLASH,
+    right_bracket = c.SDLK_RIGHTBRACKET,
+    caret = c.SDLK_CARET,
+    underscore = c.SDLK_UNDERSCORE,
+    grave = c.SDLK_GRAVE,
+    a = c.SDLK_A,
+    b = c.SDLK_B,
+    c = c.SDLK_C,
+    d = c.SDLK_D,
+    e = c.SDLK_E,
+    f = c.SDLK_F,
+    g = c.SDLK_G,
+    h = c.SDLK_H,
+    i = c.SDLK_I,
+    j = c.SDLK_J,
+    k = c.SDLK_K,
+    l = c.SDLK_L,
+    m = c.SDLK_M,
+    n = c.SDLK_N,
+    o = c.SDLK_O,
+    p = c.SDLK_P,
+    q = c.SDLK_Q,
+    r = c.SDLK_R,
+    s = c.SDLK_S,
+    t = c.SDLK_T,
+    u = c.SDLK_U,
+    v = c.SDLK_V,
+    w = c.SDLK_W,
+    x = c.SDLK_X,
+    y = c.SDLK_Y,
+    z = c.SDLK_Z,
+    left_brace = c.SDLK_LEFTBRACE,
+    pipe = c.SDLK_PIPE,
+    right_brace = c.SDLK_RIGHTBRACE,
+    tilde = c.SDLK_TILDE,
+    delete = c.SDLK_DELETE,
+    plus_minus = c.SDLK_PLUSMINUS,
+    caps_lock = c.SDLK_CAPSLOCK,
+    func1 = c.SDLK_F1,
+    func2 = c.SDLK_F2,
+    func3 = c.SDLK_F3,
+    func4 = c.SDLK_F4,
+    func5 = c.SDLK_F5,
+    func6 = c.SDLK_F6,
+    func7 = c.SDLK_F7,
+    func8 = c.SDLK_F8,
+    func9 = c.SDLK_F9,
+    func10 = c.SDLK_F10,
+    func11 = c.SDLK_F11,
+    func12 = c.SDLK_F12,
+    print_screen = c.SDLK_PRINTSCREEN,
+    scroll_lock = c.SDLK_SCROLLLOCK,
+    pause = c.SDLK_PAUSE,
+    insert = c.SDLK_INSERT,
+    home = c.SDLK_HOME,
+    page_up = c.SDLK_PAGEUP,
+    end = c.SDLK_END,
+    page_down = c.SDLK_PAGEDOWN,
+    right = c.SDLK_RIGHT,
+    left = c.SDLK_LEFT,
+    down = c.SDLK_DOWN,
+    up = c.SDLK_UP,
+    num_lock_clear = c.SDLK_NUMLOCKCLEAR,
+    kp_divide = c.SDLK_KP_DIVIDE,
+    kp_multiply = c.SDLK_KP_MULTIPLY,
+    kp_minus = c.SDLK_KP_MINUS,
+    kp_plus = c.SDLK_KP_PLUS,
+    kp_enter = c.SDLK_KP_ENTER,
+    kp_1 = c.SDLK_KP_1,
+    kp_2 = c.SDLK_KP_2,
+    kp_3 = c.SDLK_KP_3,
+    kp_4 = c.SDLK_KP_4,
+    kp_5 = c.SDLK_KP_5,
+    kp_6 = c.SDLK_KP_6,
+    kp_7 = c.SDLK_KP_7,
+    kp_8 = c.SDLK_KP_8,
+    kp_9 = c.SDLK_KP_9,
+    kp_0 = c.SDLK_KP_0,
+    kp_period = c.SDLK_KP_PERIOD,
+    application = c.SDLK_APPLICATION,
+    power = c.SDLK_POWER,
+    kp_equals = c.SDLK_KP_EQUALS,
+    func13 = c.SDLK_F13,
+    func14 = c.SDLK_F14,
+    func15 = c.SDLK_F15,
+    func16 = c.SDLK_F16,
+    func17 = c.SDLK_F17,
+    func18 = c.SDLK_F18,
+    func19 = c.SDLK_F19,
+    func20 = c.SDLK_F20,
+    func21 = c.SDLK_F21,
+    func22 = c.SDLK_F22,
+    func23 = c.SDLK_F23,
+    func24 = c.SDLK_F24,
+    execute = c.SDLK_EXECUTE,
+    help = c.SDLK_HELP,
+    menu = c.SDLK_MENU,
+    select = c.SDLK_SELECT,
+    stop = c.SDLK_STOP,
+    again = c.SDLK_AGAIN,
+    undo = c.SDLK_UNDO,
+    cut = c.SDLK_CUT,
+    copy = c.SDLK_COPY,
+    paste = c.SDLK_PASTE,
+    find = c.SDLK_FIND,
+    mute = c.SDLK_MUTE,
+    volume_up = c.SDLK_VOLUMEUP,
+    volume_down = c.SDLK_VOLUMEDOWN,
+    kp_comma = c.SDLK_KP_COMMA,
+    kp_equals_as_400 = c.SDLK_KP_EQUALSAS400,
+    alt_erase = c.SDLK_ALTERASE,
+    sysreq = c.SDLK_SYSREQ,
+    cancel = c.SDLK_CANCEL,
+    clear = c.SDLK_CLEAR,
+    prior = c.SDLK_PRIOR,
+    return_key2 = c.SDLK_RETURN2,
+    separator = c.SDLK_SEPARATOR,
+    out = c.SDLK_OUT,
+    oper = c.SDLK_OPER,
+    clear_again = c.SDLK_CLEARAGAIN,
+    cr_sel = c.SDLK_CRSEL,
+    ex_sel = c.SDLK_EXSEL,
+    kp_00 = c.SDLK_KP_00,
+    kp_000 = c.SDLK_KP_000,
+    thousands_separator = c.SDLK_THOUSANDSSEPARATOR,
+    decimal_separator = c.SDLK_DECIMALSEPARATOR,
+    currency_unit = c.SDLK_CURRENCYUNIT,
+    currency_subunit = c.SDLK_CURRENCYSUBUNIT,
+    kp_left_paren = c.SDLK_KP_LEFTPAREN,
+    kp_right_paren = c.SDLK_KP_RIGHTPAREN,
+    kp_left_brace = c.SDLK_KP_LEFTBRACE,
+    kp_right_brace = c.SDLK_KP_RIGHTBRACE,
+    kp_tab = c.SDLK_KP_TAB,
+    kp_backspace = c.SDLK_KP_BACKSPACE,
+    kp_a = c.SDLK_KP_A,
+    kp_b = c.SDLK_KP_B,
+    kp_c = c.SDLK_KP_C,
+    kp_d = c.SDLK_KP_D,
+    kp_e = c.SDLK_KP_E,
+    kp_f = c.SDLK_KP_F,
+    kp_xor = c.SDLK_KP_XOR,
+    kp_power = c.SDLK_KP_POWER,
+    kp_percent = c.SDLK_KP_PERCENT,
+    kp_less = c.SDLK_KP_LESS,
+    kp_greater = c.SDLK_KP_GREATER,
+    kp_ampersand = c.SDLK_KP_AMPERSAND,
+    kp_dblampersand = c.SDLK_KP_DBLAMPERSAND,
+    kp_verticalbar = c.SDLK_KP_VERTICALBAR,
+    kp_dbl_vertical_bar = c.SDLK_KP_DBLVERTICALBAR,
+    kp_colon = c.SDLK_KP_COLON,
+    kp_hash = c.SDLK_KP_HASH,
+    kp_space = c.SDLK_KP_SPACE,
+    kp_at = c.SDLK_KP_AT,
+    kp_exclam = c.SDLK_KP_EXCLAM,
+    kp_mem_store = c.SDLK_KP_MEMSTORE,
+    kp_mem_recall = c.SDLK_KP_MEMRECALL,
+    kp_mem_clear = c.SDLK_KP_MEMCLEAR,
+    kp_mem_add = c.SDLK_KP_MEMADD,
+    kp_mem_subtract = c.SDLK_KP_MEMSUBTRACT,
+    kp_mem_multiply = c.SDLK_KP_MEMMULTIPLY,
+    kp_mem_divide = c.SDLK_KP_MEMDIVIDE,
+    kp_plus_minus = c.SDLK_KP_PLUSMINUS,
+    kp_clear = c.SDLK_KP_CLEAR,
+    kp_clear_entry = c.SDLK_KP_CLEARENTRY,
+    kp_binary = c.SDLK_KP_BINARY,
+    kp_octal = c.SDLK_KP_OCTAL,
+    kp_decimal = c.SDLK_KP_DECIMAL,
+    kp_hexadecimal = c.SDLK_KP_HEXADECIMAL,
+    left_ctrl = c.SDLK_LCTRL,
+    left_shift = c.SDLK_LSHIFT,
+    left_alt = c.SDLK_LALT,
+    left_gui = c.SDLK_LGUI,
+    right_ctrl = c.SDLK_RCTRL,
+    right_shift = c.SDLK_RSHIFT,
+    right_alt = c.SDLK_RALT,
+    right_gui = c.SDLK_RGUI,
+    mode = c.SDLK_MODE,
+    sleep = c.SDLK_SLEEP,
+    wake = c.SDLK_WAKE,
+    channel_increment = c.SDLK_CHANNEL_INCREMENT,
+    channel_decrement = c.SDLK_CHANNEL_DECREMENT,
+    media_play = c.SDLK_MEDIA_PLAY,
+    media_pause = c.SDLK_MEDIA_PAUSE,
+    media_record = c.SDLK_MEDIA_RECORD,
+    media_fast_forward = c.SDLK_MEDIA_FAST_FORWARD,
+    media_rewind = c.SDLK_MEDIA_REWIND,
+    media_next_track = c.SDLK_MEDIA_NEXT_TRACK,
+    media_previous_track = c.SDLK_MEDIA_PREVIOUS_TRACK,
+    media_stop = c.SDLK_MEDIA_STOP,
+    media_eject = c.SDLK_MEDIA_EJECT,
+    media_play_pause = c.SDLK_MEDIA_PLAY_PAUSE,
+    media_select = c.SDLK_MEDIA_SELECT,
+    ac_new = c.SDLK_AC_NEW,
+    ac_open = c.SDLK_AC_OPEN,
+    ac_close = c.SDLK_AC_CLOSE,
+    ac_exit = c.SDLK_AC_EXIT,
+    ac_save = c.SDLK_AC_SAVE,
+    ac_print = c.SDLK_AC_PRINT,
+    ac_properties = c.SDLK_AC_PROPERTIES,
+    ac_search = c.SDLK_AC_SEARCH,
+    ac_home = c.SDLK_AC_HOME,
+    ac_back = c.SDLK_AC_BACK,
+    ac_forward = c.SDLK_AC_FORWARD,
+    ac_stop = c.SDLK_AC_STOP,
+    ac_refresh = c.SDLK_AC_REFRESH,
+    ac_bookmarks = c.SDLK_AC_BOOKMARKS,
+    soft_left = c.SDLK_SOFTLEFT,
+    soft_right = c.SDLK_SOFTRIGHT,
+    call = c.SDLK_CALL,
+    end_call = c.SDLK_ENDCALL,
+    left_tab = c.SDLK_LEFT_TAB,
+    level5_shift = c.SDLK_LEVEL5_SHIFT,
+    multi_key_compose = c.SDLK_MULTI_KEY_COMPOSE,
+    left_meta = c.SDLK_LMETA,
+    right_meta = c.SDLK_RMETA,
+    left_hyper = c.SDLK_LHYPER,
+    right_hyper = c.SDLK_RHYPER,
     _, // non-exhaustive enum for SDL compatibility
 
     /// Create a keycode from a scancode.
@@ -285,7 +285,7 @@ pub const Keycode = enum(C.SDL_Keycode) {
     pub fn fromScancode(
         code: scancode.Scancode,
     ) ?Keycode {
-        const ret = C.SDL_SCANCODE_TO_KEYCODE(code.toSdl());
+        const ret = c.SDL_SCANCODE_TO_KEYCODE(code.toSdl());
         return Keycode.fromSdl(ret);
     }
 
@@ -302,7 +302,7 @@ pub const Keycode = enum(C.SDL_Keycode) {
     pub fn isExtended(
         self: Keycode,
     ) bool {
-        return C.SDLK_EXTENDED_MASK & @intFromEnum(self) != 0;
+        return c.SDLK_EXTENDED_MASK & @intFromEnum(self) != 0;
     }
 
     /// Returns if this keycode maps to a scancode.
@@ -316,7 +316,7 @@ pub const Keycode = enum(C.SDL_Keycode) {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn isScancode(self: Keycode) bool {
-        return C.SDLK_SCANCODE_MASK & @intFromEnum(self) != 0;
+        return c.SDLK_SCANCODE_MASK & @intFromEnum(self) != 0;
     }
 
     /// Create an unmanaged keycode from a keycode enum.
@@ -332,8 +332,8 @@ pub const Keycode = enum(C.SDL_Keycode) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn toSdl(self: ?Keycode) C.SDL_Keycode {
-        return if (self) |val| @intFromEnum(val) else C.SDLK_UNKNOWN;
+    pub fn toSdl(self: ?Keycode) c.SDL_Keycode {
+        return if (self) |val| @intFromEnum(val) else c.SDLK_UNKNOWN;
     }
 
     /// Create a keycode enum from an SDL keycode.
@@ -349,8 +349,8 @@ pub const Keycode = enum(C.SDL_Keycode) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn fromSdl(key_code: C.SDL_Keycode) ?Keycode {
-        if (key_code == C.SDLK_UNKNOWN) return null;
+    pub fn fromSdl(key_code: c.SDL_Keycode) ?Keycode {
+        if (key_code == c.SDLK_UNKNOWN) return null;
         return @enumFromInt(key_code);
     }
 };
@@ -381,39 +381,39 @@ pub const KeyModifier = struct {
     pub const none = KeyModifier{};
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_Keymod) KeyModifier {
+    pub fn fromSdl(flags: c.SDL_Keymod) KeyModifier {
         return .{
-            .left_shift = (flags & C.SDL_KMOD_LSHIFT) != 0,
-            .right_shift = (flags & C.SDL_KMOD_RSHIFT) != 0,
-            .level5_shift = (flags & C.SDL_KMOD_LEVEL5) != 0,
-            .left_control = (flags & C.SDL_KMOD_LCTRL) != 0,
-            .right_control = (flags & C.SDL_KMOD_RCTRL) != 0,
-            .left_alt = (flags & C.SDL_KMOD_LALT) != 0,
-            .right_alt = (flags & C.SDL_KMOD_RALT) != 0,
-            .left_gui = (flags & C.SDL_KMOD_LGUI) != 0,
-            .right_gui = (flags & C.SDL_KMOD_RGUI) != 0,
-            .num_lock = (flags & C.SDL_KMOD_NUM) != 0,
-            .caps_lock = (flags & C.SDL_KMOD_CAPS) != 0,
-            .mode = (flags & C.SDL_KMOD_MODE) != 0,
-            .scroll_lock = (flags & C.SDL_KMOD_SCROLL) != 0,
+            .left_shift = (flags & c.SDL_KMOD_LSHIFT) != 0,
+            .right_shift = (flags & c.SDL_KMOD_RSHIFT) != 0,
+            .level5_shift = (flags & c.SDL_KMOD_LEVEL5) != 0,
+            .left_control = (flags & c.SDL_KMOD_LCTRL) != 0,
+            .right_control = (flags & c.SDL_KMOD_RCTRL) != 0,
+            .left_alt = (flags & c.SDL_KMOD_LALT) != 0,
+            .right_alt = (flags & c.SDL_KMOD_RALT) != 0,
+            .left_gui = (flags & c.SDL_KMOD_LGUI) != 0,
+            .right_gui = (flags & c.SDL_KMOD_RGUI) != 0,
+            .num_lock = (flags & c.SDL_KMOD_NUM) != 0,
+            .caps_lock = (flags & c.SDL_KMOD_CAPS) != 0,
+            .mode = (flags & c.SDL_KMOD_MODE) != 0,
+            .scroll_lock = (flags & c.SDL_KMOD_SCROLL) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: KeyModifier) C.SDL_Keymod {
-        return (if (self.left_shift) @as(C.SDL_Keymod, C.SDL_KMOD_LSHIFT) else 0) |
-            (if (self.right_shift) @as(C.SDL_Keymod, C.SDL_KMOD_RSHIFT) else 0) |
-            (if (self.level5_shift) @as(C.SDL_Keymod, C.SDL_KMOD_LEVEL5) else 0) |
-            (if (self.left_control) @as(C.SDL_Keymod, C.SDL_KMOD_LCTRL) else 0) |
-            (if (self.right_control) @as(C.SDL_Keymod, C.SDL_KMOD_RCTRL) else 0) |
-            (if (self.left_alt) @as(C.SDL_Keymod, C.SDL_KMOD_LALT) else 0) |
-            (if (self.right_alt) @as(C.SDL_Keymod, C.SDL_KMOD_RALT) else 0) |
-            (if (self.left_gui) @as(C.SDL_Keymod, C.SDL_KMOD_LGUI) else 0) |
-            (if (self.right_gui) @as(C.SDL_Keymod, C.SDL_KMOD_RGUI) else 0) |
-            (if (self.num_lock) @as(C.SDL_Keymod, C.SDL_KMOD_NUM) else 0) |
-            (if (self.caps_lock) @as(C.SDL_Keymod, C.SDL_KMOD_CAPS) else 0) |
-            (if (self.mode) @as(C.SDL_Keymod, C.SDL_KMOD_MODE) else 0) |
-            (if (self.scroll_lock) @as(C.SDL_Keymod, C.SDL_KMOD_SCROLL) else 0) |
+    pub fn toSdl(self: KeyModifier) c.SDL_Keymod {
+        return (if (self.left_shift) @as(c.SDL_Keymod, c.SDL_KMOD_LSHIFT) else 0) |
+            (if (self.right_shift) @as(c.SDL_Keymod, c.SDL_KMOD_RSHIFT) else 0) |
+            (if (self.level5_shift) @as(c.SDL_Keymod, c.SDL_KMOD_LEVEL5) else 0) |
+            (if (self.left_control) @as(c.SDL_Keymod, c.SDL_KMOD_LCTRL) else 0) |
+            (if (self.right_control) @as(c.SDL_Keymod, c.SDL_KMOD_RCTRL) else 0) |
+            (if (self.left_alt) @as(c.SDL_Keymod, c.SDL_KMOD_LALT) else 0) |
+            (if (self.right_alt) @as(c.SDL_Keymod, c.SDL_KMOD_RALT) else 0) |
+            (if (self.left_gui) @as(c.SDL_Keymod, c.SDL_KMOD_LGUI) else 0) |
+            (if (self.right_gui) @as(c.SDL_Keymod, c.SDL_KMOD_RGUI) else 0) |
+            (if (self.num_lock) @as(c.SDL_Keymod, c.SDL_KMOD_NUM) else 0) |
+            (if (self.caps_lock) @as(c.SDL_Keymod, c.SDL_KMOD_CAPS) else 0) |
+            (if (self.mode) @as(c.SDL_Keymod, c.SDL_KMOD_MODE) else 0) |
+            (if (self.scroll_lock) @as(c.SDL_Keymod, c.SDL_KMOD_SCROLL) else 0) |
             0;
     }
 
@@ -428,7 +428,7 @@ pub const KeyModifier = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn controlDown(self: KeyModifier) bool {
-        return self.toSdl() & C.SDL_KMOD_CTRL != 0;
+        return self.toSdl() & c.SDL_KMOD_CTRL != 0;
     }
 
     /// If any shift key is down.
@@ -442,7 +442,7 @@ pub const KeyModifier = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn shiftDown(self: KeyModifier) bool {
-        return self.toSdl() & C.SDL_KMOD_SHIFT != 0;
+        return self.toSdl() & c.SDL_KMOD_SHIFT != 0;
     }
 
     /// If any alt key is down.
@@ -456,7 +456,7 @@ pub const KeyModifier = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn altDown(self: KeyModifier) bool {
-        return self.toSdl() & C.SDL_KMOD_ALT != 0;
+        return self.toSdl() & c.SDL_KMOD_ALT != 0;
     }
 
     /// If any gui key is down.
@@ -470,7 +470,7 @@ pub const KeyModifier = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn guiDown(self: KeyModifier) bool {
-        return self.toSdl() & C.SDL_KMOD_GUI != 0;
+        return self.toSdl() & c.SDL_KMOD_GUI != 0;
     }
 };
 

--- a/src/loadso.zig
+++ b/src/loadso.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -7,7 +7,7 @@ const std = @import("std");
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const SharedObject = packed struct {
-    value: *C.SDL_SharedObject,
+    value: *c.SDL_SharedObject,
 
     /// Dynamically load a shared object.
     ///
@@ -25,10 +25,10 @@ pub const SharedObject = packed struct {
     pub fn load(
         name: [:0]const u8,
     ) !SharedObject {
-        const ret = C.SDL_LoadObject(
+        const ret = c.SDL_LoadObject(
             name.ptr,
         );
-        return SharedObject{ .value = try errors.wrapNull(*C.SDL_SharedObject, ret) };
+        return SharedObject{ .value = try errors.wrapNull(*c.SDL_SharedObject, ret) };
     }
 
     /// Look up the address of the named function in a shared object.
@@ -69,7 +69,7 @@ pub const SharedObject = packed struct {
         self: SharedObject,
         name: [:0]const u8,
     ) !*const anyopaque {
-        const ret = C.SDL_LoadFunction(
+        const ret = c.SDL_LoadFunction(
             self.value,
             name.ptr,
         );
@@ -92,7 +92,7 @@ pub const SharedObject = packed struct {
     pub fn unload(
         self: SharedObject,
     ) void {
-        C.SDL_UnloadObject(
+        c.SDL_UnloadObject(
             self.value,
         );
     }

--- a/src/loadso.zig
+++ b/src/loadso.zig
@@ -62,7 +62,7 @@ pub const SharedObject = packed struct {
     /// const lib = try sdl3.SharedObject.load("mylib.so");
     /// defer lib.unload();
     ///
-    /// const my_func: *const fn(num: c_int) callconv(.C) void = @alignCast(@ptrCast(try lib.loadFunction("myfunc")));
+    /// const my_func: *const fn(num: c_int) callconv(.c) void = @alignCast(@ptrCast(try lib.loadFunction("myfunc")));
     /// return my_func(15);
     /// ```
     pub fn loadFunction(

--- a/src/locale.zig
+++ b/src/locale.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const stdinc = @import("stdinc.zig");
@@ -21,11 +21,11 @@ pub const Locale = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_Locale) == @sizeOf(Locale));
-        std.debug.assert(@offsetOf(C.SDL_Locale, "language") == @offsetOf(Locale, "language"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_Locale, "language")) == @sizeOf(@FieldType(Locale, "language")));
-        std.debug.assert(@offsetOf(C.SDL_Locale, "country") == @offsetOf(Locale, "country"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_Locale, "country")) == @sizeOf(@FieldType(Locale, "country")));
+        std.debug.assert(@sizeOf(c.SDL_Locale) == @sizeOf(Locale));
+        std.debug.assert(@offsetOf(c.SDL_Locale, "language") == @offsetOf(Locale, "language"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_Locale, "language")) == @sizeOf(@FieldType(Locale, "language")));
+        std.debug.assert(@offsetOf(c.SDL_Locale, "country") == @offsetOf(Locale, "country"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_Locale, "country")) == @sizeOf(@FieldType(Locale, "country")));
     }
 
     /// Report the user's preferred locale.
@@ -57,7 +57,7 @@ pub const Locale = extern struct {
     /// This function is available since SDL 3.2.0.
     pub fn getPreferred() ![]*Locale {
         var cnt: c_int = undefined;
-        const val = C.SDL_GetPreferredLocales(&cnt);
+        const val = c.SDL_GetPreferredLocales(&cnt);
         const ret = try errors.wrapCallCPtr(*Locale, @ptrCast(val));
         return ret[0..@intCast(cnt)];
     }

--- a/src/log.zig
+++ b/src/log.zig
@@ -25,7 +25,7 @@ pub const LogOutputFunction = *const fn (
     category: c_int,
     priority: c.SDL_LogPriority,
     message: [*c]const u8,
-) callconv(.C) void;
+) callconv(.c) void;
 
 /// The predefined log priorities.
 ///
@@ -496,7 +496,7 @@ const TestLogCallbackData = struct {
     last_priority: ?Priority = null,
 };
 
-fn testLogCallback(user_data: ?*anyopaque, category: c_int, priority: c.SDL_LogPriority, message: [*c]const u8) callconv(.C) void {
+fn testLogCallback(user_data: ?*anyopaque, category: c_int, priority: c.SDL_LogPriority, message: [*c]const u8) callconv(.c) void {
     var data: *TestLogCallbackData = @ptrCast(@alignCast(user_data));
     data.last_str = data.buf.items.len;
     data.last_category = Category.fromSdl(category);

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const stdinc = @import("stdinc.zig");
@@ -23,7 +23,7 @@ const max_log_message_stack = 1024;
 pub const LogOutputFunction = *const fn (
     user_data: ?*anyopaque,
     category: c_int,
-    priority: C.SDL_LogPriority,
+    priority: c.SDL_LogPriority,
     message: [*c]const u8,
 ) callconv(.C) void;
 
@@ -32,17 +32,17 @@ pub const LogOutputFunction = *const fn (
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Priority = enum(c_uint) {
-    trace = C.SDL_LOG_PRIORITY_TRACE,
-    verbose = C.SDL_LOG_PRIORITY_VERBOSE,
-    debug = C.SDL_LOG_PRIORITY_DEBUG,
-    info = C.SDL_LOG_PRIORITY_INFO,
-    warn = C.SDL_LOG_PRIORITY_WARN,
-    err = C.SDL_LOG_PRIORITY_ERROR,
-    critical = C.SDL_LOG_PRIORITY_CRITICAL,
+    trace = c.SDL_LOG_PRIORITY_TRACE,
+    verbose = c.SDL_LOG_PRIORITY_VERBOSE,
+    debug = c.SDL_LOG_PRIORITY_DEBUG,
+    info = c.SDL_LOG_PRIORITY_INFO,
+    warn = c.SDL_LOG_PRIORITY_WARN,
+    err = c.SDL_LOG_PRIORITY_ERROR,
+    critical = c.SDL_LOG_PRIORITY_CRITICAL,
 
     /// Make a priority from an SDL value.
     pub fn fromSdl(val: c_uint) ?Priority {
-        if (val == C.SDL_LOG_PRIORITY_INVALID)
+        if (val == c.SDL_LOG_PRIORITY_INVALID)
             return null;
         return @enumFromInt(val);
     }
@@ -67,7 +67,7 @@ pub const Priority = enum(c_uint) {
         self: Priority,
         prefix: ?[:0]const u8,
     ) !void {
-        const ret = C.SDL_SetLogPriorityPrefix(
+        const ret = c.SDL_SetLogPriorityPrefix(
             @intFromEnum(self),
             if (prefix) |val| val.ptr else null,
         );
@@ -87,22 +87,22 @@ pub const Priority = enum(c_uint) {
 /// This is available since SDL 3.2.0.
 pub const Category = packed struct {
     value: c_int,
-    pub const application = Category{ .value = C.SDL_LOG_CATEGORY_APPLICATION };
-    pub const errors = Category{ .value = C.SDL_LOG_CATEGORY_ERROR };
-    pub const assert = Category{ .value = C.SDL_LOG_CATEGORY_ASSERT };
-    pub const system = Category{ .value = C.SDL_LOG_CATEGORY_SYSTEM };
-    pub const audio = Category{ .value = C.SDL_LOG_CATEGORY_AUDIO };
-    pub const video = Category{ .value = C.SDL_LOG_CATEGORY_VIDEO };
-    pub const render = Category{ .value = C.SDL_LOG_CATEGORY_RENDER };
-    pub const input = Category{ .value = C.SDL_LOG_CATEGORY_INPUT };
-    pub const testing = Category{ .value = C.SDL_LOG_CATEGORY_TEST };
-    pub const gpu = Category{ .value = C.SDL_LOG_CATEGORY_GPU };
+    pub const application = Category{ .value = c.SDL_LOG_CATEGORY_APPLICATION };
+    pub const errors = Category{ .value = c.SDL_LOG_CATEGORY_ERROR };
+    pub const assert = Category{ .value = c.SDL_LOG_CATEGORY_ASSERT };
+    pub const system = Category{ .value = c.SDL_LOG_CATEGORY_SYSTEM };
+    pub const audio = Category{ .value = c.SDL_LOG_CATEGORY_AUDIO };
+    pub const video = Category{ .value = c.SDL_LOG_CATEGORY_VIDEO };
+    pub const render = Category{ .value = c.SDL_LOG_CATEGORY_RENDER };
+    pub const input = Category{ .value = c.SDL_LOG_CATEGORY_INPUT };
+    pub const testing = Category{ .value = c.SDL_LOG_CATEGORY_TEST };
+    pub const gpu = Category{ .value = c.SDL_LOG_CATEGORY_GPU };
     /// First value to use for custom log categories.
-    pub const custom = Category{ .value = C.SDL_LOG_CATEGORY_CUSTOM };
+    pub const custom = Category{ .value = c.SDL_LOG_CATEGORY_CUSTOM };
 
     /// Get zig representation of a category.
     pub fn fromSdl(val: c_int) ?Category {
-        if (val == C.SDL_LOG_CATEGORY_ERROR)
+        if (val == c.SDL_LOG_CATEGORY_ERROR)
             return null;
         return .{ .value = val };
     }
@@ -123,7 +123,7 @@ pub const Category = packed struct {
     pub fn getPriority(
         self: Category,
     ) Priority {
-        return @enumFromInt(C.SDL_GetLogPriority(self.value));
+        return @enumFromInt(c.SDL_GetLogPriority(self.value));
     }
 
     /// Log a message with the specified category and priority.
@@ -149,7 +149,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogMessage(
+        c.SDL_LogMessage(
             self.value,
             @intFromEnum(priority),
             "%s",
@@ -178,7 +178,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogCritical(
+        c.SDL_LogCritical(
             self.value,
             "%s",
             msg.ptr,
@@ -206,7 +206,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogDebug(
+        c.SDL_LogDebug(
             self.value,
             "%s",
             msg.ptr,
@@ -234,7 +234,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogError(
+        c.SDL_LogError(
             self.value,
             "%s",
             msg.ptr,
@@ -262,7 +262,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogInfo(
+        c.SDL_LogInfo(
             self.value,
             "%s",
             msg.ptr,
@@ -290,7 +290,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogTrace(
+        c.SDL_LogTrace(
             self.value,
             "%s",
             msg.ptr,
@@ -318,7 +318,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogVerbose(
+        c.SDL_LogVerbose(
             self.value,
             "%s",
             msg.ptr,
@@ -346,7 +346,7 @@ pub const Category = packed struct {
         const allocator = fallback.get();
         const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
         defer allocator.free(msg);
-        C.SDL_LogWarn(
+        c.SDL_LogWarn(
             self.value,
             "%s",
             msg.ptr,
@@ -368,7 +368,7 @@ pub const Category = packed struct {
         self: Category,
         priority: Priority,
     ) void {
-        const ret = C.SDL_SetLogPriority(
+        const ret = c.SDL_SetLogPriority(
             self.value,
             @intFromEnum(priority),
         );
@@ -387,7 +387,7 @@ pub const Category = packed struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getDefaultLogOutputFunction() LogOutputFunction {
-    return C.SDL_GetDefaultLogOutputFunction().?;
+    return c.SDL_GetDefaultLogOutputFunction().?;
 }
 
 /// Get the current log output function.
@@ -402,9 +402,9 @@ pub fn getDefaultLogOutputFunction() LogOutputFunction {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getLogOutputFunction() struct { callback: LogOutputFunction, user_data: ?*anyopaque } {
-    var callback: C.SDL_LogOutputFunction = undefined;
+    var callback: c.SDL_LogOutputFunction = undefined;
     var user_data: ?*anyopaque = undefined;
-    C.SDL_GetLogOutputFunction(
+    c.SDL_GetLogOutputFunction(
         &callback,
         &user_data,
     );
@@ -430,7 +430,7 @@ pub fn log(
     const allocator = fallback.get();
     const msg = try std.fmt.allocPrintZ(allocator, fmt, args);
     defer allocator.free(msg);
-    C.SDL_Log(
+    c.SDL_Log(
         "%s",
         msg.ptr,
     );
@@ -447,7 +447,7 @@ pub fn log(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn resetAllPriorities() void {
-    C.SDL_ResetLogPriorities();
+    c.SDL_ResetLogPriorities();
 }
 
 /// Set the priority of all log categories.
@@ -463,7 +463,7 @@ pub fn resetAllPriorities() void {
 pub fn setAllPriorities(
     priority: Priority,
 ) void {
-    C.SDL_SetLogPriorities(
+    c.SDL_SetLogPriorities(
         @intFromEnum(priority),
     );
 }
@@ -483,7 +483,7 @@ pub fn setLogOutputFunction(
     callback: LogOutputFunction,
     user_data: ?*anyopaque,
 ) void {
-    C.SDL_SetLogOutputFunction(
+    c.SDL_SetLogOutputFunction(
         callback,
         user_data,
     );
@@ -496,7 +496,7 @@ const TestLogCallbackData = struct {
     last_priority: ?Priority = null,
 };
 
-fn testLogCallback(user_data: ?*anyopaque, category: c_int, priority: C.SDL_LogPriority, message: [*c]const u8) callconv(.C) void {
+fn testLogCallback(user_data: ?*anyopaque, category: c_int, priority: c.SDL_LogPriority, message: [*c]const u8) callconv(.C) void {
     var data: *TestLogCallbackData = @ptrCast(@alignCast(user_data));
     data.last_str = data.buf.items.len;
     data.last_category = Category.fromSdl(category);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const sdl3 = @import("sdl3.zig");
 const std = @import("std");
 
@@ -47,7 +47,7 @@ pub fn enterAppMainCallbacks(
     app_event: sdl3.AppEventCallback,
     app_quit: sdl3.AppQuitCallback,
 ) c_int {
-    return C.SDL_EnterAppMainCallbacks(
+    return c.SDL_EnterAppMainCallbacks(
         @intCast(args.len),
         @ptrCast(args.ptr),
         app_init,
@@ -65,7 +65,7 @@ pub fn enterAppMainCallbacks(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn gdkSuspendComplete() void {
-    C.SDL_GDKSuspendComplete();
+    c.SDL_GDKSuspendComplete();
 }
 
 // I'm pretty sure `SDL_main` makes no sense to include in this subsystem so I will not until reason is given.
@@ -112,7 +112,7 @@ pub fn runApp(
     args: [:null]?[*:0]u8,
     main_function: MainCallback,
 ) c_int {
-    return C.SDL_RunApp(
+    return c.SDL_RunApp(
         @intCast(args.len),
         @ptrCast(args.ptr),
         main_function,
@@ -128,7 +128,7 @@ pub fn runApp(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn setMainReady() void {
-    C.SDL_SetMainReady();
+    c.SDL_SetMainReady();
 }
 
 fn dummyMain(
@@ -149,31 +149,31 @@ fn dummyInit(
     arg_values: [*c][*c]u8,
 ) callconv(.C) c_uint {
     if (arg_count < 2)
-        return C.SDL_APP_FAILURE;
-    std.testing.expectEqualStrings("Hello", std.mem.span(arg_values[0])) catch return C.SDL_APP_FAILURE;
-    std.testing.expectEqualStrings("World", std.mem.span(arg_values[1])) catch return C.SDL_APP_FAILURE;
-    std.testing.expectEqual(null, arg_values[2]) catch return C.SDL_APP_FAILURE;
+        return c.SDL_APP_FAILURE;
+    std.testing.expectEqualStrings("Hello", std.mem.span(arg_values[0])) catch return c.SDL_APP_FAILURE;
+    std.testing.expectEqualStrings("World", std.mem.span(arg_values[1])) catch return c.SDL_APP_FAILURE;
+    std.testing.expectEqual(null, arg_values[2]) catch return c.SDL_APP_FAILURE;
     app_state.* = @ptrFromInt(5);
-    return C.SDL_APP_CONTINUE;
+    return c.SDL_APP_CONTINUE;
 }
 
 fn dummyIterate(
     app_state: ?*anyopaque,
 ) callconv(.C) c_uint {
     if (app_state) |val| {
-        std.testing.expectEqual(5, @intFromPtr(val)) catch return C.SDL_APP_FAILURE;
-        return C.SDL_APP_SUCCESS;
+        std.testing.expectEqual(5, @intFromPtr(val)) catch return c.SDL_APP_FAILURE;
+        return c.SDL_APP_SUCCESS;
     }
-    return C.SDL_APP_FAILURE;
+    return c.SDL_APP_FAILURE;
 }
 
 fn dummyEvent(
     app_state: ?*anyopaque,
-    event: [*c]C.SDL_Event,
+    event: [*c]c.SDL_Event,
 ) callconv(.C) c_uint {
     _ = app_state;
     _ = event;
-    return C.SDL_APP_CONTINUE;
+    return c.SDL_APP_CONTINUE;
 }
 
 fn dummyQuit(

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,7 +13,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const MainCallback = *const fn (arg_count: c_int, arg_values: [*c][*c]u8) callconv(.C) c_int;
+pub const MainCallback = *const fn (arg_count: c_int, arg_values: [*c][*c]u8) callconv(.c) c_int;
 
 /// An entry point for SDL's use in main callbacks.
 ///
@@ -134,7 +134,7 @@ pub fn setMainReady() void {
 fn dummyMain(
     arg_count: c_int,
     arg_values: [*c][*c]u8,
-) callconv(.C) c_int {
+) callconv(.c) c_int {
     if (arg_count < 2)
         return -1;
     std.testing.expectEqualStrings("Hello", std.mem.span(arg_values[0])) catch return -1;
@@ -147,7 +147,7 @@ fn dummyInit(
     app_state: [*c]?*anyopaque,
     arg_count: c_int,
     arg_values: [*c][*c]u8,
-) callconv(.C) c_uint {
+) callconv(.c) c_uint {
     if (arg_count < 2)
         return c.SDL_APP_FAILURE;
     std.testing.expectEqualStrings("Hello", std.mem.span(arg_values[0])) catch return c.SDL_APP_FAILURE;
@@ -159,7 +159,7 @@ fn dummyInit(
 
 fn dummyIterate(
     app_state: ?*anyopaque,
-) callconv(.C) c_uint {
+) callconv(.c) c_uint {
     if (app_state) |val| {
         std.testing.expectEqual(5, @intFromPtr(val)) catch return c.SDL_APP_FAILURE;
         return c.SDL_APP_SUCCESS;
@@ -170,7 +170,7 @@ fn dummyIterate(
 fn dummyEvent(
     app_state: ?*anyopaque,
     event: [*c]c.SDL_Event,
-) callconv(.C) c_uint {
+) callconv(.c) c_uint {
     _ = app_state;
     _ = event;
     return c.SDL_APP_CONTINUE;
@@ -179,7 +179,7 @@ fn dummyEvent(
 fn dummyQuit(
     app_state: ?*anyopaque,
     result: c_uint,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = app_state;
     _ = result;
 }

--- a/src/message_box.zig
+++ b/src/message_box.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const video = @import("video.zig");
@@ -16,7 +16,7 @@ pub const BoxData = struct {
     color_scheme: ?ColorScheme,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_MessageBoxData) BoxData {
+    pub fn fromSdl(value: c.SDL_MessageBoxData) BoxData {
         return .{
             .flags = BoxFlags.fromSdl(value.flags),
             .parent_window = if (value.window) |window| .{ .value = window } else null,
@@ -28,7 +28,7 @@ pub const BoxData = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: BoxData, color_scheme_out: *C.SDL_MessageBoxColorScheme) C.SDL_MessageBoxData {
+    pub fn toSdl(self: BoxData, color_scheme_out: *c.SDL_MessageBoxColorScheme) c.SDL_MessageBoxData {
         if (self.color_scheme) |val|
             color_scheme_out.* = val.toSdl();
         return .{
@@ -63,23 +63,23 @@ pub const BoxFlags = struct {
     buttons_right_to_left: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_MessageBoxFlags) BoxFlags {
+    pub fn fromSdl(flags: c.SDL_MessageBoxFlags) BoxFlags {
         return .{
-            .error_dialog = (flags & C.SDL_MESSAGEBOX_ERROR) != 0,
-            .warning_dialog = (flags & C.SDL_MESSAGEBOX_WARNING) != 0,
-            .information_dialog = (flags & C.SDL_MESSAGEBOX_INFORMATION) != 0,
-            .buttons_left_to_right = (flags & C.SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT) != 0,
-            .buttons_right_to_left = (flags & C.SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT) != 0,
+            .error_dialog = (flags & c.SDL_MESSAGEBOX_ERROR) != 0,
+            .warning_dialog = (flags & c.SDL_MESSAGEBOX_WARNING) != 0,
+            .information_dialog = (flags & c.SDL_MESSAGEBOX_INFORMATION) != 0,
+            .buttons_left_to_right = (flags & c.SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT) != 0,
+            .buttons_right_to_left = (flags & c.SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: BoxFlags) C.SDL_MessageBoxFlags {
-        return (if (self.error_dialog) @as(C.SDL_MessageBoxFlags, C.SDL_MESSAGEBOX_ERROR) else 0) |
-            (if (self.warning_dialog) @as(C.SDL_MessageBoxFlags, C.SDL_MESSAGEBOX_WARNING) else 0) |
-            (if (self.information_dialog) @as(C.SDL_MessageBoxFlags, C.SDL_MESSAGEBOX_INFORMATION) else 0) |
-            (if (self.buttons_left_to_right) @as(C.SDL_MessageBoxFlags, C.SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT) else 0) |
-            (if (self.buttons_right_to_left) @as(C.SDL_MessageBoxFlags, C.SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT) else 0) |
+    pub fn toSdl(self: BoxFlags) c.SDL_MessageBoxFlags {
+        return (if (self.error_dialog) @as(c.SDL_MessageBoxFlags, c.SDL_MESSAGEBOX_ERROR) else 0) |
+            (if (self.warning_dialog) @as(c.SDL_MessageBoxFlags, c.SDL_MESSAGEBOX_WARNING) else 0) |
+            (if (self.information_dialog) @as(c.SDL_MessageBoxFlags, c.SDL_MESSAGEBOX_INFORMATION) else 0) |
+            (if (self.buttons_left_to_right) @as(c.SDL_MessageBoxFlags, c.SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT) else 0) |
+            (if (self.buttons_right_to_left) @as(c.SDL_MessageBoxFlags, c.SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT) else 0) |
             0;
     }
 };
@@ -97,17 +97,17 @@ pub const Button = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_MessageBoxButtonData) == @sizeOf(Button));
-        std.debug.assert(@offsetOf(C.SDL_MessageBoxButtonData, "flags") == @offsetOf(Button, "flags"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_MessageBoxButtonData, "flags")) == @sizeOf(@FieldType(Button, "flags")));
-        std.debug.assert(@offsetOf(C.SDL_MessageBoxButtonData, "buttonID") == @offsetOf(Button, "value"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_MessageBoxButtonData, "buttonID")) == @sizeOf(@FieldType(Button, "value")));
-        std.debug.assert(@offsetOf(C.SDL_MessageBoxButtonData, "text") == @offsetOf(Button, "text"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_MessageBoxButtonData, "text")) == @sizeOf(@FieldType(Button, "text")));
+        std.debug.assert(@sizeOf(c.SDL_MessageBoxButtonData) == @sizeOf(Button));
+        std.debug.assert(@offsetOf(c.SDL_MessageBoxButtonData, "flags") == @offsetOf(Button, "flags"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_MessageBoxButtonData, "flags")) == @sizeOf(@FieldType(Button, "flags")));
+        std.debug.assert(@offsetOf(c.SDL_MessageBoxButtonData, "buttonID") == @offsetOf(Button, "value"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_MessageBoxButtonData, "buttonID")) == @sizeOf(@FieldType(Button, "value")));
+        std.debug.assert(@offsetOf(c.SDL_MessageBoxButtonData, "text") == @offsetOf(Button, "text"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_MessageBoxButtonData, "text")) == @sizeOf(@FieldType(Button, "text")));
     }
 
     /// Convert from an SDL value.
-    pub fn fromSdl(data: C.SDL_MessageBoxButtonData) Button {
+    pub fn fromSdl(data: c.SDL_MessageBoxButtonData) Button {
         return .{
             .flags = ButtonFlags.fromSdl(data.flags),
             .value = @intCast(data.buttonID),
@@ -116,7 +116,7 @@ pub const Button = extern struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Button) C.SDL_MessageBoxButtonData {
+    pub fn toSdl(self: Button) c.SDL_MessageBoxButtonData {
         return .{
             .flags = self.flags.toSdl(),
             .buttonID = @intCast(self.value),
@@ -136,23 +136,23 @@ pub const ButtonFlags = packed struct(u32) { // Need to be packed to fit into da
 
     // Button flag tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_MessageBoxButtonFlags) == @sizeOf(ButtonFlags));
-        std.debug.assert(C.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT == @as(C.SDL_MessageBoxButtonFlags, @bitCast(ButtonFlags{ .mark_default_with_return_key = true })));
-        std.debug.assert(C.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT == @as(C.SDL_MessageBoxButtonFlags, @bitCast(ButtonFlags{ .mark_default_with_escape_key = true })));
+        std.debug.assert(@sizeOf(c.SDL_MessageBoxButtonFlags) == @sizeOf(ButtonFlags));
+        std.debug.assert(c.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT == @as(c.SDL_MessageBoxButtonFlags, @bitCast(ButtonFlags{ .mark_default_with_return_key = true })));
+        std.debug.assert(c.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT == @as(c.SDL_MessageBoxButtonFlags, @bitCast(ButtonFlags{ .mark_default_with_escape_key = true })));
     }
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_MessageBoxButtonFlags) ButtonFlags {
+    pub fn fromSdl(flags: c.SDL_MessageBoxButtonFlags) ButtonFlags {
         return .{
-            .mark_default_with_return_key = (flags & C.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT) != 0,
-            .mark_default_with_escape_key = (flags & C.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT) != 0,
+            .mark_default_with_return_key = (flags & c.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT) != 0,
+            .mark_default_with_escape_key = (flags & c.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ButtonFlags) C.SDL_MessageBoxButtonFlags {
-        return (if (self.mark_default_with_return_key) @as(C.SDL_MessageBoxButtonFlags, C.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT) else 0) |
-            (if (self.mark_default_with_escape_key) @as(C.SDL_MessageBoxButtonFlags, C.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT) else 0) |
+    pub fn toSdl(self: ButtonFlags) c.SDL_MessageBoxButtonFlags {
+        return (if (self.mark_default_with_return_key) @as(c.SDL_MessageBoxButtonFlags, c.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT) else 0) |
+            (if (self.mark_default_with_escape_key) @as(c.SDL_MessageBoxButtonFlags, c.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT) else 0) |
             0;
     }
 };
@@ -167,7 +167,7 @@ pub const Color = struct {
     b: u8,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(data: C.SDL_MessageBoxColor) Color {
+    pub fn fromSdl(data: c.SDL_MessageBoxColor) Color {
         return .{
             .r = @intCast(data.r),
             .g = @intCast(data.g),
@@ -176,7 +176,7 @@ pub const Color = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Color) C.SDL_MessageBoxColor {
+    pub fn toSdl(self: Color) c.SDL_MessageBoxColor {
         return .{
             .r = @intCast(self.r),
             .g = @intCast(self.g),
@@ -206,23 +206,23 @@ pub const ColorScheme = struct {
     button_selected: Color,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(data: C.SDL_MessageBoxColorScheme) ColorScheme {
+    pub fn fromSdl(data: c.SDL_MessageBoxColorScheme) ColorScheme {
         return .{
-            .background = Color.fromSdl(data.colors[C.SDL_MESSAGEBOX_COLOR_BACKGROUND]),
-            .text = Color.fromSdl(data.colors[C.SDL_MESSAGEBOX_COLOR_TEXT]),
-            .button_border = Color.fromSdl(data.colors[C.SDL_MESSAGEBOX_COLOR_BUTTON_BORDER]),
-            .button_background = Color.fromSdl(data.colors[C.SDL_MESSAGEBOX_COLOR_BUTTON_BACKGROUND]),
-            .button_selected = Color.fromSdl(data.colors[C.SDL_MESSAGEBOX_COLOR_BUTTON_SELECTED]),
+            .background = Color.fromSdl(data.colors[c.SDL_MESSAGEBOX_COLOR_BACKGROUND]),
+            .text = Color.fromSdl(data.colors[c.SDL_MESSAGEBOX_COLOR_TEXT]),
+            .button_border = Color.fromSdl(data.colors[c.SDL_MESSAGEBOX_COLOR_BUTTON_BORDER]),
+            .button_background = Color.fromSdl(data.colors[c.SDL_MESSAGEBOX_COLOR_BUTTON_BACKGROUND]),
+            .button_selected = Color.fromSdl(data.colors[c.SDL_MESSAGEBOX_COLOR_BUTTON_SELECTED]),
         };
     }
     /// Convert to an SDL value.
-    pub fn toSdl(self: ColorScheme) C.SDL_MessageBoxColorScheme {
-        var ret: C.SDL_MessageBoxColorScheme = undefined;
-        ret.colors[C.SDL_MESSAGEBOX_COLOR_BACKGROUND] = self.background.toSdl();
-        ret.colors[C.SDL_MESSAGEBOX_COLOR_TEXT] = self.text.toSdl();
-        ret.colors[C.SDL_MESSAGEBOX_COLOR_BUTTON_BORDER] = self.button_border.toSdl();
-        ret.colors[C.SDL_MESSAGEBOX_COLOR_BUTTON_BACKGROUND] = self.button_background.toSdl();
-        ret.colors[C.SDL_MESSAGEBOX_COLOR_BUTTON_SELECTED] = self.button_selected.toSdl();
+    pub fn toSdl(self: ColorScheme) c.SDL_MessageBoxColorScheme {
+        var ret: c.SDL_MessageBoxColorScheme = undefined;
+        ret.colors[c.SDL_MESSAGEBOX_COLOR_BACKGROUND] = self.background.toSdl();
+        ret.colors[c.SDL_MESSAGEBOX_COLOR_TEXT] = self.text.toSdl();
+        ret.colors[c.SDL_MESSAGEBOX_COLOR_BUTTON_BORDER] = self.button_border.toSdl();
+        ret.colors[c.SDL_MESSAGEBOX_COLOR_BUTTON_BACKGROUND] = self.button_background.toSdl();
+        ret.colors[c.SDL_MESSAGEBOX_COLOR_BUTTON_SELECTED] = self.button_selected.toSdl();
         return ret;
     }
 };
@@ -254,10 +254,10 @@ pub const ColorScheme = struct {
 pub fn show(
     data: BoxData,
 ) !c_int {
-    var color_scheme: C.SDL_MessageBoxColorScheme = undefined;
+    var color_scheme: c.SDL_MessageBoxColorScheme = undefined;
     const button_data = data.toSdl(&color_scheme);
     var button_id: c_int = undefined;
-    const ret = C.SDL_ShowMessageBox(&button_data, &button_id);
+    const ret = c.SDL_ShowMessageBox(&button_data, &button_id);
     try errors.wrapCallBool(ret);
     return @intCast(button_id);
 }
@@ -292,7 +292,7 @@ pub fn showSimple(
     message: [:0]const u8,
     parent_window: ?video.Window,
 ) !void {
-    const ret = C.SDL_ShowSimpleMessageBox(
+    const ret = c.SDL_ShowSimpleMessageBox(
         flags.toSdl(),
         title,
         message,

--- a/src/metal.zig
+++ b/src/metal.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const init = @import("init.zig");
 const std = @import("std");
 const video = @import("video.zig");
@@ -20,7 +20,7 @@ pub const View = packed struct {
     pub fn deinit(
         self: View,
     ) void {
-        C.SDL_Metal_DestroyView(self.value);
+        c.SDL_Metal_DestroyView(self.value);
     }
 
     /// Get a pointer to the backing `CAMetalLayer` for the given view.
@@ -36,7 +36,7 @@ pub const View = packed struct {
     pub fn getLayer(
         self: View,
     ) ?*anyopaque {
-        return C.SDL_Metal_GetLayer(self.value);
+        return c.SDL_Metal_GetLayer(self.value);
     }
 
     /// Create a `CAMetalLayer`-backed `NSView`/`UIView` and attach it to the specified window.
@@ -58,7 +58,7 @@ pub const View = packed struct {
     pub fn init(
         window: video.Window,
     ) ?View {
-        return .{ .value = C.SDL_Metal_CreateView(window.value) orelse return null };
+        return .{ .value = c.SDL_Metal_CreateView(window.value) orelse return null };
     }
 };
 

--- a/src/misc.zig
+++ b/src/misc.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -28,7 +28,7 @@ const std = @import("std");
 pub fn openURL(
     url: [:0]const u8,
 ) !void {
-    const ret = C.SDL_OpenURL(
+    const ret = c.SDL_OpenURL(
         url.ptr,
     );
     return errors.wrapCallBool(ret);

--- a/src/mouse.zig
+++ b/src/mouse.zig
@@ -29,7 +29,7 @@ const video = @import("video.zig");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.6.
-pub const MotionTransformCallback = *const fn (user_data: ?*anyopaque, timestamp: u64, window: ?*c.SDL_Window, id: c.SDL_MouseID, x: ?*f32, y: ?*f32) callconv(.C) void;
+pub const MotionTransformCallback = *const fn (user_data: ?*anyopaque, timestamp: u64, window: ?*c.SDL_Window, id: c.SDL_MouseID, x: ?*f32, y: ?*f32) callconv(.c) void;
 
 /// A bitmask of pressed mouse buttons, as reported by `mouse.getState()`, etc.
 ///

--- a/src/mouse.zig
+++ b/src/mouse.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const init = @import("init.zig");
 const rect = @import("rect.zig");
@@ -29,7 +29,7 @@ const video = @import("video.zig");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.6.
-pub const MotionTransformCallback = *const fn (user_data: ?*anyopaque, timestamp: u64, window: ?*C.SDL_Window, id: C.SDL_MouseID, x: ?*f32, y: ?*f32) callconv(.C) void;
+pub const MotionTransformCallback = *const fn (user_data: ?*anyopaque, timestamp: u64, window: ?*c.SDL_Window, id: c.SDL_MouseID, x: ?*f32, y: ?*f32) callconv(.C) void;
 
 /// A bitmask of pressed mouse buttons, as reported by `mouse.getState()`, etc.
 ///
@@ -43,29 +43,29 @@ pub const ButtonFlags = struct {
     side2: bool,
 
     /// Get button flags from an SDL value.
-    pub fn fromSdl(value: C.SDL_MouseButtonFlags) ButtonFlags {
+    pub fn fromSdl(value: c.SDL_MouseButtonFlags) ButtonFlags {
         return .{
-            .left = value & C.SDL_BUTTON_LEFT > 0,
-            .middle = value & C.SDL_BUTTON_MIDDLE > 0,
-            .right = value & C.SDL_BUTTON_RIGHT > 0,
-            .side1 = value & C.SDL_BUTTON_X1 > 0,
-            .side2 = value & C.SDL_BUTTON_X2 > 0,
+            .left = value & c.SDL_BUTTON_LEFT > 0,
+            .middle = value & c.SDL_BUTTON_MIDDLE > 0,
+            .right = value & c.SDL_BUTTON_RIGHT > 0,
+            .side1 = value & c.SDL_BUTTON_X1 > 0,
+            .side2 = value & c.SDL_BUTTON_X2 > 0,
         };
     }
 
     /// Get this as an SDL value.
-    pub fn toSdl(self: ButtonFlags) C.SDL_MouseButtonFlags {
-        var ret: C.SDL_MouseButtonFlags = 0;
+    pub fn toSdl(self: ButtonFlags) c.SDL_MouseButtonFlags {
+        var ret: c.SDL_MouseButtonFlags = 0;
         if (self.left)
-            ret |= C.SDL_BUTTON_LEFT;
+            ret |= c.SDL_BUTTON_LEFT;
         if (self.middle)
-            ret |= C.SDL_BUTTON_MIDDLE;
+            ret |= c.SDL_BUTTON_MIDDLE;
         if (self.right)
-            ret |= C.SDL_BUTTON_RIGHT;
+            ret |= c.SDL_BUTTON_RIGHT;
         if (self.side1)
-            ret |= C.SDL_BUTTON_X1;
+            ret |= c.SDL_BUTTON_X1;
         if (self.side2)
-            ret |= C.SDL_BUTTON_X2;
+            ret |= c.SDL_BUTTON_X2;
         return ret;
     }
 };
@@ -79,34 +79,34 @@ pub const ButtonFlags = struct {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_MouseID,
+    value: c.SDL_MouseID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_MouseID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_MouseID) == @sizeOf(ID));
     }
 
     /// The `mouse.ID` for mouse events simulated with pen input.
     ///
     /// ## Version
     /// This constant is available since SDL 3.2.0.
-    pub const pen = ID{ .value = C.SDL_PEN_MOUSEID };
+    pub const pen = ID{ .value = c.SDL_PEN_MOUSEID };
 
     /// The `mouse.ID` for mouse events simulated with touch input.
     ///
     /// ## Version
     /// This constant is available since SDL 3.2.0.
-    pub const touch = ID{ .value = C.SDL_TOUCH_MOUSEID };
+    pub const touch = ID{ .value = c.SDL_TOUCH_MOUSEID };
 
     /// Get from an SDL value.
-    pub fn fromSdl(value: C.SDL_MouseID) ?ID {
+    pub fn fromSdl(value: c.SDL_MouseID) ?ID {
         if (value == 0)
             return null;
         return .{ .value = value };
     }
 
     /// Get an SDL value.
-    pub fn toSdl(self: ?ID) C.SDL_MouseID {
+    pub fn toSdl(self: ?ID) c.SDL_MouseID {
         if (self) |val| {
             return val.value;
         }
@@ -129,7 +129,7 @@ pub const ID = packed struct {
     pub fn getName(
         self: ID,
     ) !?[:0]const u8 {
-        const ret = try errors.wrapCallCString(C.SDL_GetMouseNameForID(self.value));
+        const ret = try errors.wrapCallCString(c.SDL_GetMouseNameForID(self.value));
         if (std.mem.eql(u8, ret, ""))
             return null;
         return ret;
@@ -142,45 +142,45 @@ pub const ID = packed struct {
 /// This enum is available since SDL 3.2.0.
 pub const SystemCursor = enum(c_uint) {
     /// Default cursor. Usually an arrow.
-    default = C.SDL_SYSTEM_CURSOR_DEFAULT,
+    default = c.SDL_SYSTEM_CURSOR_DEFAULT,
     /// Text selection. Usually an I-beam.
-    text = C.SDL_SYSTEM_CURSOR_TEXT,
+    text = c.SDL_SYSTEM_CURSOR_TEXT,
     /// Wait. Usually an hourglass or watch or spinning ball.
-    wait = C.SDL_SYSTEM_CURSOR_WAIT,
+    wait = c.SDL_SYSTEM_CURSOR_WAIT,
     /// Crosshair.
-    crosshair = C.SDL_SYSTEM_CURSOR_CROSSHAIR,
+    crosshair = c.SDL_SYSTEM_CURSOR_CROSSHAIR,
     /// Program is busy but still interactive. Usually it's `mouse.SystemCursor.wait` with an arrow.
-    progress = C.SDL_SYSTEM_CURSOR_PROGRESS,
+    progress = c.SDL_SYSTEM_CURSOR_PROGRESS,
     /// Double arrow pointing northwest and southeast.
-    northwest_southeast_resize = C.SDL_SYSTEM_CURSOR_NWSE_RESIZE,
+    northwest_southeast_resize = c.SDL_SYSTEM_CURSOR_NWSE_RESIZE,
     /// Double arrow pointing northeast and southwest.
-    northeast_southwest_resize = C.SDL_SYSTEM_CURSOR_NESW_RESIZE,
+    northeast_southwest_resize = c.SDL_SYSTEM_CURSOR_NESW_RESIZE,
     /// Double arrow pointing west and east.
-    east_west_resize = C.SDL_SYSTEM_CURSOR_EW_RESIZE,
+    east_west_resize = c.SDL_SYSTEM_CURSOR_EW_RESIZE,
     /// Double arrow pointing north and south.
-    north_south_resize = C.SDL_SYSTEM_CURSOR_NS_RESIZE,
+    north_south_resize = c.SDL_SYSTEM_CURSOR_NS_RESIZE,
     /// Four pointed arrow pointing north, south, east, and west.
-    move = C.SDL_SYSTEM_CURSOR_MOVE,
+    move = c.SDL_SYSTEM_CURSOR_MOVE,
     /// Not permitted. Usually a slashed circle or crossbones.
-    not_allowed = C.SDL_SYSTEM_CURSOR_NOT_ALLOWED,
+    not_allowed = c.SDL_SYSTEM_CURSOR_NOT_ALLOWED,
     /// Pointer that indicates a link. Usually a pointing hand.
-    pointer = C.SDL_SYSTEM_CURSOR_POINTER,
+    pointer = c.SDL_SYSTEM_CURSOR_POINTER,
     /// Window resize top-left. This may be a single arrow or a double arrow like `mouse.SystemCursor.resize`.
-    north_west_resize = C.SDL_SYSTEM_CURSOR_NW_RESIZE,
+    north_west_resize = c.SDL_SYSTEM_CURSOR_NW_RESIZE,
     /// Window resize top. May be `mouse.SystemCursor.north_south_resize`.
-    north_resize = C.SDL_SYSTEM_CURSOR_N_RESIZE,
+    north_resize = c.SDL_SYSTEM_CURSOR_N_RESIZE,
     /// Window resize top-right. May be `mouse.SystemCursor.northeast_southwest_resize`.
-    north_east_resize = C.SDL_SYSTEM_CURSOR_NE_RESIZE,
+    north_east_resize = c.SDL_SYSTEM_CURSOR_NE_RESIZE,
     /// Window resize right. May be `mouse.SystemCursor.east_west_resize`.
-    east_resize = C.SDL_SYSTEM_CURSOR_E_RESIZE,
+    east_resize = c.SDL_SYSTEM_CURSOR_E_RESIZE,
     /// Window resize bottom-right. May be `mouse.SystemCursor.northwest_southeast_resize`.
-    southeast_resize = C.SDL_SYSTEM_CURSOR_SE_RESIZE,
+    southeast_resize = c.SDL_SYSTEM_CURSOR_SE_RESIZE,
     /// Window resize bottom. May be `mouse.SystemCursor.north_south_resize`.
-    south_resize = C.SDL_SYSTEM_CURSOR_S_RESIZE,
+    south_resize = c.SDL_SYSTEM_CURSOR_S_RESIZE,
     /// Window resize bottom-left. May be `mouse.SystemCursor.northeast_southwest_resize`.
-    southwest_resize = C.SDL_SYSTEM_CURSOR_SW_RESIZE,
+    southwest_resize = c.SDL_SYSTEM_CURSOR_SW_RESIZE,
     /// Window resize left. May be `mouse.SystemCursor.east_west_resize`.
-    west_resize = C.SDL_SYSTEM_CURSOR_W_RESIZE,
+    west_resize = c.SDL_SYSTEM_CURSOR_W_RESIZE,
 };
 
 /// Scroll direction types for the `events.Type.scroll` event.
@@ -202,7 +202,7 @@ pub const WheelDirection = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Cursor = packed struct {
-    value: *C.SDL_Cursor,
+    value: *c.SDL_Cursor,
 
     /// Free a previously-created cursor.
     ///
@@ -222,7 +222,7 @@ pub const Cursor = packed struct {
     pub fn deinit(
         self: Cursor,
     ) void {
-        C.SDL_DestroyCursor(self.value);
+        c.SDL_DestroyCursor(self.value);
     }
 
     /// Create a cursor using the specified bitmap data and mask (in MSB format).
@@ -272,7 +272,7 @@ pub const Cursor = packed struct {
         hot_x: usize,
         hot_y: usize,
     ) !Cursor {
-        return .{ .value = try errors.wrapNull(*C.SDL_Cursor, C.SDL_CreateCursor(
+        return .{ .value = try errors.wrapNull(*c.SDL_Cursor, c.SDL_CreateCursor(
             data,
             mask,
             @intCast(width),
@@ -315,7 +315,7 @@ pub const Cursor = packed struct {
         hot_x: usize,
         hot_y: usize,
     ) !Cursor {
-        return .{ .value = try errors.wrapNull(*C.SDL_Cursor, C.SDL_CreateColorCursor(
+        return .{ .value = try errors.wrapNull(*c.SDL_Cursor, c.SDL_CreateColorCursor(
             cursor_surface.value,
             @intCast(hot_x),
             @intCast(hot_y),
@@ -345,8 +345,8 @@ pub const Cursor = packed struct {
         id: SystemCursor,
     ) !Cursor {
         return .{ .value = try errors.wrapNull(
-            *C.SDL_Cursor,
-            C.SDL_CreateSystemCursor(@intFromEnum(id)),
+            *c.SDL_Cursor,
+            c.SDL_CreateSystemCursor(@intFromEnum(id)),
         ) };
     }
 };
@@ -391,7 +391,7 @@ pub const Cursor = packed struct {
 pub fn capture(
     enable: bool,
 ) !void {
-    return errors.wrapCallBool(C.SDL_CaptureMouse(enable));
+    return errors.wrapCallBool(c.SDL_CaptureMouse(enable));
 }
 
 /// Get the active cursor.
@@ -409,7 +409,7 @@ pub fn capture(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn get() ?Cursor {
-    const ret = C.SDL_GetCursor();
+    const ret = c.SDL_GetCursor();
     if (ret) |val| {
         return .{ .value = val };
     }
@@ -431,7 +431,7 @@ pub fn get() ?Cursor {
 /// This function is available since SDL 3.2.0.
 pub fn getDefault() !Cursor {
     return .{
-        .value = try errors.wrapNull(*C.SDL_Cursor, C.SDL_GetDefaultCursor()),
+        .value = try errors.wrapNull(*c.SDL_Cursor, c.SDL_GetDefaultCursor()),
     };
 }
 
@@ -446,7 +446,7 @@ pub fn getDefault() !Cursor {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getFocus() ?video.Window {
-    if (C.SDL_GetMouseFocus()) |val| {
+    if (c.SDL_GetMouseFocus()) |val| {
         return .{
             .value = val,
         };
@@ -478,7 +478,7 @@ pub fn getFocus() ?video.Window {
 pub fn getGlobalState() struct { flags: ButtonFlags, x: f32, y: f32 } {
     var x: f32 = undefined;
     var y: f32 = undefined;
-    const flags = C.SDL_GetGlobalMouseState(&x, &y);
+    const flags = c.SDL_GetGlobalMouseState(&x, &y);
     return .{
         .flags = ButtonFlags.fromSdl(flags),
         .x = x,
@@ -503,7 +503,7 @@ pub fn getGlobalState() struct { flags: ButtonFlags, x: f32, y: f32 } {
 /// This function is available since SDL 3.2.0.
 pub fn getMice() ![]ID {
     var len: c_int = undefined;
-    const val = C.SDL_GetMice(&len);
+    const val = c.SDL_GetMice(&len);
     const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(u32, val));
     return ret[0..@intCast(len)];
 }
@@ -533,7 +533,7 @@ pub fn getMice() ![]ID {
 pub fn getRelativeState() struct { flags: ButtonFlags, x: f32, y: f32 } {
     var x: f32 = undefined;
     var y: f32 = undefined;
-    const flags = C.SDL_GetRelativeMouseState(&x, &y);
+    const flags = c.SDL_GetRelativeMouseState(&x, &y);
     return .{
         .flags = ButtonFlags.fromSdl(flags),
         .x = x,
@@ -562,7 +562,7 @@ pub fn getRelativeState() struct { flags: ButtonFlags, x: f32, y: f32 } {
 pub fn getState() struct { flags: ButtonFlags, x: f32, y: f32 } {
     var x: f32 = undefined;
     var y: f32 = undefined;
-    const flags = C.SDL_GetMouseState(&x, &y);
+    const flags = c.SDL_GetMouseState(&x, &y);
     return .{
         .flags = ButtonFlags.fromSdl(flags),
         .x = x,
@@ -586,7 +586,7 @@ pub fn getState() struct { flags: ButtonFlags, x: f32, y: f32 } {
 pub fn getWindowGrab(
     window: video.Window,
 ) bool {
-    return C.SDL_GetWindowMouseGrab(window.value);
+    return c.SDL_GetWindowMouseGrab(window.value);
 }
 
 /// Get the mouse confinement rectangle of a window
@@ -605,7 +605,7 @@ pub fn getWindowGrab(
 pub fn getWindowRect(
     window: video.Window,
 ) ?rect.IRect {
-    const ret = C.SDL_GetWindowMouseRect(window.value);
+    const ret = c.SDL_GetWindowMouseRect(window.value);
     if (ret) |val| {
         return rect.IRect.fromSdl(val.*);
     }
@@ -628,7 +628,7 @@ pub fn getWindowRect(
 pub fn getWindowRelativeMode(
     window: video.Window,
 ) bool {
-    return C.SDL_GetWindowRelativeMouseMode(window.value);
+    return c.SDL_GetWindowRelativeMouseMode(window.value);
 }
 
 /// Return whether a mouse is currently connected.
@@ -642,7 +642,7 @@ pub fn getWindowRelativeMode(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn has() bool {
-    return C.SDL_HasMouse();
+    return c.SDL_HasMouse();
 }
 
 /// Hide the cursor.
@@ -653,7 +653,7 @@ pub fn has() bool {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn hide() !void {
-    return errors.wrapCallBool(C.SDL_HideCursor());
+    return errors.wrapCallBool(c.SDL_HideCursor());
 }
 
 /// Set the active cursor.
@@ -674,7 +674,7 @@ pub fn hide() !void {
 pub fn set(
     cursor: ?Cursor,
 ) !void {
-    return errors.wrapCallBool(C.SDL_SetCursor(if (cursor) |val| val.value else null));
+    return errors.wrapCallBool(c.SDL_SetCursor(if (cursor) |val| val.value else null));
 }
 
 // TODO: ADD THIS WHEN SDL IS UPDATED!
@@ -697,7 +697,7 @@ pub fn set(
 //     callback: MotionTransformCallback,
 //     user_data: ?*anyopaque,
 // ) !void {
-//     return errors.wrapCallBool(C.SDL_SetRelativeMouseTransform(callback, user_data));
+//     return errors.wrapCallBool(c.SDL_SetRelativeMouseTransform(callback, user_data));
 // }
 
 /// Set a window's mouse grab mode.
@@ -718,7 +718,7 @@ pub fn setWindowGrab(
     window: video.Window,
     grabbed: bool,
 ) !void {
-    return errors.wrapCallBool(C.SDL_SetWindowMouseGrab(window.value, grabbed));
+    return errors.wrapCallBool(c.SDL_SetWindowMouseGrab(window.value, grabbed));
 }
 
 /// Confines the cursor to the specified area of a window.
@@ -741,9 +741,9 @@ pub fn setWindowRect(
 ) !void {
     if (area) |val| {
         const c_val = val.toSdl();
-        return errors.wrapCallBool(C.SDL_SetWindowMouseRect(window.value, &c_val));
+        return errors.wrapCallBool(c.SDL_SetWindowMouseRect(window.value, &c_val));
     }
-    return errors.wrapCallBool(C.SDL_SetWindowMouseRect(window.value, null));
+    return errors.wrapCallBool(c.SDL_SetWindowMouseRect(window.value, null));
 }
 
 /// Set relative mouse mode for a window.
@@ -770,7 +770,7 @@ pub fn setWindowRelativeMode(
     window: video.Window,
     enabled: bool,
 ) !void {
-    return errors.wrapCallBool(C.SDL_SetWindowRelativeMouseMode(window.value, enabled));
+    return errors.wrapCallBool(c.SDL_SetWindowRelativeMouseMode(window.value, enabled));
 }
 
 /// Show the cursor.
@@ -781,7 +781,7 @@ pub fn setWindowRelativeMode(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn show() !void {
-    return errors.wrapCallBool(C.SDL_ShowCursor());
+    return errors.wrapCallBool(c.SDL_ShowCursor());
 }
 
 /// Return whether the cursor is currently being shown.
@@ -795,7 +795,7 @@ pub fn show() !void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn visible() bool {
-    return C.SDL_CursorVisible();
+    return c.SDL_CursorVisible();
 }
 
 /// Move the mouse to the given position in global screen space.
@@ -820,7 +820,7 @@ pub fn warpGlobal(
     x: f32,
     y: f32,
 ) !void {
-    return errors.wrapCallBool(C.SDL_WarpMouseGlobal(x, y));
+    return errors.wrapCallBool(c.SDL_WarpMouseGlobal(x, y));
 }
 
 /// Move the mouse cursor to the given position within the window.
@@ -846,7 +846,7 @@ pub fn warpInWindow(
     x: f32,
     y: f32,
 ) void {
-    C.SDL_WarpMouseInWindow(if (window) |val| val.value else null, x, y);
+    c.SDL_WarpMouseInWindow(if (window) |val| val.value else null, x, y);
 }
 
 // Mouse related tests.

--- a/src/pen.zig
+++ b/src/pen.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// Pen axis indices.
@@ -16,19 +16,19 @@ const std = @import("std");
 /// This enum is available since SDL 3.2.0.
 pub const Axis = enum(c_uint) {
     /// Pen pressure. Unidirectional 0 to 1.0
-    pressure = C.SDL_PEN_AXIS_PRESSURE,
+    pressure = c.SDL_PEN_AXIS_PRESSURE,
     /// Pen horizontal tilt angle. Bidirectional -90.0 to 90.0 (left-to-right).
-    x_tilt = C.SDL_PEN_AXIS_XTILT,
+    x_tilt = c.SDL_PEN_AXIS_XTILT,
     /// Pen vertical tilt angle. Bidirectional -90.0 to 90.0 (top-to-down).
-    y_tilt = C.SDL_PEN_AXIS_YTILT,
+    y_tilt = c.SDL_PEN_AXIS_YTILT,
     /// Pen distance to drawing surface. Unidirectional 0.0 to 1.0.
-    distance = C.SDL_PEN_AXIS_DISTANCE,
+    distance = c.SDL_PEN_AXIS_DISTANCE,
     /// Pen barrel rotation. Bidirectional -180 to 179.9 (clockwise, 0 is facing up, -180.0 is facing down).
-    rotation = C.SDL_PEN_AXIS_ROTATION,
+    rotation = c.SDL_PEN_AXIS_ROTATION,
     /// Pen finger wheel or slider (e.g., Airbrush Pen). Unidirectional 0 to 1.0.
-    slider = C.SDL_PEN_AXIS_SLIDER,
+    slider = c.SDL_PEN_AXIS_SLIDER,
     /// Pressure from squeezing the pen (barrel pressure).
-    tangential_pressure = C.SDL_PEN_AXIS_TANGENTIAL_PRESSURE,
+    tangential_pressure = c.SDL_PEN_AXIS_TANGENTIAL_PRESSURE,
 };
 
 /// SDL pen instance IDs.
@@ -40,11 +40,11 @@ pub const Axis = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_PenID,
+    value: c.SDL_PenID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_PenID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_PenID) == @sizeOf(ID));
     }
 };
 
@@ -69,27 +69,27 @@ pub const InputFlags = struct {
     eraser_tip: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_PenInputFlags) InputFlags {
+    pub fn fromSdl(flags: c.SDL_PenInputFlags) InputFlags {
         return .{
-            .down = (flags & C.SDL_PEN_INPUT_DOWN) != 0,
-            .button1 = (flags & C.SDL_PEN_INPUT_BUTTON_1) != 0,
-            .button2 = (flags & C.SDL_PEN_INPUT_BUTTON_2) != 0,
-            .button3 = (flags & C.SDL_PEN_INPUT_BUTTON_3) != 0,
-            .button4 = (flags & C.SDL_PEN_INPUT_BUTTON_4) != 0,
-            .button5 = (flags & C.SDL_PEN_INPUT_BUTTON_5) != 0,
-            .eraser_tip = (flags & C.SDL_PEN_INPUT_ERASER_TIP) != 0,
+            .down = (flags & c.SDL_PEN_INPUT_DOWN) != 0,
+            .button1 = (flags & c.SDL_PEN_INPUT_BUTTON_1) != 0,
+            .button2 = (flags & c.SDL_PEN_INPUT_BUTTON_2) != 0,
+            .button3 = (flags & c.SDL_PEN_INPUT_BUTTON_3) != 0,
+            .button4 = (flags & c.SDL_PEN_INPUT_BUTTON_4) != 0,
+            .button5 = (flags & c.SDL_PEN_INPUT_BUTTON_5) != 0,
+            .eraser_tip = (flags & c.SDL_PEN_INPUT_ERASER_TIP) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: InputFlags) C.SDL_PenInputFlags {
-        return (if (self.down) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_DOWN) else 0) |
-            (if (self.button1) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_BUTTON_1) else 0) |
-            (if (self.button2) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_BUTTON_2) else 0) |
-            (if (self.button3) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_BUTTON_3) else 0) |
-            (if (self.button4) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_BUTTON_4) else 0) |
-            (if (self.button5) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_BUTTON_5) else 0) |
-            (if (self.eraser_tip) @as(C.SDL_PenInputFlags, C.SDL_PEN_INPUT_ERASER_TIP) else 0) |
+    pub fn toSdl(self: InputFlags) c.SDL_PenInputFlags {
+        return (if (self.down) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_DOWN) else 0) |
+            (if (self.button1) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_BUTTON_1) else 0) |
+            (if (self.button2) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_BUTTON_2) else 0) |
+            (if (self.button3) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_BUTTON_3) else 0) |
+            (if (self.button4) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_BUTTON_4) else 0) |
+            (if (self.button5) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_BUTTON_5) else 0) |
+            (if (self.eraser_tip) @as(c.SDL_PenInputFlags, c.SDL_PEN_INPUT_ERASER_TIP) else 0) |
             0;
     }
 };

--- a/src/pixels.zig
+++ b/src/pixels.zig
@@ -700,10 +700,10 @@ pub const Format = struct {
     /// Define a format using 4 characters (Ex: YV12).
     ///
     /// ## Function Parameters
-    /// * `a`: The first character of the FourCC code.
-    /// * `b`: The second character of the FourCC code.
-    /// * `c`: The third character of the FourCC code.
-    /// * `d`: The fourth character of the FourCC code.
+    /// * `c1`: The first character of the FourCC code.
+    /// * `c2`: The second character of the FourCC code.
+    /// * `c3`: The third character of the FourCC code.
+    /// * `c4`: The fourth character of the FourCC code.
     ///
     /// ## Return Value
     /// Return a pixel format.

--- a/src/pixels.zig
+++ b/src/pixels.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const surface = @import("surface.zig");
@@ -32,25 +32,25 @@ pub const alpha_transparent_float: f32 = 0;
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const ArrayOrder = enum(c_uint) {
-    rgb = C.SDL_ARRAYORDER_RGB,
-    rgba = C.SDL_ARRAYORDER_RGBA,
-    argb = C.SDL_ARRAYORDER_ARGB,
-    bgr = C.SDL_ARRAYORDER_BGR,
-    bgra = C.SDL_ARRAYORDER_BGRA,
-    abgr = C.SDL_ARRAYORDER_ABGR,
+    rgb = c.SDL_ARRAYORDER_RGB,
+    rgba = c.SDL_ARRAYORDER_RGBA,
+    argb = c.SDL_ARRAYORDER_ARGB,
+    bgr = c.SDL_ARRAYORDER_BGR,
+    bgra = c.SDL_ARRAYORDER_BGRA,
+    abgr = c.SDL_ARRAYORDER_ABGR,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_ArrayOrder) ?ArrayOrder {
-        if (value == C.SDL_ARRAYORDER_NONE)
+    pub fn fromSdl(value: c.SDL_ArrayOrder) ?ArrayOrder {
+        if (value == c.SDL_ARRAYORDER_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?ArrayOrder) C.SDL_ArrayOrder {
+    pub fn toSdl(self: ?ArrayOrder) c.SDL_ArrayOrder {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_ARRAYORDER_NONE;
+        return c.SDL_ARRAYORDER_NONE;
     }
 };
 
@@ -59,21 +59,21 @@ pub const ArrayOrder = enum(c_uint) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const BitmapOrder = enum(c_uint) {
-    high_to_low = C.SDL_BITMAPORDER_4321,
-    low_to_high = C.SDL_BITMAPORDER_1234,
+    high_to_low = c.SDL_BITMAPORDER_4321,
+    low_to_high = c.SDL_BITMAPORDER_1234,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_BitmapOrder) ?BitmapOrder {
-        if (value == C.SDL_BITMAPORDER_NONE)
+    pub fn fromSdl(value: c.SDL_BitmapOrder) ?BitmapOrder {
+        if (value == c.SDL_BITMAPORDER_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?BitmapOrder) C.SDL_BitmapOrder {
+    pub fn toSdl(self: ?BitmapOrder) c.SDL_BitmapOrder {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_BITMAPORDER_NONE;
+        return c.SDL_BITMAPORDER_NONE;
     }
 };
 
@@ -84,25 +84,25 @@ pub const BitmapOrder = enum(c_uint) {
 pub const ChromaLocation = enum(c_uint) {
     /// In MPEG-2, MPEG-4, and AVC, Cb and Cr are taken on midpoint of the left-edge of the 2x2 square.
     /// In other words, they have the same horizontal location as the top-left pixel, but is shifted one-half pixel down vertically.
-    left = C.SDL_CHROMA_LOCATION_LEFT,
+    left = c.SDL_CHROMA_LOCATION_LEFT,
     /// In JPEG/JFIF, H.261, and MPEG-1, Cb and Cr are taken at the center of the 2x2 square.
     /// In other words, they are offset one-half pixel to the right and one-half pixel down compared to the top-left pixel.
-    center = C.SDL_CHROMA_LOCATION_CENTER,
+    center = c.SDL_CHROMA_LOCATION_CENTER,
     /// In HEVC for BT.2020 and BT.2100 content (in particular on Blu-rays), Cb and Cr are sampled at the same location as the group's top-left Y pixel (co-sited, co-located).
-    top_left = C.SDL_CHROMA_LOCATION_TOPLEFT,
+    top_left = c.SDL_CHROMA_LOCATION_TOPLEFT,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_ChromaLocation) ?ChromaLocation {
-        if (value == C.SDL_CHROMA_LOCATION_NONE)
+    pub fn fromSdl(value: c.SDL_ChromaLocation) ?ChromaLocation {
+        if (value == c.SDL_CHROMA_LOCATION_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?ChromaLocation) C.SDL_ChromaLocation {
+    pub fn toSdl(self: ?ChromaLocation) c.SDL_ChromaLocation {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_CHROMA_LOCATION_NONE;
+        return c.SDL_CHROMA_LOCATION_NONE;
     }
 };
 
@@ -114,7 +114,7 @@ pub const ChromaLocation = enum(c_uint) {
 ///
 /// ## Version
 /// This struct is available since SDL 3.2.0.
-pub const Color = C.SDL_Color;
+pub const Color = c.SDL_Color;
 
 /// Colorspace definitions.
 /// How these are formed can be seen at: https://wiki.libsdl.org/SDL3/SDL_Colorspace
@@ -128,30 +128,30 @@ pub const Color = C.SDL_Color;
 pub const Colorspace = struct {
     value: u32,
     /// sRGB is a gamma corrected colorspace, and the default colorspace for SDL rendering and 8-bit RGB surfaces.
-    pub const srgb = Colorspace{ .value = C.SDL_COLORSPACE_SRGB };
+    pub const srgb = Colorspace{ .value = c.SDL_COLORSPACE_SRGB };
     /// This is a linear colorspace and the default colorspace for floating point surfaces.
     /// On Windows this is the scRGB colorspace, and on Apple platforms this is `kCGColorSpaceExtendedLinearSRGB` for EDR content.
-    pub const srgb_linear = Colorspace{ .value = C.SDL_COLORSPACE_SRGB_LINEAR };
+    pub const srgb_linear = Colorspace{ .value = c.SDL_COLORSPACE_SRGB_LINEAR };
     /// HDR10 is a non-linear HDR colorspace and the default colorspace for 10-bit surfaces.
-    pub const hdr10 = Colorspace{ .value = C.SDL_COLORSPACE_HDR10 };
+    pub const hdr10 = Colorspace{ .value = c.SDL_COLORSPACE_HDR10 };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_FULL_G22_NONE_P709_X601`.
-    pub const jpeg = Colorspace{ .value = C.SDL_COLORSPACE_JPEG };
+    pub const jpeg = Colorspace{ .value = c.SDL_COLORSPACE_JPEG };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P601`.
-    pub const bt601_limited = Colorspace{ .value = C.SDL_COLORSPACE_BT601_LIMITED };
+    pub const bt601_limited = Colorspace{ .value = c.SDL_COLORSPACE_BT601_LIMITED };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P601`.
-    pub const bt601_full = Colorspace{ .value = C.SDL_COLORSPACE_BT601_FULL };
+    pub const bt601_full = Colorspace{ .value = c.SDL_COLORSPACE_BT601_FULL };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P709`.
-    pub const bt709_limited = Colorspace{ .value = C.SDL_COLORSPACE_BT709_LIMITED };
+    pub const bt709_limited = Colorspace{ .value = c.SDL_COLORSPACE_BT709_LIMITED };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P709`.
-    pub const bt709_full = Colorspace{ .value = C.SDL_COLORSPACE_BT709_FULL };
+    pub const bt709_full = Colorspace{ .value = c.SDL_COLORSPACE_BT709_FULL };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020`.
-    pub const bt2020_limited = Colorspace{ .value = C.SDL_COLORSPACE_BT2020_LIMITED };
+    pub const bt2020_limited = Colorspace{ .value = c.SDL_COLORSPACE_BT2020_LIMITED };
     /// Equivalent to `DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P2020`.
-    pub const bt2020_full = Colorspace{ .value = C.SDL_COLORSPACE_BT2020_FULL };
+    pub const bt2020_full = Colorspace{ .value = c.SDL_COLORSPACE_BT2020_FULL };
     /// The default colorspace for RGB surfaces if no colorspace is specified.
-    pub const rgb_default = Colorspace{ .value = C.SDL_COLORSPACE_RGB_DEFAULT };
+    pub const rgb_default = Colorspace{ .value = c.SDL_COLORSPACE_RGB_DEFAULT };
     /// The default colorspace for YUV surfaces if no colorspace is specified.
-    pub const yuv_default = Colorspace{ .value = C.SDL_COLORSPACE_YUV_DEFAULT };
+    pub const yuv_default = Colorspace{ .value = c.SDL_COLORSPACE_YUV_DEFAULT };
 
     /// Create a colorspace.
     ///
@@ -193,7 +193,7 @@ pub const Colorspace = struct {
         matrix: MatrixCoefficients,
         chroma: ?ChromaLocation,
     ) Colorspace {
-        const ret = C.SDL_DEFINE_COLORSPACE(
+        const ret = c.SDL_DEFINE_COLORSPACE(
             ColorType.toSdl(color_type),
             ColorRange.toSdl(range),
             ColorPrimaries.toSdl(primaries),
@@ -217,7 +217,7 @@ pub const Colorspace = struct {
     pub fn getChromaLocation(
         self: Colorspace,
     ) ?ChromaLocation {
-        const ret = C.SDL_COLORSPACECHROMA(
+        const ret = c.SDL_COLORSPACECHROMA(
             self.value,
         );
         return ChromaLocation.fromSdl(ret);
@@ -236,7 +236,7 @@ pub const Colorspace = struct {
     pub fn getColorPrimaries(
         self: Colorspace,
     ) ?ColorPrimaries {
-        const ret = C.SDL_COLORSPACEPRIMARIES(
+        const ret = c.SDL_COLORSPACEPRIMARIES(
             self.value,
         );
         return ColorPrimaries.fromSdl(ret);
@@ -258,7 +258,7 @@ pub const Colorspace = struct {
     pub fn getMatrix(
         self: Colorspace,
     ) MatrixCoefficients {
-        const ret = C.SDL_COLORSPACEMATRIX(
+        const ret = c.SDL_COLORSPACEMATRIX(
             self.value,
         );
         return @enumFromInt(ret);
@@ -280,7 +280,7 @@ pub const Colorspace = struct {
     pub fn getRange(
         self: Colorspace,
     ) ?ColorRange {
-        const ret = C.SDL_COLORSPACERANGE(
+        const ret = c.SDL_COLORSPACERANGE(
             self.value,
         );
         return ColorRange.fromSdl(ret);
@@ -302,7 +302,7 @@ pub const Colorspace = struct {
     pub fn getTransferCharacteristics(
         self: Colorspace,
     ) ?TransferCharacteristics {
-        const ret = C.SDL_COLORSPACETRANSFER(
+        const ret = c.SDL_COLORSPACETRANSFER(
             self.value,
         );
         return TransferCharacteristics.fromSdl(ret);
@@ -324,7 +324,7 @@ pub const Colorspace = struct {
     pub fn getType(
         self: Colorspace,
     ) ?ColorType {
-        const ret = C.SDL_COLORSPACETYPE(
+        const ret = c.SDL_COLORSPACETYPE(
             self.value,
         );
         return ColorType.fromSdl(ret);
@@ -346,7 +346,7 @@ pub const Colorspace = struct {
     pub fn isMatrixBt2020Ncl(
         self: Colorspace,
     ) bool {
-        const ret = C.SDL_ISCOLORSPACE_MATRIX_BT2020_NCL(
+        const ret = c.SDL_ISCOLORSPACE_MATRIX_BT2020_NCL(
             self.value,
         );
         return ret;
@@ -368,7 +368,7 @@ pub const Colorspace = struct {
     pub fn isMatrixBt601(
         self: Colorspace,
     ) bool {
-        const ret = C.SDL_ISCOLORSPACE_MATRIX_BT601(
+        const ret = c.SDL_ISCOLORSPACE_MATRIX_BT601(
             self.value,
         );
         return ret;
@@ -390,7 +390,7 @@ pub const Colorspace = struct {
     pub fn isMatrixBT709(
         self: Colorspace,
     ) bool {
-        const ret = C.SDL_ISCOLORSPACE_MATRIX_BT709(
+        const ret = c.SDL_ISCOLORSPACE_MATRIX_BT709(
             self.value,
         );
         return ret;
@@ -412,7 +412,7 @@ pub const Colorspace = struct {
     pub fn isFullRange(
         self: Colorspace,
     ) bool {
-        const ret = C.SDL_ISCOLORSPACE_FULL_RANGE(
+        const ret = c.SDL_ISCOLORSPACE_FULL_RANGE(
             self.value,
         );
         return ret;
@@ -434,7 +434,7 @@ pub const Colorspace = struct {
     pub fn isLimitedRange(
         self: Colorspace,
     ) bool {
-        const ret = C.SDL_ISCOLORSPACE_LIMITED_RANGE(
+        const ret = c.SDL_ISCOLORSPACE_LIMITED_RANGE(
             self.value,
         );
         return ret;
@@ -447,42 +447,42 @@ pub const Colorspace = struct {
 /// This enum is available since SDL 3.2.0.
 pub const ColorPrimaries = enum(c_uint) {
     /// ITU-R BT.709-6.
-    bt709 = C.SDL_COLOR_PRIMARIES_BT709,
-    unspecified = C.SDL_COLOR_PRIMARIES_UNSPECIFIED,
+    bt709 = c.SDL_COLOR_PRIMARIES_BT709,
+    unspecified = c.SDL_COLOR_PRIMARIES_UNSPECIFIED,
     /// ITU-R BT.470-6 System M.
-    bt470m = C.SDL_COLOR_PRIMARIES_BT470M,
+    bt470m = c.SDL_COLOR_PRIMARIES_BT470M,
     /// ITU-R BT.470-6 System B, G / ITU-R BT.601-7 625.
-    bt470bg = C.SDL_COLOR_PRIMARIES_BT470BG,
+    bt470bg = c.SDL_COLOR_PRIMARIES_BT470BG,
     /// ITU-R BT.601-7 525, SMPTE 170M.
-    bt601 = C.SDL_COLOR_PRIMARIES_BT601,
+    bt601 = c.SDL_COLOR_PRIMARIES_BT601,
     /// SMPTE 240M, functionally the same as SDL_COLOR_PRIMARIES_BT601.
-    smpte240 = C.SDL_COLOR_PRIMARIES_SMPTE240,
+    smpte240 = c.SDL_COLOR_PRIMARIES_SMPTE240,
     /// Generic film (color filters using Illuminant C).
-    generic_film = C.SDL_COLOR_PRIMARIES_GENERIC_FILM,
+    generic_film = c.SDL_COLOR_PRIMARIES_GENERIC_FILM,
     /// ITU-R BT.2020-2 / ITU-R BT.2100-0
-    bt2020 = C.SDL_COLOR_PRIMARIES_BT2020,
+    bt2020 = c.SDL_COLOR_PRIMARIES_BT2020,
     /// SMPTE ST 428-1SMPTE ST 428-1.
-    xyz = C.SDL_COLOR_PRIMARIES_XYZ,
+    xyz = c.SDL_COLOR_PRIMARIES_XYZ,
     /// SMPTE RP 431-2.
-    smpte431 = C.SDL_COLOR_PRIMARIES_SMPTE431,
+    smpte431 = c.SDL_COLOR_PRIMARIES_SMPTE431,
     /// SMPTE EG 432-1 / DCI P3.
-    smpte432 = C.SDL_COLOR_PRIMARIES_SMPTE432,
+    smpte432 = c.SDL_COLOR_PRIMARIES_SMPTE432,
     /// EBU Tech. 3213-E.
-    ebu3213 = C.SDL_COLOR_PRIMARIES_EBU3213,
-    custom = C.SDL_COLOR_PRIMARIES_CUSTOM,
+    ebu3213 = c.SDL_COLOR_PRIMARIES_EBU3213,
+    custom = c.SDL_COLOR_PRIMARIES_CUSTOM,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_ColorPrimaries) ?ColorPrimaries {
-        if (value == C.SDL_COLOR_PRIMARIES_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_ColorPrimaries) ?ColorPrimaries {
+        if (value == c.SDL_COLOR_PRIMARIES_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?ColorPrimaries) C.SDL_ColorPrimaries {
+    pub fn toSdl(self: ?ColorPrimaries) c.SDL_ColorPrimaries {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_COLOR_PRIMARIES_UNKNOWN;
+        return c.SDL_COLOR_PRIMARIES_UNKNOWN;
     }
 };
 
@@ -492,22 +492,22 @@ pub const ColorPrimaries = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const ColorRange = enum(c_uint) {
     /// Narrow range, e.g. 16-235 for 8-bit RGB and luma, and 16-240 for 8-bit chroma.
-    limited = C.SDL_COLOR_RANGE_LIMITED,
+    limited = c.SDL_COLOR_RANGE_LIMITED,
     /// Full range, e.g. 0-255 for 8-bit RGB and luma, and 1-255 for 8-bit chroma.
-    full = C.SDL_COLOR_RANGE_FULL,
+    full = c.SDL_COLOR_RANGE_FULL,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_ColorRange) ?ColorRange {
-        if (value == C.SDL_COLOR_RANGE_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_ColorRange) ?ColorRange {
+        if (value == c.SDL_COLOR_RANGE_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?ColorRange) C.SDL_ColorRange {
+    pub fn toSdl(self: ?ColorRange) c.SDL_ColorRange {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_COLOR_RANGE_UNKNOWN;
+        return c.SDL_COLOR_RANGE_UNKNOWN;
     }
 };
 
@@ -516,21 +516,21 @@ pub const ColorRange = enum(c_uint) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const ColorType = enum(c_uint) {
-    rgb = C.SDL_COLOR_TYPE_RGB,
-    ycbcr = C.SDL_COLOR_TYPE_YCBCR,
+    rgb = c.SDL_COLOR_TYPE_RGB,
+    ycbcr = c.SDL_COLOR_TYPE_YCBCR,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_ColorType) ?ColorType {
-        if (value == C.SDL_COLOR_TYPE_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_ColorType) ?ColorType {
+        if (value == c.SDL_COLOR_TYPE_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?ColorType) C.SDL_ColorType {
+    pub fn toSdl(self: ?ColorType) c.SDL_ColorType {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_COLOR_TYPE_UNKNOWN;
+        return c.SDL_COLOR_TYPE_UNKNOWN;
     }
 };
 
@@ -538,7 +538,7 @@ pub const ColorType = enum(c_uint) {
 ///
 /// ## Version
 /// This struct is available since SDL 3.2.0.
-pub const FColor = C.SDL_FColor;
+pub const FColor = c.SDL_FColor;
 
 /// Pixel format.
 ///
@@ -563,92 +563,92 @@ pub const FColor = C.SDL_FColor;
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Format = struct {
-    value: C.SDL_PixelFormat,
-    pub const index_1_lsb = Format{ .value = C.SDL_PIXELFORMAT_INDEX1LSB };
-    pub const index_1_msb = Format{ .value = C.SDL_PIXELFORMAT_INDEX1MSB };
-    pub const index_2_lsb = Format{ .value = C.SDL_PIXELFORMAT_INDEX2LSB };
-    pub const index_2_msb = Format{ .value = C.SDL_PIXELFORMAT_INDEX2MSB };
-    pub const index_4_lsb = Format{ .value = C.SDL_PIXELFORMAT_INDEX4LSB };
-    pub const index_4_msb = Format{ .value = C.SDL_PIXELFORMAT_INDEX4MSB };
-    pub const index_8 = Format{ .value = C.SDL_PIXELFORMAT_INDEX8 };
-    pub const packed_rgb_3_3_2 = Format{ .value = C.SDL_PIXELFORMAT_RGB332 };
-    pub const packed_xrgb_4_4_4_4 = Format{ .value = C.SDL_PIXELFORMAT_XRGB4444 };
-    pub const packed_xbgr_4_4_4_4 = Format{ .value = C.SDL_PIXELFORMAT_XBGR4444 };
-    pub const packed_xrgb_1_5_5_5 = Format{ .value = C.SDL_PIXELFORMAT_XRGB1555 };
-    pub const packed_xbgr_1_5_5_5 = Format{ .value = C.SDL_PIXELFORMAT_XBGR1555 };
-    pub const packed_argb_4_4_4_4 = Format{ .value = C.SDL_PIXELFORMAT_ARGB4444 };
-    pub const packed_rgba_4_4_4_4 = Format{ .value = C.SDL_PIXELFORMAT_RGBA4444 };
-    pub const packed_abgr_4_4_4_4 = Format{ .value = C.SDL_PIXELFORMAT_ABGR4444 };
-    pub const packed_bgra_4_4_4_4 = Format{ .value = C.SDL_PIXELFORMAT_BGRA4444 };
-    pub const packed_argb_1_5_5_5 = Format{ .value = C.SDL_PIXELFORMAT_ARGB1555 };
-    pub const packed_rgba_5_5_5_1 = Format{ .value = C.SDL_PIXELFORMAT_RGBA5551 };
-    pub const packed_abgr_1_5_5_5 = Format{ .value = C.SDL_PIXELFORMAT_ABGR1555 };
-    pub const packed_bgra_5_5_5_1 = Format{ .value = C.SDL_PIXELFORMAT_BGRA5551 };
-    pub const packed_rgb_5_6_5 = Format{ .value = C.SDL_PIXELFORMAT_RGB565 };
-    pub const packed_bgr_5_6_5 = Format{ .value = C.SDL_PIXELFORMAT_BGR565 };
-    pub const array_rgb_24 = Format{ .value = C.SDL_PIXELFORMAT_RGB24 };
-    pub const array_bgr_24 = Format{ .value = C.SDL_PIXELFORMAT_BGR24 };
-    pub const packed_xrgb_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_XRGB8888 };
-    pub const packed_rgbx_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_RGBX8888 };
-    pub const packed_xbgr_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_XBGR8888 };
-    pub const packed_bgrx_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_BGRX8888 };
-    pub const packed_argb_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_ARGB8888 };
-    pub const packed_rgba_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_RGBA8888 };
-    pub const packed_abgr_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_ABGR8888 };
-    pub const packed_bgra_8_8_8_8 = Format{ .value = C.SDL_PIXELFORMAT_BGRA8888 };
-    pub const packed_xrgb_2_10_10_10 = Format{ .value = C.SDL_PIXELFORMAT_XRGB2101010 };
-    pub const packed_xbgr_2_10_10_10 = Format{ .value = C.SDL_PIXELFORMAT_XBGR2101010 };
-    pub const packed_argb_2_10_10_10 = Format{ .value = C.SDL_PIXELFORMAT_ARGB2101010 };
-    pub const packed_abgr_2_10_10_10 = Format{ .value = C.SDL_PIXELFORMAT_ABGR2101010 };
-    pub const array_rgb_48 = Format{ .value = C.SDL_PIXELFORMAT_RGB48 };
-    pub const array_bgr_48 = Format{ .value = C.SDL_PIXELFORMAT_BGR48 };
-    pub const array_rgba_64 = Format{ .value = C.SDL_PIXELFORMAT_RGBA64 };
-    pub const array_argb_64 = Format{ .value = C.SDL_PIXELFORMAT_ARGB64 };
-    pub const array_bgra_64 = Format{ .value = C.SDL_PIXELFORMAT_BGRA64 };
-    pub const array_abgr_64 = Format{ .value = C.SDL_PIXELFORMAT_ABGR64 };
-    pub const array_rgb_48_float = Format{ .value = C.SDL_PIXELFORMAT_RGB48_FLOAT };
-    pub const array_bgr_48_float = Format{ .value = C.SDL_PIXELFORMAT_BGR48_FLOAT };
-    pub const array_rgba_64_float = Format{ .value = C.SDL_PIXELFORMAT_RGBA64_FLOAT };
-    pub const array_argb_64_float = Format{ .value = C.SDL_PIXELFORMAT_ARGB64_FLOAT };
-    pub const array_bgra_64_float = Format{ .value = C.SDL_PIXELFORMAT_BGRA64_FLOAT };
-    pub const array_abgr_64_float = Format{ .value = C.SDL_PIXELFORMAT_ABGR64_FLOAT };
-    pub const array_rgb_96_float = Format{ .value = C.SDL_PIXELFORMAT_RGB96_FLOAT };
-    pub const array_bgr_96_float = Format{ .value = C.SDL_PIXELFORMAT_BGR96_FLOAT };
-    pub const array_rgba_128_float = Format{ .value = C.SDL_PIXELFORMAT_RGBA128_FLOAT };
-    pub const array_argb_128_float = Format{ .value = C.SDL_PIXELFORMAT_ARGB128_FLOAT };
-    pub const array_bgra_128_float = Format{ .value = C.SDL_PIXELFORMAT_BGRA128_FLOAT };
-    pub const array_abgr_128_float = Format{ .value = C.SDL_PIXELFORMAT_ABGR128_FLOAT };
-    pub const fourcc_yv12 = Format{ .value = C.SDL_PIXELFORMAT_YV12 };
-    pub const fourcc_iyuv = Format{ .value = C.SDL_PIXELFORMAT_IYUV };
-    pub const fourcc_yuy2 = Format{ .value = C.SDL_PIXELFORMAT_YUY2 };
-    pub const fourcc_uyvy = Format{ .value = C.SDL_PIXELFORMAT_UYVY };
-    pub const fourcc_yvyu = Format{ .value = C.SDL_PIXELFORMAT_YVYU };
-    pub const fourcc_nv12 = Format{ .value = C.SDL_PIXELFORMAT_NV12 };
-    pub const fourcc_nv21 = Format{ .value = C.SDL_PIXELFORMAT_NV21 };
-    pub const fourcc_p010 = Format{ .value = C.SDL_PIXELFORMAT_P010 };
-    pub const fourcc_oes = Format{ .value = C.SDL_PIXELFORMAT_EXTERNAL_OES };
+    value: c.SDL_PixelFormat,
+    pub const index_1_lsb = Format{ .value = c.SDL_PIXELFORMAT_INDEX1LSB };
+    pub const index_1_msb = Format{ .value = c.SDL_PIXELFORMAT_INDEX1MSB };
+    pub const index_2_lsb = Format{ .value = c.SDL_PIXELFORMAT_INDEX2LSB };
+    pub const index_2_msb = Format{ .value = c.SDL_PIXELFORMAT_INDEX2MSB };
+    pub const index_4_lsb = Format{ .value = c.SDL_PIXELFORMAT_INDEX4LSB };
+    pub const index_4_msb = Format{ .value = c.SDL_PIXELFORMAT_INDEX4MSB };
+    pub const index_8 = Format{ .value = c.SDL_PIXELFORMAT_INDEX8 };
+    pub const packed_rgb_3_3_2 = Format{ .value = c.SDL_PIXELFORMAT_RGB332 };
+    pub const packed_xrgb_4_4_4_4 = Format{ .value = c.SDL_PIXELFORMAT_XRGB4444 };
+    pub const packed_xbgr_4_4_4_4 = Format{ .value = c.SDL_PIXELFORMAT_XBGR4444 };
+    pub const packed_xrgb_1_5_5_5 = Format{ .value = c.SDL_PIXELFORMAT_XRGB1555 };
+    pub const packed_xbgr_1_5_5_5 = Format{ .value = c.SDL_PIXELFORMAT_XBGR1555 };
+    pub const packed_argb_4_4_4_4 = Format{ .value = c.SDL_PIXELFORMAT_ARGB4444 };
+    pub const packed_rgba_4_4_4_4 = Format{ .value = c.SDL_PIXELFORMAT_RGBA4444 };
+    pub const packed_abgr_4_4_4_4 = Format{ .value = c.SDL_PIXELFORMAT_ABGR4444 };
+    pub const packed_bgra_4_4_4_4 = Format{ .value = c.SDL_PIXELFORMAT_BGRA4444 };
+    pub const packed_argb_1_5_5_5 = Format{ .value = c.SDL_PIXELFORMAT_ARGB1555 };
+    pub const packed_rgba_5_5_5_1 = Format{ .value = c.SDL_PIXELFORMAT_RGBA5551 };
+    pub const packed_abgr_1_5_5_5 = Format{ .value = c.SDL_PIXELFORMAT_ABGR1555 };
+    pub const packed_bgra_5_5_5_1 = Format{ .value = c.SDL_PIXELFORMAT_BGRA5551 };
+    pub const packed_rgb_5_6_5 = Format{ .value = c.SDL_PIXELFORMAT_RGB565 };
+    pub const packed_bgr_5_6_5 = Format{ .value = c.SDL_PIXELFORMAT_BGR565 };
+    pub const array_rgb_24 = Format{ .value = c.SDL_PIXELFORMAT_RGB24 };
+    pub const array_bgr_24 = Format{ .value = c.SDL_PIXELFORMAT_BGR24 };
+    pub const packed_xrgb_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_XRGB8888 };
+    pub const packed_rgbx_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_RGBX8888 };
+    pub const packed_xbgr_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_XBGR8888 };
+    pub const packed_bgrx_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_BGRX8888 };
+    pub const packed_argb_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_ARGB8888 };
+    pub const packed_rgba_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_RGBA8888 };
+    pub const packed_abgr_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_ABGR8888 };
+    pub const packed_bgra_8_8_8_8 = Format{ .value = c.SDL_PIXELFORMAT_BGRA8888 };
+    pub const packed_xrgb_2_10_10_10 = Format{ .value = c.SDL_PIXELFORMAT_XRGB2101010 };
+    pub const packed_xbgr_2_10_10_10 = Format{ .value = c.SDL_PIXELFORMAT_XBGR2101010 };
+    pub const packed_argb_2_10_10_10 = Format{ .value = c.SDL_PIXELFORMAT_ARGB2101010 };
+    pub const packed_abgr_2_10_10_10 = Format{ .value = c.SDL_PIXELFORMAT_ABGR2101010 };
+    pub const array_rgb_48 = Format{ .value = c.SDL_PIXELFORMAT_RGB48 };
+    pub const array_bgr_48 = Format{ .value = c.SDL_PIXELFORMAT_BGR48 };
+    pub const array_rgba_64 = Format{ .value = c.SDL_PIXELFORMAT_RGBA64 };
+    pub const array_argb_64 = Format{ .value = c.SDL_PIXELFORMAT_ARGB64 };
+    pub const array_bgra_64 = Format{ .value = c.SDL_PIXELFORMAT_BGRA64 };
+    pub const array_abgr_64 = Format{ .value = c.SDL_PIXELFORMAT_ABGR64 };
+    pub const array_rgb_48_float = Format{ .value = c.SDL_PIXELFORMAT_RGB48_FLOAT };
+    pub const array_bgr_48_float = Format{ .value = c.SDL_PIXELFORMAT_BGR48_FLOAT };
+    pub const array_rgba_64_float = Format{ .value = c.SDL_PIXELFORMAT_RGBA64_FLOAT };
+    pub const array_argb_64_float = Format{ .value = c.SDL_PIXELFORMAT_ARGB64_FLOAT };
+    pub const array_bgra_64_float = Format{ .value = c.SDL_PIXELFORMAT_BGRA64_FLOAT };
+    pub const array_abgr_64_float = Format{ .value = c.SDL_PIXELFORMAT_ABGR64_FLOAT };
+    pub const array_rgb_96_float = Format{ .value = c.SDL_PIXELFORMAT_RGB96_FLOAT };
+    pub const array_bgr_96_float = Format{ .value = c.SDL_PIXELFORMAT_BGR96_FLOAT };
+    pub const array_rgba_128_float = Format{ .value = c.SDL_PIXELFORMAT_RGBA128_FLOAT };
+    pub const array_argb_128_float = Format{ .value = c.SDL_PIXELFORMAT_ARGB128_FLOAT };
+    pub const array_bgra_128_float = Format{ .value = c.SDL_PIXELFORMAT_BGRA128_FLOAT };
+    pub const array_abgr_128_float = Format{ .value = c.SDL_PIXELFORMAT_ABGR128_FLOAT };
+    pub const fourcc_yv12 = Format{ .value = c.SDL_PIXELFORMAT_YV12 };
+    pub const fourcc_iyuv = Format{ .value = c.SDL_PIXELFORMAT_IYUV };
+    pub const fourcc_yuy2 = Format{ .value = c.SDL_PIXELFORMAT_YUY2 };
+    pub const fourcc_uyvy = Format{ .value = c.SDL_PIXELFORMAT_UYVY };
+    pub const fourcc_yvyu = Format{ .value = c.SDL_PIXELFORMAT_YVYU };
+    pub const fourcc_nv12 = Format{ .value = c.SDL_PIXELFORMAT_NV12 };
+    pub const fourcc_nv21 = Format{ .value = c.SDL_PIXELFORMAT_NV21 };
+    pub const fourcc_p010 = Format{ .value = c.SDL_PIXELFORMAT_P010 };
+    pub const fourcc_oes = Format{ .value = c.SDL_PIXELFORMAT_EXTERNAL_OES };
     // MJPG is in SDL 3.4.0?
-    pub const array_rgba_32 = Format{ .value = C.SDL_PIXELFORMAT_RGBA32 };
-    pub const array_argb_32 = Format{ .value = C.SDL_PIXELFORMAT_ARGB32 };
-    pub const array_bgra_32 = Format{ .value = C.SDL_PIXELFORMAT_BGRA32 };
-    pub const array_abgr_32 = Format{ .value = C.SDL_PIXELFORMAT_ABGR32 };
-    pub const array_rgbx_32 = Format{ .value = C.SDL_PIXELFORMAT_RGBX32 };
-    pub const array_xrgb_32 = Format{ .value = C.SDL_PIXELFORMAT_XRGB32 };
-    pub const array_bgrx_32 = Format{ .value = C.SDL_PIXELFORMAT_BGRX32 };
-    pub const array_xbgr_32 = Format{ .value = C.SDL_PIXELFORMAT_XBGR32 };
+    pub const array_rgba_32 = Format{ .value = c.SDL_PIXELFORMAT_RGBA32 };
+    pub const array_argb_32 = Format{ .value = c.SDL_PIXELFORMAT_ARGB32 };
+    pub const array_bgra_32 = Format{ .value = c.SDL_PIXELFORMAT_BGRA32 };
+    pub const array_abgr_32 = Format{ .value = c.SDL_PIXELFORMAT_ABGR32 };
+    pub const array_rgbx_32 = Format{ .value = c.SDL_PIXELFORMAT_RGBX32 };
+    pub const array_xrgb_32 = Format{ .value = c.SDL_PIXELFORMAT_XRGB32 };
+    pub const array_bgrx_32 = Format{ .value = c.SDL_PIXELFORMAT_BGRX32 };
+    pub const array_xbgr_32 = Format{ .value = c.SDL_PIXELFORMAT_XBGR32 };
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_PixelFormat) ?Format {
-        if (value == C.SDL_PIXELFORMAT_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_PixelFormat) ?Format {
+        if (value == c.SDL_PIXELFORMAT_UNKNOWN)
             return null;
         return .{ .value = value };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?Format) C.SDL_PixelFormat {
+    pub fn toSdl(self: ?Format) c.SDL_PixelFormat {
         if (self) |val|
             return val.value;
-        return C.SDL_PIXELFORMAT_UNKNOWN;
+        return c.SDL_PIXELFORMAT_UNKNOWN;
     }
 
     /// Define a pixel format.
@@ -687,7 +687,7 @@ pub const Format = struct {
         bits: u8,
         bytes: u8,
     ) Format {
-        const ret = C.SDL_DEFINE_PIXELFORMAT(
+        const ret = c.SDL_DEFINE_PIXELFORMAT(
             @intFromEnum(pixel_type),
             @intFromEnum(order),
             PackedLayout.toSdl(layout),
@@ -717,16 +717,16 @@ pub const Format = struct {
     /// ## Version
     /// This macro is available since SDL 3.2.0.
     pub fn define4CC(
-        a: u8,
-        b: u8,
-        c: u8,
-        d: u8,
+        c1: u8,
+        c2: u8,
+        c3: u8,
+        c4: u8,
     ) Format {
-        const ret = C.SDL_DEFINE_PIXELFOURCC(
-            @as(c_uint, @intCast(a)),
-            @as(c_uint, @intCast(b)),
-            @as(c_uint, @intCast(c)),
-            @as(c_uint, @intCast(d)),
+        const ret = c.SDL_DEFINE_PIXELFOURCC(
+            @as(c_uint, @intCast(c1)),
+            @as(c_uint, @intCast(c2)),
+            @as(c_uint, @intCast(c3)),
+            @as(c_uint, @intCast(c4)),
         );
         return Format{ .value = ret };
     }
@@ -767,7 +767,7 @@ pub const Format = struct {
         bits: u8,
         bytes: u8,
     ) Format {
-        const ret = C.SDL_DEFINE_PIXELFORMAT(
+        const ret = c.SDL_DEFINE_PIXELFORMAT(
             @as(c_int, @intCast(Type.toSdl(pixel_type))),
             @as(c_int, @intCast(order)),
             @as(c_int, @intCast(PackedLayout.toSdl(layout))),
@@ -801,7 +801,7 @@ pub const Format = struct {
         b_mask: u32,
         a_mask: u32,
     ) ?Format {
-        const ret = C.SDL_GetPixelFormatForMasks(
+        const ret = c.SDL_GetPixelFormatForMasks(
             @intCast(bpp),
             r_mask,
             g_mask,
@@ -830,7 +830,7 @@ pub const Format = struct {
     pub fn getBitsPerPixel(
         self: Format,
     ) u8 {
-        const ret = C.SDL_BITSPERPIXEL(
+        const ret = c.SDL_BITSPERPIXEL(
             @as(c_int, @intCast(self.value)),
         );
         return @intCast(ret);
@@ -855,7 +855,7 @@ pub const Format = struct {
     pub fn getBytesPerPixel(
         self: Format,
     ) u8 {
-        const ret = C.SDL_BYTESPERPIXEL(
+        const ret = c.SDL_BYTESPERPIXEL(
             @as(c_int, @intCast(self.value)),
         );
         return @intCast(ret);
@@ -877,10 +877,10 @@ pub const Format = struct {
     pub fn getDetails(
         self: Format,
     ) !FormatDetails {
-        const ret = try errors.wrapNull(*const C.SDL_PixelFormatDetails, C.SDL_GetPixelFormatDetails(
+        const ret = try errors.wrapNull(*const c.SDL_PixelFormatDetails, c.SDL_GetPixelFormatDetails(
             self.value,
         ));
-        return .{ .value = (try errors.wrapNull(*const C.SDL_PixelFormatDetails, ret)).* };
+        return .{ .value = (try errors.wrapNull(*const c.SDL_PixelFormatDetails, ret)).* };
     }
 
     /// If format was created by `define` rather than `define4CC`.
@@ -902,7 +902,7 @@ pub const Format = struct {
     pub fn getFlag(
         self: Format,
     ) bool {
-        const ret = C.SDL_PIXELFLAG(
+        const ret = c.SDL_PIXELFLAG(
             self.value,
         );
         return ret != 0;
@@ -924,7 +924,7 @@ pub const Format = struct {
     pub fn getLayout(
         self: Format,
     ) ?PackedLayout {
-        const ret = C.SDL_PIXELLAYOUT(
+        const ret = c.SDL_PIXELLAYOUT(
             self.value,
         );
         return PackedLayout.fromSdl(ret);
@@ -951,7 +951,7 @@ pub const Format = struct {
         var g_mask: u32 = undefined;
         var b_mask: u32 = undefined;
         var a_mask: u32 = undefined;
-        const ret = C.SDL_GetMasksForPixelFormat(
+        const ret = c.SDL_GetMasksForPixelFormat(
             self.value,
             &bpp,
             &r_mask,
@@ -979,7 +979,7 @@ pub const Format = struct {
     pub fn getName(
         self: Format,
     ) ?[:0]const u8 {
-        const ret = C.SDL_GetPixelFormatName(
+        const ret = c.SDL_GetPixelFormatName(
             self.value,
         );
         const converted_ret = std.mem.span(ret);
@@ -1001,7 +1001,7 @@ pub const Format = struct {
     pub fn getOrder(
         self: Format,
     ) c_uint {
-        const ret = C.SDL_PIXELORDER(
+        const ret = c.SDL_PIXELORDER(
             self.value,
         );
         return @bitCast(ret);
@@ -1023,7 +1023,7 @@ pub const Format = struct {
     pub fn getOrderTyped(
         self: Format,
     ) ?OrderType(self.getType().?) {
-        const ret = C.SDL_PIXELORDER(
+        const ret = c.SDL_PIXELORDER(
             self.value,
         );
         return OrderType(self.getType().?).fromSdl(ret);
@@ -1042,7 +1042,7 @@ pub const Format = struct {
     pub fn getType(
         self: Format,
     ) ?Type {
-        const ret = C.SDL_PIXELTYPE(
+        const ret = c.SDL_PIXELTYPE(
             self.value,
         );
         return Type.fromSdl(ret);
@@ -1085,7 +1085,7 @@ pub const Format = struct {
         self: Format,
     ) bool {
         const format = self.value;
-        return !(C.SDL_ISPIXELFORMAT_FOURCC(format)) and ((C.SDL_PIXELTYPE(format) == C.SDL_PIXELTYPE_PACKED32) and (C.SDL_PIXELLAYOUT(format) == C.SDL_PACKEDLAYOUT_2101010));
+        return !(c.SDL_ISPIXELFORMAT_FOURCC(format)) and ((c.SDL_PIXELTYPE(format) == c.SDL_PIXELTYPE_PACKED32) and (c.SDL_PIXELLAYOUT(format) == c.SDL_PACKEDLAYOUT_2101010));
     }
 
     /// If the format is 4cc.
@@ -1104,7 +1104,7 @@ pub const Format = struct {
     pub fn is4cc(
         self: Format,
     ) bool {
-        const ret = C.SDL_ISPIXELFORMAT_FOURCC(
+        const ret = c.SDL_ISPIXELFORMAT_FOURCC(
             self.value,
         );
         return ret;
@@ -1184,7 +1184,7 @@ pub const Format = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const FormatDetails = struct {
-    value: C.SDL_PixelFormatDetails,
+    value: c.SDL_PixelFormatDetails,
 
     /// Initialize the format details.
     ///
@@ -1261,7 +1261,7 @@ pub const FormatDetails = struct {
         var r: u8 = undefined;
         var g: u8 = undefined;
         var b: u8 = undefined;
-        C.SDL_GetRGB(
+        c.SDL_GetRGB(
             @intCast(pixel.value),
             &self.value,
             if (palette) |palette_val| palette_val.value else null,
@@ -1302,7 +1302,7 @@ pub const FormatDetails = struct {
         var g: u8 = undefined;
         var b: u8 = undefined;
         var a: u8 = undefined;
-        C.SDL_GetRGBA(
+        c.SDL_GetRGBA(
             @intCast(pixel.value),
             &self.value,
             if (palette) |palette_val| palette_val.value else null,
@@ -1393,7 +1393,7 @@ pub const FormatDetails = struct {
         g: u8,
         b: u8,
     ) Pixel {
-        const ret = C.SDL_MapRGB(
+        const ret = c.SDL_MapRGB(
             &self.value,
             if (palette) |palette_val| palette_val.value else null,
             r,
@@ -1439,7 +1439,7 @@ pub const FormatDetails = struct {
         b: u8,
         a: u8,
     ) Pixel {
-        const ret = C.SDL_MapRGBA(
+        const ret = c.SDL_MapRGBA(
             &self.value,
             if (palette) |palette_val| palette_val.value else null,
             r,
@@ -1459,30 +1459,30 @@ pub const FormatDetails = struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const MatrixCoefficients = enum(c_uint) {
-    identity = C.SDL_MATRIX_COEFFICIENTS_IDENTITY,
+    identity = c.SDL_MATRIX_COEFFICIENTS_IDENTITY,
     /// ITU-R BT.709-6.
-    bt709 = C.SDL_MATRIX_COEFFICIENTS_BT709,
-    unspecified = C.SDL_MATRIX_COEFFICIENTS_UNSPECIFIED,
+    bt709 = c.SDL_MATRIX_COEFFICIENTS_BT709,
+    unspecified = c.SDL_MATRIX_COEFFICIENTS_UNSPECIFIED,
     /// US FCC Title 47.
-    fcc = C.SDL_MATRIX_COEFFICIENTS_FCC,
+    fcc = c.SDL_MATRIX_COEFFICIENTS_FCC,
     /// ITU-R BT.470-6 System B, G / ITU-R BT.601-7 625, functionally the same as SDL_MATRIX_COEFFICIENTS_BT601.
-    bt470bg = C.SDL_MATRIX_COEFFICIENTS_BT470BG,
+    bt470bg = c.SDL_MATRIX_COEFFICIENTS_BT470BG,
     /// ITU-R BT.601-7 525.
-    bt601 = C.SDL_MATRIX_COEFFICIENTS_BT601,
+    bt601 = c.SDL_MATRIX_COEFFICIENTS_BT601,
     /// SMPTE 240M.
-    smpte240 = C.SDL_MATRIX_COEFFICIENTS_SMPTE240,
-    ycgco = C.SDL_MATRIX_COEFFICIENTS_YCGCO,
+    smpte240 = c.SDL_MATRIX_COEFFICIENTS_SMPTE240,
+    ycgco = c.SDL_MATRIX_COEFFICIENTS_YCGCO,
     /// ITU-R BT.2020-2 non-constant luminance.
-    bt2020_ncl = C.SDL_MATRIX_COEFFICIENTS_BT2020_NCL,
+    bt2020_ncl = c.SDL_MATRIX_COEFFICIENTS_BT2020_NCL,
     /// ITU-R BT.2020-2 constant luminance.
-    bt2020_cl = C.SDL_MATRIX_COEFFICIENTS_BT2020_CL,
+    bt2020_cl = c.SDL_MATRIX_COEFFICIENTS_BT2020_CL,
     /// SMPTE ST 2085.
-    smpte2085 = C.SDL_MATRIX_COEFFICIENTS_SMPTE2085,
-    chroma_derived_ncl = C.SDL_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
-    chroma_derived_cl = C.SDL_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL,
+    smpte2085 = c.SDL_MATRIX_COEFFICIENTS_SMPTE2085,
+    chroma_derived_ncl = c.SDL_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
+    chroma_derived_cl = c.SDL_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL,
     /// ITU-R BT.2100-0 ICTCP.
-    ictcp = C.SDL_MATRIX_COEFFICIENTS_ICTCP,
-    custom = C.SDL_MATRIX_COEFFICIENTS_CUSTOM,
+    ictcp = c.SDL_MATRIX_COEFFICIENTS_ICTCP,
+    custom = c.SDL_MATRIX_COEFFICIENTS_CUSTOM,
 };
 
 /// Packed component layout.
@@ -1490,27 +1490,27 @@ pub const MatrixCoefficients = enum(c_uint) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const PackedLayout = enum(c_uint) {
-    bit_3_3_2 = C.SDL_PACKEDLAYOUT_332,
-    bit_4_4_4_4 = C.SDL_PACKEDLAYOUT_4444,
-    bit_1_5_5_5 = C.SDL_PACKEDLAYOUT_1555,
-    bit_5_5_5_1 = C.SDL_PACKEDLAYOUT_5551,
-    bit_5_6_5 = C.SDL_PACKEDLAYOUT_565,
-    bit_8_8_8_8 = C.SDL_PACKEDLAYOUT_8888,
-    bit_2_10_10_10 = C.SDL_PACKEDLAYOUT_2101010,
-    bit_10_10_10_2 = C.SDL_PACKEDLAYOUT_1010102,
+    bit_3_3_2 = c.SDL_PACKEDLAYOUT_332,
+    bit_4_4_4_4 = c.SDL_PACKEDLAYOUT_4444,
+    bit_1_5_5_5 = c.SDL_PACKEDLAYOUT_1555,
+    bit_5_5_5_1 = c.SDL_PACKEDLAYOUT_5551,
+    bit_5_6_5 = c.SDL_PACKEDLAYOUT_565,
+    bit_8_8_8_8 = c.SDL_PACKEDLAYOUT_8888,
+    bit_2_10_10_10 = c.SDL_PACKEDLAYOUT_2101010,
+    bit_10_10_10_2 = c.SDL_PACKEDLAYOUT_1010102,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_PackedLayout) ?PackedLayout {
-        if (value == C.SDL_PACKEDLAYOUT_NONE)
+    pub fn fromSdl(value: c.SDL_PackedLayout) ?PackedLayout {
+        if (value == c.SDL_PACKEDLAYOUT_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?PackedLayout) C.SDL_PackedLayout {
+    pub fn toSdl(self: ?PackedLayout) c.SDL_PackedLayout {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_PACKEDLAYOUT_NONE;
+        return c.SDL_PACKEDLAYOUT_NONE;
     }
 };
 
@@ -1519,27 +1519,27 @@ pub const PackedLayout = enum(c_uint) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const PackedOrder = enum(c_uint) {
-    xrgb = C.SDL_PACKEDORDER_XRGB,
-    rgbx = C.SDL_PACKEDORDER_RGBX,
-    argb = C.SDL_PACKEDORDER_ARGB,
-    rgba = C.SDL_PACKEDORDER_RGBA,
-    xbgr = C.SDL_PACKEDORDER_XBGR,
-    bgrx = C.SDL_PACKEDORDER_BGRX,
-    abgr = C.SDL_PACKEDORDER_ABGR,
-    bgra = C.SDL_PACKEDORDER_BGRA,
+    xrgb = c.SDL_PACKEDORDER_XRGB,
+    rgbx = c.SDL_PACKEDORDER_RGBX,
+    argb = c.SDL_PACKEDORDER_ARGB,
+    rgba = c.SDL_PACKEDORDER_RGBA,
+    xbgr = c.SDL_PACKEDORDER_XBGR,
+    bgrx = c.SDL_PACKEDORDER_BGRX,
+    abgr = c.SDL_PACKEDORDER_ABGR,
+    bgra = c.SDL_PACKEDORDER_BGRA,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_PackedOrder) ?PackedOrder {
-        if (value == C.SDL_PACKEDORDER_NONE)
+    pub fn fromSdl(value: c.SDL_PackedOrder) ?PackedOrder {
+        if (value == c.SDL_PACKEDORDER_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?PackedOrder) C.SDL_PackedOrder {
+    pub fn toSdl(self: ?PackedOrder) c.SDL_PackedOrder {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_PACKEDORDER_NONE;
+        return c.SDL_PACKEDORDER_NONE;
     }
 };
 
@@ -1548,7 +1548,7 @@ pub const PackedOrder = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Palette = struct {
-    value: *C.SDL_Palette,
+    value: *c.SDL_Palette,
 
     /// Free a palette created earlier.
     ///
@@ -1563,7 +1563,7 @@ pub const Palette = struct {
     pub fn deinit(
         self: Palette,
     ) void {
-        C.SDL_DestroyPalette(
+        c.SDL_DestroyPalette(
             self.value,
         );
     }
@@ -1600,10 +1600,10 @@ pub const Palette = struct {
     pub fn init(
         num_colors: usize,
     ) !Palette {
-        const ret = C.SDL_CreatePalette(
+        const ret = c.SDL_CreatePalette(
             @intCast(num_colors),
         );
-        return Palette{ .value = try errors.wrapNull(*C.SDL_Palette, ret) };
+        return Palette{ .value = try errors.wrapNull(*c.SDL_Palette, ret) };
     }
 
     /// Set a range of colors in a palette.
@@ -1623,7 +1623,7 @@ pub const Palette = struct {
         colors: []const Color,
         first_color: usize,
     ) !void {
-        const ret = C.SDL_SetPaletteColors(
+        const ret = c.SDL_SetPaletteColors(
             self.value,
             colors.ptr,
             @intCast(first_color),
@@ -1650,49 +1650,49 @@ pub const Pixel = packed struct {
 /// This enum is available since SDL 3.2.0.
 pub const TransferCharacteristics = enum(c_uint) {
     /// Rec. ITU-R BT.709-6 / ITU-R BT1361.
-    bt709 = C.SDL_TRANSFER_CHARACTERISTICS_BT709,
-    unspecified = C.SDL_TRANSFER_CHARACTERISTICS_UNSPECIFIED,
+    bt709 = c.SDL_TRANSFER_CHARACTERISTICS_BT709,
+    unspecified = c.SDL_TRANSFER_CHARACTERISTICS_UNSPECIFIED,
     /// ITU-R BT.470-6 System M / ITU-R BT1700 625 PAL & SECAM.
-    gamma22 = C.SDL_TRANSFER_CHARACTERISTICS_GAMMA22,
+    gamma22 = c.SDL_TRANSFER_CHARACTERISTICS_GAMMA22,
     /// ITU-R BT.470-6 System B, G.
-    gamma28 = C.SDL_TRANSFER_CHARACTERISTICS_GAMMA28,
+    gamma28 = c.SDL_TRANSFER_CHARACTERISTICS_GAMMA28,
     /// SMPTE ST 170M / ITU-R BT.601-7 525 or 625.
-    bt601 = C.SDL_TRANSFER_CHARACTERISTICS_BT601,
+    bt601 = c.SDL_TRANSFER_CHARACTERISTICS_BT601,
     /// SMPTE ST 240M.
-    smpte240 = C.SDL_TRANSFER_CHARACTERISTICS_SMPTE240,
-    linear = C.SDL_TRANSFER_CHARACTERISTICS_LINEAR,
-    log100 = C.SDL_TRANSFER_CHARACTERISTICS_LOG100,
-    log100_sqrt10 = C.SDL_TRANSFER_CHARACTERISTICS_LOG100_SQRT10,
+    smpte240 = c.SDL_TRANSFER_CHARACTERISTICS_SMPTE240,
+    linear = c.SDL_TRANSFER_CHARACTERISTICS_LINEAR,
+    log100 = c.SDL_TRANSFER_CHARACTERISTICS_LOG100,
+    log100_sqrt10 = c.SDL_TRANSFER_CHARACTERISTICS_LOG100_SQRT10,
     /// IEC 61966-2-4.
-    iec61966 = C.SDL_TRANSFER_CHARACTERISTICS_IEC61966,
+    iec61966 = c.SDL_TRANSFER_CHARACTERISTICS_IEC61966,
     /// ITU-R BT1361 Extended Colour Gamut.
-    bt1361 = C.SDL_TRANSFER_CHARACTERISTICS_BT1361,
+    bt1361 = c.SDL_TRANSFER_CHARACTERISTICS_BT1361,
     /// IEC 61966-2-1 (sRGB or sYCC).
-    srgb = C.SDL_TRANSFER_CHARACTERISTICS_SRGB,
+    srgb = c.SDL_TRANSFER_CHARACTERISTICS_SRGB,
     /// ITU-R BT2020 for 10-bit system.
-    bt2020_10bit = C.SDL_TRANSFER_CHARACTERISTICS_BT2020_10BIT,
+    bt2020_10bit = c.SDL_TRANSFER_CHARACTERISTICS_BT2020_10BIT,
     /// ITU-R BT2020 for 12-bit system.
-    bt2020_12bit = C.SDL_TRANSFER_CHARACTERISTICS_BT2020_12BIT,
+    bt2020_12bit = c.SDL_TRANSFER_CHARACTERISTICS_BT2020_12BIT,
     /// SMPTE ST 2084 for 10-, 12-, 14- and 16-bit system.
-    pq = C.SDL_TRANSFER_CHARACTERISTICS_PQ,
+    pq = c.SDL_TRANSFER_CHARACTERISTICS_PQ,
     /// SMPTE ST 428-1.
-    smpte428 = C.SDL_TRANSFER_CHARACTERISTICS_SMPTE428,
+    smpte428 = c.SDL_TRANSFER_CHARACTERISTICS_SMPTE428,
     /// ARIB STD-B67, known as hybrid log-gamma (HLG).
-    hlg = C.SDL_TRANSFER_CHARACTERISTICS_HLG,
-    custom = C.SDL_TRANSFER_CHARACTERISTICS_CUSTOM,
+    hlg = c.SDL_TRANSFER_CHARACTERISTICS_HLG,
+    custom = c.SDL_TRANSFER_CHARACTERISTICS_CUSTOM,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_TransferCharacteristics) ?TransferCharacteristics {
-        if (value == C.SDL_TRANSFER_CHARACTERISTICS_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_TransferCharacteristics) ?TransferCharacteristics {
+        if (value == c.SDL_TRANSFER_CHARACTERISTICS_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?TransferCharacteristics) C.SDL_TransferCharacteristics {
+    pub fn toSdl(self: ?TransferCharacteristics) c.SDL_TransferCharacteristics {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_TRANSFER_CHARACTERISTICS_UNKNOWN;
+        return c.SDL_TRANSFER_CHARACTERISTICS_UNKNOWN;
     }
 };
 
@@ -1701,31 +1701,31 @@ pub const TransferCharacteristics = enum(c_uint) {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Type = enum(c_uint) {
-    index1 = C.SDL_PIXELTYPE_INDEX1,
-    index2 = C.SDL_PIXELTYPE_INDEX2,
-    index4 = C.SDL_PIXELTYPE_INDEX4,
-    index8 = C.SDL_PIXELTYPE_INDEX8,
-    packed8 = C.SDL_PIXELTYPE_PACKED8,
-    packed16 = C.SDL_PIXELTYPE_PACKED16,
-    packed32 = C.SDL_PIXELTYPE_PACKED32,
-    array_u8 = C.SDL_PIXELTYPE_ARRAYU8,
-    array_u16 = C.SDL_PIXELTYPE_ARRAYU16,
-    array_u32 = C.SDL_PIXELTYPE_ARRAYU32,
-    array_f16 = C.SDL_PIXELTYPE_ARRAYF16,
-    array_f32 = C.SDL_PIXELTYPE_ARRAYF32,
+    index1 = c.SDL_PIXELTYPE_INDEX1,
+    index2 = c.SDL_PIXELTYPE_INDEX2,
+    index4 = c.SDL_PIXELTYPE_INDEX4,
+    index8 = c.SDL_PIXELTYPE_INDEX8,
+    packed8 = c.SDL_PIXELTYPE_PACKED8,
+    packed16 = c.SDL_PIXELTYPE_PACKED16,
+    packed32 = c.SDL_PIXELTYPE_PACKED32,
+    array_u8 = c.SDL_PIXELTYPE_ARRAYU8,
+    array_u16 = c.SDL_PIXELTYPE_ARRAYU16,
+    array_u32 = c.SDL_PIXELTYPE_ARRAYU32,
+    array_f16 = c.SDL_PIXELTYPE_ARRAYF16,
+    array_f32 = c.SDL_PIXELTYPE_ARRAYF32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_PixelType) ?Type {
-        if (value == C.SDL_PIXELTYPE_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_PixelType) ?Type {
+        if (value == c.SDL_PIXELTYPE_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?Type) C.SDL_PixelType {
+    pub fn toSdl(self: ?Type) c.SDL_PixelType {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_PIXELTYPE_UNKNOWN;
+        return c.SDL_PIXELTYPE_UNKNOWN;
     }
 };
 
@@ -1761,7 +1761,7 @@ pub fn mapSurfaceRgb(
     g: u8,
     b: u8,
 ) Pixel {
-    const ret = C.SDL_MapSurfaceRGB(
+    const ret = c.SDL_MapSurfaceRGB(
         surface_value.value,
         r,
         g,
@@ -1804,7 +1804,7 @@ pub fn mapSurfaceRgba(
     b: u8,
     a: u8,
 ) Pixel {
-    const ret = C.SDL_MapSurfaceRGBA(
+    const ret = c.SDL_MapSurfaceRGBA(
         surface_value.value,
         r,
         g,

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -1,17 +1,17 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// Constant only true if compiling for AIX.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const aix = @hasDecl(C, "SDL_PLATFORM_AIX");
+pub const aix = @hasDecl(c, "SDL_PLATFORM_AIX");
 
 /// Constant only true if compiling for Android.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const android = @hasDecl(C, "SDL_PLATFORM_ANDROID");
+pub const android = @hasDecl(c, "SDL_PLATFORM_ANDROID");
 
 /// Constant only true if compiling for Apple platforms.
 ///
@@ -20,61 +20,61 @@ pub const android = @hasDecl(C, "SDL_PLATFORM_ANDROID");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const apple = @hasDecl(C, "SDL_PLATFORM_APPLE");
+pub const apple = @hasDecl(c, "SDL_PLATFORM_APPLE");
 
 /// Constant only true if compiling for BSDi.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const bsdi = @hasDecl(C, "SDL_PLATFORM_BSDI");
+pub const bsdi = @hasDecl(c, "SDL_PLATFORM_BSDI");
 
 /// Constant only true if compiling for Cygwin.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const cygwin = @hasDecl(C, "SDL_PLATFORM_CYGWIN");
+pub const cygwin = @hasDecl(c, "SDL_PLATFORM_CYGWIN");
 
 /// Constant only true if compiling for Emscripten.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const emscripten = @hasDecl(C, "SDL_PLATFORM_EMSCRIPTEN");
+pub const emscripten = @hasDecl(c, "SDL_PLATFORM_EMSCRIPTEN");
 
 /// Constant only true if compiling for FreeBSD.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const free_bsd = @hasDecl(C, "SDL_PLATFORM_FREEBSD");
+pub const free_bsd = @hasDecl(c, "SDL_PLATFORM_FREEBSD");
 
 /// Constant only true if compiling for Microsoft GDK on any platform.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const gdk = @hasDecl(C, "SDL_PLATFORM_GDK");
+pub const gdk = @hasDecl(c, "SDL_PLATFORM_GDK");
 
 /// Constant only true if compiling for Haiku OS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const haiku = @hasDecl(C, "SDL_PLATFORM_HAIKU");
+pub const haiku = @hasDecl(c, "SDL_PLATFORM_HAIKU");
 
 /// Constant only true if compiling for HP-UX.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const hp_ux = @hasDecl(C, "SDL_PLATFORM_HPUX");
+pub const hp_ux = @hasDecl(c, "SDL_PLATFORM_HPUX");
 
 /// Constant only true if compiling for iOS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const ios = @hasDecl(C, "SDL_PLATFORM_IOS");
+pub const ios = @hasDecl(c, "SDL_PLATFORM_IOS");
 
 /// Constant only true if compiling for IRIX.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const irix = @hasDecl(C, "SDL_PLATFORM_IRIX");
+pub const irix = @hasDecl(c, "SDL_PLATFORM_IRIX");
 
 /// Constant only true if compiling for Linux.
 ///
@@ -84,79 +84,79 @@ pub const irix = @hasDecl(C, "SDL_PLATFORM_IRIX");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const linux = @hasDecl(C, "SDL_PLATFORM_LINUX");
+pub const linux = @hasDecl(c, "SDL_PLATFORM_LINUX");
 
 /// Constant only true if compiling for macOS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const macos = @hasDecl(C, "SDL_PLATFORM_MACOS");
+pub const macos = @hasDecl(c, "SDL_PLATFORM_MACOS");
 
 /// Constant only true if compiling for Nintendo 3DS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const n3ds = @hasDecl(C, "SDL_PLATFORM_3DS");
+pub const n3ds = @hasDecl(c, "SDL_PLATFORM_3DS");
 
 /// Constant only true if compiling for NetBSD.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const net_bsd = @hasDecl(C, "SDL_PLATFORM_NETBSD");
+pub const net_bsd = @hasDecl(c, "SDL_PLATFORM_NETBSD");
 
 /// Constant only true if compiling for OpenBSD.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const open_bsd = @hasDecl(C, "SDL_PLATFORM_OPENBSD");
+pub const open_bsd = @hasDecl(c, "SDL_PLATFORM_OPENBSD");
 
 /// Constant only true if compiling for OS/2.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const os2 = @hasDecl(C, "SDL_PLATFORM_OS2");
+pub const os2 = @hasDecl(c, "SDL_PLATFORM_OS2");
 
 /// Constant only true if compiling for Tru64 (OSF/1).
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const osf = @hasDecl(C, "SDL_PLATFORM_OSF");
+pub const osf = @hasDecl(c, "SDL_PLATFORM_OSF");
 
 /// Constant only true if compiling for Sony PlayStation 2.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const ps2 = @hasDecl(C, "SDL_PLATFORM_PS2");
+pub const ps2 = @hasDecl(c, "SDL_PLATFORM_PS2");
 
 /// Constant only true if compiling for Sony PSP.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const psp = @hasDecl(C, "SDL_PLATFORM_PSP");
+pub const psp = @hasDecl(c, "SDL_PLATFORM_PSP");
 
 /// Constant only true if compiling for QNX Neutrino.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const qnx_nto = @hasDecl(C, "SDL_PLATFORM_QNXNTO");
+pub const qnx_nto = @hasDecl(c, "SDL_PLATFORM_QNXNTO");
 
 /// Constant only true if compiling for RISC OS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const risc_os = @hasDecl(C, "SDL_PLATFORM_RISCOS");
+pub const risc_os = @hasDecl(c, "SDL_PLATFORM_RISCOS");
 
 /// Constant only true if compiling for SunOS/Solaris.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const solaris = @hasDecl(C, "SDL_PLATFORM_SOLARIS");
+pub const solaris = @hasDecl(c, "SDL_PLATFORM_SOLARIS");
 
 /// Constant only true if compiling for tvOS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const tv_os = @hasDecl(C, "SDL_PLATFORM_TVOS");
+pub const tv_os = @hasDecl(c, "SDL_PLATFORM_TVOS");
 
 /// Constant only true if compiling for a Unix-like system.
 ///
@@ -165,25 +165,25 @@ pub const tv_os = @hasDecl(C, "SDL_PLATFORM_TVOS");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const unix = @hasDecl(C, "SDL_PLATFORM_UNIX");
+pub const unix = @hasDecl(c, "SDL_PLATFORM_UNIX");
 
 /// Constant only true if compiling for VisionOS.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const vision_os = @hasDecl(C, "SDL_PLATFORM_VISIONOS");
+pub const vision_os = @hasDecl(c, "SDL_PLATFORM_VISIONOS");
 
 /// Constant only true if compiling for Sony Vita.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const vita = @hasDecl(C, "SDL_PLATFORM_VITA");
+pub const vita = @hasDecl(c, "SDL_PLATFORM_VITA");
 
 /// Constant only true if compiling for Microsoft GDK for Windows.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const win_gdk = @hasDecl(C, "SDL_PLATFORM_WINGDK");
+pub const win_gdk = @hasDecl(c, "SDL_PLATFORM_WINGDK");
 
 /// Constant only true if compiling for desktop Windows.
 ///
@@ -192,7 +192,7 @@ pub const win_gdk = @hasDecl(C, "SDL_PLATFORM_WINGDK");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const win32 = @hasDecl(C, "SDL_PLATFORM_WIN32");
+pub const win32 = @hasDecl(c, "SDL_PLATFORM_WIN32");
 
 /// Constant only true if compiling for Windows.
 ///
@@ -202,19 +202,19 @@ pub const win32 = @hasDecl(C, "SDL_PLATFORM_WIN32");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const windows = @hasDecl(C, "SDL_PLATFORM_WINDOWS");
+pub const windows = @hasDecl(c, "SDL_PLATFORM_WINDOWS");
 
 /// Constant only true if compiling for Xbox One.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const xbox_one = @hasDecl(C, "SDL_PLATFORM_XBOXONE");
+pub const xbox_one = @hasDecl(c, "SDL_PLATFORM_XBOXONE");
 
 /// Constant only true if compiling for Xbox Series.
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const xbox_series = @hasDecl(C, "SDL_PLATFORM_XBOXSERIES");
+pub const xbox_series = @hasDecl(c, "SDL_PLATFORM_XBOXSERIES");
 
 // Not sure how to do the WinAPI phone here.
 
@@ -235,7 +235,7 @@ pub const xbox_series = @hasDecl(C, "SDL_PLATFORM_XBOXSERIES");
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn get() [:0]const u8 {
-    return std.mem.span(C.SDL_GetPlatform());
+    return std.mem.span(c.SDL_GetPlatform());
 }
 
 // Test platform.

--- a/src/power.zig
+++ b/src/power.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -11,15 +11,15 @@ const std = @import("std");
 /// This enum is available since SDL 3.2.0.
 pub const PowerState = enum(c_int) {
     /// Can not determine power status.
-    unknown = C.SDL_POWERSTATE_UNKNOWN,
+    unknown = c.SDL_POWERSTATE_UNKNOWN,
     /// Not plugged in, running on battery.
-    on_battery = C.SDL_POWERSTATE_ON_BATTERY,
+    on_battery = c.SDL_POWERSTATE_ON_BATTERY,
     /// Plugged in, no battery available.
-    no_battery = C.SDL_POWERSTATE_NO_BATTERY,
+    no_battery = c.SDL_POWERSTATE_NO_BATTERY,
     /// Plugged in, battery charging.
-    charging = C.SDL_POWERSTATE_CHARGING,
+    charging = c.SDL_POWERSTATE_CHARGING,
     /// Plugged in, battery charged.
-    charged = C.SDL_POWERSTATE_CHARGED,
+    charged = c.SDL_POWERSTATE_CHARGED,
 
     /// Get the current power supply details.
     ///
@@ -43,11 +43,11 @@ pub const PowerState = enum(c_int) {
     pub fn get() !struct { state: PowerState, seconds_left: ?u32, percent: ?u7 } {
         var seconds_left: c_int = undefined;
         var percent: c_int = undefined;
-        const val = C.SDL_GetPowerInfo(
+        const val = c.SDL_GetPowerInfo(
             &seconds_left,
             &percent,
         );
-        const ret = try errors.wrapCall(c_int, val, C.SDL_POWERSTATE_ERROR);
+        const ret = try errors.wrapCall(c_int, val, c.SDL_POWERSTATE_ERROR);
         return .{
             .state = @enumFromInt(ret),
             .seconds_left = if (seconds_left == -1) null else @intCast(seconds_left),

--- a/src/process.zig
+++ b/src/process.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const io_stream = @import("io_stream.zig");
 const errors = @import("errors.zig");
 const properties = @import("properties.zig");
@@ -9,7 +9,7 @@ const stdinc = @import("stdinc.zig");
 ///
 /// This datatype is available since SDL 3.2.0.
 pub const Process = packed struct {
-    value: *C.SDL_Process,
+    value: *c.SDL_Process,
 
     /// Description of where standard I/O should be directed when creating a process.
     ///
@@ -37,13 +37,13 @@ pub const Process = packed struct {
     /// This enum is available since SDL 3.2.0.
     pub const Io = enum(c_uint) {
         /// The I/O stream is inherited from the application.
-        inherited = C.SDL_PROCESS_STDIO_INHERITED,
+        inherited = c.SDL_PROCESS_STDIO_INHERITED,
         /// The I/O stream is ignored.
-        ignored = C.SDL_PROCESS_STDIO_NULL,
+        ignored = c.SDL_PROCESS_STDIO_NULL,
         /// The I/O stream is connected to a new `io_stream.Stream` that the application can read or write.
-        app = C.SDL_PROCESS_STDIO_APP,
+        app = c.SDL_PROCESS_STDIO_APP,
         /// The I/O stream is redirected to an existing `io_stream.Stream`.
-        redirect = C.SDL_PROCESS_STDIO_REDIRECT,
+        redirect = c.SDL_PROCESS_STDIO_REDIRECT,
     };
 
     /// Process creation properties.
@@ -79,25 +79,25 @@ pub const Process = packed struct {
         /// Convert to properties.
         pub fn toProperties(self: CreateProperties) !properties.Group {
             const ret = try properties.Group.init();
-            try ret.set(C.SDL_PROP_PROCESS_CREATE_ARGS_POINTER, .{ .pointer = @constCast(@ptrCast(self.args.ptr)) });
+            try ret.set(c.SDL_PROP_PROCESS_CREATE_ARGS_POINTER, .{ .pointer = @constCast(@ptrCast(self.args.ptr)) });
             if (self.environment) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_ENVIRONMENT_POINTER, .{ .pointer = val.value });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_ENVIRONMENT_POINTER, .{ .pointer = val.value });
             if (self.stdin) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDIN_NUMBER, .{ .number = @intFromEnum(val) });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDIN_NUMBER, .{ .number = @intFromEnum(val) });
             if (self.stdin_redirect) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDIN_POINTER, .{ .pointer = val.value });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDIN_POINTER, .{ .pointer = val.value });
             if (self.stdout) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDOUT_NUMBER, .{ .number = @intFromEnum(val) });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDOUT_NUMBER, .{ .number = @intFromEnum(val) });
             if (self.stdout_redirect) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDOUT_POINTER, .{ .pointer = val.value });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDOUT_POINTER, .{ .pointer = val.value });
             if (self.stderr) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDERR_NUMBER, .{ .number = @intFromEnum(val) });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDERR_NUMBER, .{ .number = @intFromEnum(val) });
             if (self.stderr_redirect) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDERR_POINTER, .{ .pointer = val.value });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDERR_POINTER, .{ .pointer = val.value });
             if (self.stderr_to_stdout) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_STDERR_TO_STDOUT_BOOLEAN, .{ .boolean = val });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_STDERR_TO_STDOUT_BOOLEAN, .{ .boolean = val });
             if (self.background) |val|
-                try ret.set(C.SDL_PROP_PROCESS_CREATE_BACKGROUND_BOOLEAN, .{ .boolean = val });
+                try ret.set(c.SDL_PROP_PROCESS_CREATE_BACKGROUND_BOOLEAN, .{ .boolean = val });
             return ret;
         }
     };
@@ -121,11 +121,11 @@ pub const Process = packed struct {
         /// Convert from an SDL value.
         pub fn fromSdl(value: properties.Group) Properties {
             return .{
-                .pid = if (value.get(C.SDL_PROP_PROCESS_PID_NUMBER)) |val| val.number else null,
-                .stdin = if (value.get(C.SDL_PROP_PROCESS_STDIN_POINTER)) |val| @alignCast(@ptrCast(val.pointer)) else null,
-                .stdout = if (value.get(C.SDL_PROP_PROCESS_STDOUT_POINTER)) |val| @alignCast(@ptrCast(val.pointer)) else null,
-                .stderr = if (value.get(C.SDL_PROP_PROCESS_STDERR_POINTER)) |val| @alignCast(@ptrCast(val.pointer)) else null,
-                .background = if (value.get(C.SDL_PROP_PROCESS_BACKGROUND_BOOLEAN)) |val| val.boolean else null,
+                .pid = if (value.get(c.SDL_PROP_PROCESS_PID_NUMBER)) |val| val.number else null,
+                .stdin = if (value.get(c.SDL_PROP_PROCESS_STDIN_POINTER)) |val| @alignCast(@ptrCast(val.pointer)) else null,
+                .stdout = if (value.get(c.SDL_PROP_PROCESS_STDOUT_POINTER)) |val| @alignCast(@ptrCast(val.pointer)) else null,
+                .stderr = if (value.get(c.SDL_PROP_PROCESS_STDERR_POINTER)) |val| @alignCast(@ptrCast(val.pointer)) else null,
+                .background = if (value.get(c.SDL_PROP_PROCESS_BACKGROUND_BOOLEAN)) |val| val.boolean else null,
             };
         }
     };
@@ -147,7 +147,7 @@ pub const Process = packed struct {
     pub fn deinit(
         self: Process,
     ) void {
-        C.SDL_DestroyProcess(self.value);
+        c.SDL_DestroyProcess(self.value);
     }
 
     /// Create a new process.
@@ -176,11 +176,11 @@ pub const Process = packed struct {
         args: []const [*:0]u8,
         pipe_stdio: bool,
     ) !Process {
-        const ret = C.SDL_CreateProcess(
+        const ret = c.SDL_CreateProcess(
             @ptrCast(args.ptr),
             pipe_stdio,
         );
-        return .{ .value = try errors.wrapNull(*C.SDL_Process, ret) };
+        return .{ .value = try errors.wrapNull(*c.SDL_Process, ret) };
     }
 
     /// Create a new process with the specified properties.
@@ -206,7 +206,7 @@ pub const Process = packed struct {
     ) !?Process {
         const vals = try props.toProperties();
         defer vals.deinit();
-        const ret = C.SDL_CreateProcessWithProperties(vals.value);
+        const ret = c.SDL_CreateProcessWithProperties(vals.value);
         if (ret) |val| {
             return .{ .value = val };
         }
@@ -236,7 +236,7 @@ pub const Process = packed struct {
     pub fn getInput(
         self: Process,
     ) !io_stream.Stream {
-        return .{ .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_GetProcessOutput(self.value)) };
+        return .{ .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_GetProcessOutput(self.value)) };
     }
 
     /// Get the `io_stream.Stream` associated with process standard output.
@@ -261,7 +261,7 @@ pub const Process = packed struct {
     pub fn getOutput(
         self: Process,
     ) !io_stream.Stream {
-        return .{ .value = try errors.wrapNull(*C.SDL_IOStream, C.SDL_GetProcessOutput(self.value)) };
+        return .{ .value = try errors.wrapNull(*c.SDL_IOStream, c.SDL_GetProcessOutput(self.value)) };
     }
 
     /// Get the properties associated with a process.
@@ -280,7 +280,7 @@ pub const Process = packed struct {
     pub fn getProperties(
         self: Process,
     ) !Properties {
-        return Properties.fromSdl(.{ .value = try errors.wrapCall(C.SDL_PropertiesID, C.SDL_GetProcessProperties(self.value), 0) });
+        return Properties.fromSdl(.{ .value = try errors.wrapCall(c.SDL_PropertiesID, c.SDL_GetProcessProperties(self.value), 0) });
     }
 
     /// Stop a process.
@@ -298,7 +298,7 @@ pub const Process = packed struct {
         self: Process,
         force: bool,
     ) !void {
-        return errors.wrapCallBool(C.SDL_KillProcess(self.value, force));
+        return errors.wrapCallBool(c.SDL_KillProcess(self.value, force));
     }
 
     /// Read all the output from a process.
@@ -329,7 +329,7 @@ pub const Process = packed struct {
     ) !struct { data: []u8, exit_code: c_int } {
         var size: usize = undefined;
         var exit_code: c_int = undefined;
-        const ret = C.SDL_ReadProcess(self.value, &size, &exit_code);
+        const ret = c.SDL_ReadProcess(self.value, &size, &exit_code);
         return .{
             .data = @as([*]u8, @alignCast(@ptrCast(try errors.wrapNull(*anyopaque, ret))))[0..@intCast(size)],
             .exit_code = exit_code,
@@ -349,7 +349,7 @@ pub const Process = packed struct {
         block: bool,
     ) ?c_int {
         var exit_code: c_int = undefined;
-        const ret = C.SDL_WaitProcess(self.value, block, &exit_code);
+        const ret = c.SDL_WaitProcess(self.value, block, &exit_code);
         if (!ret)
             return null;
         return exit_code;

--- a/src/properties.zig
+++ b/src/properties.zig
@@ -24,7 +24,7 @@ const std = @import("std");
 pub const CleanupCallback = *const fn (
     user_data: ?*anyopaque,
     value: ?*anyopaque,
-) callconv(.C) void;
+) callconv(.c) void;
 
 /// A callback used to enumerate all the properties in a group of properties.
 ///
@@ -45,7 +45,7 @@ pub const EnumerateCallback = *const fn (
     user_data: ?*anyopaque,
     props: c.SDL_PropertiesID,
     name: [*c]const u8,
-) callconv(.C) void;
+) callconv(.c) void;
 
 /// SDL properties type.
 ///
@@ -196,7 +196,7 @@ pub const Group = packed struct {
     }
 
     /// Used for adding properties to a list.
-    fn getAllEnumerateCallback(user_data: ?*anyopaque, id: c.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
+    fn getAllEnumerateCallback(user_data: ?*anyopaque, id: c.SDL_PropertiesID, name: [*c]const u8) callconv(.c) void {
         const group = Group{ .value = id };
         const data_ptr: *GetAllData = @ptrCast(@alignCast(user_data));
         const spanned_name = std.mem.span(name);
@@ -431,13 +431,13 @@ pub fn getGlobal() !Group {
     return Group{ .value = ret };
 }
 
-fn testPropertiesCleanupCb(user_data: ?*anyopaque, value: ?*anyopaque) callconv(.C) void {
+fn testPropertiesCleanupCb(user_data: ?*anyopaque, value: ?*anyopaque) callconv(.c) void {
     _ = user_data;
     const ptr: *std.ArrayList(u32) = @ptrCast(@alignCast(value));
     ptr.deinit();
 }
 
-fn testEnumeratePropertiesCb(user_data: ?*anyopaque, id: c.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
+fn testEnumeratePropertiesCb(user_data: ?*anyopaque, id: c.SDL_PropertiesID, name: [*c]const u8) callconv(.c) void {
     _ = user_data;
     _ = id;
     _ = name;

--- a/src/properties.zig
+++ b/src/properties.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -43,7 +43,7 @@ pub const CleanupCallback = *const fn (
 /// This datatype is available since SDL 3.2.0.
 pub const EnumerateCallback = *const fn (
     user_data: ?*anyopaque,
-    props: C.SDL_PropertiesID,
+    props: c.SDL_PropertiesID,
     name: [*c]const u8,
 ) callconv(.C) void;
 
@@ -52,11 +52,11 @@ pub const EnumerateCallback = *const fn (
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Type = enum(c_uint) {
-    pointer = C.SDL_PROPERTY_TYPE_POINTER,
-    string = C.SDL_PROPERTY_TYPE_STRING,
-    number = C.SDL_PROPERTY_TYPE_NUMBER,
-    float = C.SDL_PROPERTY_TYPE_FLOAT,
-    boolean = C.SDL_PROPERTY_TYPE_BOOLEAN,
+    pointer = c.SDL_PROPERTY_TYPE_POINTER,
+    string = c.SDL_PROPERTY_TYPE_STRING,
+    number = c.SDL_PROPERTY_TYPE_NUMBER,
+    float = c.SDL_PROPERTY_TYPE_FLOAT,
+    boolean = c.SDL_PROPERTY_TYPE_BOOLEAN,
 };
 
 /// SDL properties group.
@@ -65,7 +65,7 @@ pub const Type = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const Group = packed struct {
-    value: C.SDL_PropertiesID,
+    value: c.SDL_PropertiesID,
 
     /// Clear a property from a group of properties.
     ///
@@ -82,7 +82,7 @@ pub const Group = packed struct {
         self: Group,
         name: [:0]const u8,
     ) !void {
-        const ret = C.SDL_ClearProperty(
+        const ret = c.SDL_ClearProperty(
             self.value,
             name.ptr,
         );
@@ -109,7 +109,7 @@ pub const Group = packed struct {
         self: Group,
         dest: Group,
     ) !void {
-        const ret = C.SDL_CopyProperties(
+        const ret = c.SDL_CopyProperties(
             self.value,
             dest.value,
         );
@@ -132,7 +132,7 @@ pub const Group = packed struct {
     pub fn deinit(
         self: Group,
     ) void {
-        C.SDL_DestroyProperties(
+        c.SDL_DestroyProperties(
             self.value,
         );
     }
@@ -157,7 +157,7 @@ pub const Group = packed struct {
         callback: EnumerateCallback,
         user_data: ?*anyopaque,
     ) !void {
-        const ret = C.SDL_EnumerateProperties(self.value, callback, user_data);
+        const ret = c.SDL_EnumerateProperties(self.value, callback, user_data);
         return errors.wrapCallBool(ret);
     }
 
@@ -185,18 +185,18 @@ pub const Group = packed struct {
         self: Group,
         name: [:0]const u8,
     ) ?Property {
-        return switch (C.SDL_GetPropertyType(self.value, name.ptr)) {
-            C.SDL_PROPERTY_TYPE_POINTER => Property{ .pointer = C.SDL_GetPointerProperty(self.value, name.ptr, null) },
-            C.SDL_PROPERTY_TYPE_STRING => Property{ .string = std.mem.span(C.SDL_GetStringProperty(self.value, name.ptr, "")) },
-            C.SDL_PROPERTY_TYPE_NUMBER => Property{ .number = C.SDL_GetNumberProperty(self.value, name.ptr, 0) },
-            C.SDL_PROPERTY_TYPE_FLOAT => Property{ .float = C.SDL_GetFloatProperty(self.value, name.ptr, 0) },
-            C.SDL_PROPERTY_TYPE_BOOLEAN => Property{ .boolean = C.SDL_GetBooleanProperty(self.value, name.ptr, false) },
+        return switch (c.SDL_GetPropertyType(self.value, name.ptr)) {
+            c.SDL_PROPERTY_TYPE_POINTER => Property{ .pointer = c.SDL_GetPointerProperty(self.value, name.ptr, null) },
+            c.SDL_PROPERTY_TYPE_STRING => Property{ .string = std.mem.span(c.SDL_GetStringProperty(self.value, name.ptr, "")) },
+            c.SDL_PROPERTY_TYPE_NUMBER => Property{ .number = c.SDL_GetNumberProperty(self.value, name.ptr, 0) },
+            c.SDL_PROPERTY_TYPE_FLOAT => Property{ .float = c.SDL_GetFloatProperty(self.value, name.ptr, 0) },
+            c.SDL_PROPERTY_TYPE_BOOLEAN => Property{ .boolean = c.SDL_GetBooleanProperty(self.value, name.ptr, false) },
             else => null,
         };
     }
 
     /// Used for adding properties to a list.
-    fn getAllEnumerateCallback(user_data: ?*anyopaque, id: C.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
+    fn getAllEnumerateCallback(user_data: ?*anyopaque, id: c.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
         const group = Group{ .value = id };
         const data_ptr: *GetAllData = @ptrCast(@alignCast(user_data));
         const spanned_name = std.mem.span(name);
@@ -253,10 +253,10 @@ pub const Group = packed struct {
         self: Group,
         name: [:0]const u8,
     ) ?Type {
-        const ret = errors.wrapCall(C.SDL_PropertyType, C.SDL_GetPropertyType(
+        const ret = errors.wrapCall(c.SDL_PropertyType, c.SDL_GetPropertyType(
             self.value,
             name.ptr,
-        ), C.SDL_PROPERTY_TYPE_INVALID) catch return null;
+        ), c.SDL_PROPERTY_TYPE_INVALID) catch return null;
         return @enumFromInt(ret);
     }
 
@@ -275,7 +275,7 @@ pub const Group = packed struct {
         self: Group,
         name: [:0]const u8,
     ) bool {
-        const ret = C.SDL_HasProperty(
+        const ret = c.SDL_HasProperty(
             self.value,
             name.ptr,
         );
@@ -296,8 +296,8 @@ pub const Group = packed struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn init() !Group {
-        const ret = C.SDL_CreateProperties();
-        return Group{ .value = try errors.wrapCall(C.SDL_PropertiesID, ret, 0) };
+        const ret = c.SDL_CreateProperties();
+        return Group{ .value = try errors.wrapCall(c.SDL_PropertiesID, ret, 0) };
     }
 
     /// Lock a group of properties.
@@ -321,7 +321,7 @@ pub const Group = packed struct {
     pub fn lock(
         self: Group,
     ) !void {
-        const ret = C.SDL_LockProperties(
+        const ret = c.SDL_LockProperties(
             self.value,
         );
         return errors.wrapCallBool(ret);
@@ -345,11 +345,11 @@ pub const Group = packed struct {
         value: Property,
     ) !void {
         const ret = switch (value) {
-            .pointer => |pt| C.SDL_SetPointerProperty(self.value, name, pt),
-            .string => |str| C.SDL_SetStringProperty(self.value, name, str),
-            .number => |num| C.SDL_SetNumberProperty(self.value, name, num),
-            .float => |num| C.SDL_SetFloatProperty(self.value, name, num),
-            .boolean => |val| C.SDL_SetBooleanProperty(self.value, name, val),
+            .pointer => |pt| c.SDL_SetPointerProperty(self.value, name, pt),
+            .string => |str| c.SDL_SetStringProperty(self.value, name, str),
+            .number => |num| c.SDL_SetNumberProperty(self.value, name, num),
+            .float => |num| c.SDL_SetFloatProperty(self.value, name, num),
+            .boolean => |val| c.SDL_SetBooleanProperty(self.value, name, val),
         };
         return errors.wrapCallBool(ret);
     }
@@ -381,7 +381,7 @@ pub const Group = packed struct {
         cleanup: CleanupCallback,
         user_data: ?*anyopaque,
     ) !void {
-        const ret = C.SDL_SetPointerPropertyWithCleanup(
+        const ret = c.SDL_SetPointerPropertyWithCleanup(
             self.value,
             name.ptr,
             value,
@@ -404,7 +404,7 @@ pub const Group = packed struct {
     pub fn unlock(
         self: Group,
     ) void {
-        C.SDL_UnlockProperties(
+        c.SDL_UnlockProperties(
             self.value,
         );
     }
@@ -427,7 +427,7 @@ pub const Property = union(Type) {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getGlobal() !Group {
-    const ret = try errors.wrapCall(C.SDL_PropertiesID, C.SDL_GetGlobalProperties(), 0);
+    const ret = try errors.wrapCall(c.SDL_PropertiesID, c.SDL_GetGlobalProperties(), 0);
     return Group{ .value = ret };
 }
 
@@ -437,7 +437,7 @@ fn testPropertiesCleanupCb(user_data: ?*anyopaque, value: ?*anyopaque) callconv(
     ptr.deinit();
 }
 
-fn testEnumeratePropertiesCb(user_data: ?*anyopaque, id: C.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
+fn testEnumeratePropertiesCb(user_data: ?*anyopaque, id: c.SDL_PropertiesID, name: [*c]const u8) callconv(.C) void {
     _ = user_data;
     _ = id;
     _ = name;

--- a/src/rect.zig
+++ b/src/rect.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -17,17 +17,17 @@ pub fn Point(comptime Type: type) type {
 
         // Size tests.
         comptime {
-            std.debug.assert(@sizeOf(C.SDL_Point) == @sizeOf(IPoint));
-            std.debug.assert(@offsetOf(C.SDL_Point, "x") == @offsetOf(IPoint, "x"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_Point, "x")) == @sizeOf(@FieldType(IPoint, "x")));
-            std.debug.assert(@offsetOf(C.SDL_Point, "y") == @offsetOf(IPoint, "y"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_Point, "y")) == @sizeOf(@FieldType(IPoint, "y")));
+            std.debug.assert(@sizeOf(c.SDL_Point) == @sizeOf(IPoint));
+            std.debug.assert(@offsetOf(c.SDL_Point, "x") == @offsetOf(IPoint, "x"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_Point, "x")) == @sizeOf(@FieldType(IPoint, "x")));
+            std.debug.assert(@offsetOf(c.SDL_Point, "y") == @offsetOf(IPoint, "y"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_Point, "y")) == @sizeOf(@FieldType(IPoint, "y")));
 
-            std.debug.assert(@sizeOf(C.SDL_FPoint) == @sizeOf(FPoint));
-            std.debug.assert(@offsetOf(C.SDL_FPoint, "x") == @offsetOf(FPoint, "x"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_FPoint, "x")) == @sizeOf(@FieldType(FPoint, "x")));
-            std.debug.assert(@offsetOf(C.SDL_FPoint, "y") == @offsetOf(FPoint, "y"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_FPoint, "y")) == @sizeOf(@FieldType(FPoint, "y")));
+            std.debug.assert(@sizeOf(c.SDL_FPoint) == @sizeOf(FPoint));
+            std.debug.assert(@offsetOf(c.SDL_FPoint, "x") == @offsetOf(FPoint, "x"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_FPoint, "x")) == @sizeOf(@FieldType(FPoint, "x")));
+            std.debug.assert(@offsetOf(c.SDL_FPoint, "y") == @offsetOf(FPoint, "y"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_FPoint, "y")) == @sizeOf(@FieldType(FPoint, "y")));
         }
 
         /// Get this as a different type of point.
@@ -78,7 +78,7 @@ pub fn Point(comptime Type: type) type {
         }
 
         /// From an SDL point.
-        fn fromSdlFPoint(self: C.SDL_FPoint) Self {
+        fn fromSdlFPoint(self: c.SDL_FPoint) Self {
             return .{
                 .x = @floatCast(self.x),
                 .y = @floatCast(self.y),
@@ -86,7 +86,7 @@ pub fn Point(comptime Type: type) type {
         }
 
         /// From an SDL point.
-        fn fromSdlIPoint(self: C.SDL_Point) Self {
+        fn fromSdlIPoint(self: c.SDL_Point) Self {
             return .{
                 .x = @intCast(self.x),
                 .y = @intCast(self.y),
@@ -94,7 +94,7 @@ pub fn Point(comptime Type: type) type {
         }
 
         /// Get the SDL point.
-        fn toSdlFPoint(self: Self) C.SDL_FPoint {
+        fn toSdlFPoint(self: Self) c.SDL_FPoint {
             return .{
                 .x = @floatCast(self.x),
                 .y = @floatCast(self.y),
@@ -102,7 +102,7 @@ pub fn Point(comptime Type: type) type {
         }
 
         /// Get the SDL point.
-        fn toSdlIPoint(self: Self) C.SDL_Point {
+        fn toSdlIPoint(self: Self) c.SDL_Point {
             return .{
                 .x = @intCast(self.x),
                 .y = @intCast(self.y),
@@ -146,25 +146,25 @@ pub fn Rect(comptime Type: type) type {
 
         // Size tests.
         comptime {
-            std.debug.assert(@sizeOf(C.SDL_Rect) == @sizeOf(IRect));
-            std.debug.assert(@offsetOf(C.SDL_Rect, "x") == @offsetOf(IRect, "x"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_Rect, "x")) == @sizeOf(@FieldType(IRect, "x")));
-            std.debug.assert(@offsetOf(C.SDL_Rect, "y") == @offsetOf(IRect, "y"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_Rect, "y")) == @sizeOf(@FieldType(IRect, "y")));
-            std.debug.assert(@offsetOf(C.SDL_Rect, "w") == @offsetOf(IRect, "w"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_Rect, "w")) == @sizeOf(@FieldType(IRect, "w")));
-            std.debug.assert(@offsetOf(C.SDL_Rect, "h") == @offsetOf(IRect, "h"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_Rect, "h")) == @sizeOf(@FieldType(IRect, "h")));
+            std.debug.assert(@sizeOf(c.SDL_Rect) == @sizeOf(IRect));
+            std.debug.assert(@offsetOf(c.SDL_Rect, "x") == @offsetOf(IRect, "x"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_Rect, "x")) == @sizeOf(@FieldType(IRect, "x")));
+            std.debug.assert(@offsetOf(c.SDL_Rect, "y") == @offsetOf(IRect, "y"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_Rect, "y")) == @sizeOf(@FieldType(IRect, "y")));
+            std.debug.assert(@offsetOf(c.SDL_Rect, "w") == @offsetOf(IRect, "w"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_Rect, "w")) == @sizeOf(@FieldType(IRect, "w")));
+            std.debug.assert(@offsetOf(c.SDL_Rect, "h") == @offsetOf(IRect, "h"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_Rect, "h")) == @sizeOf(@FieldType(IRect, "h")));
 
-            std.debug.assert(@sizeOf(C.SDL_FRect) == @sizeOf(FRect));
-            std.debug.assert(@offsetOf(C.SDL_FRect, "x") == @offsetOf(FRect, "x"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_FRect, "x")) == @sizeOf(@FieldType(FRect, "x")));
-            std.debug.assert(@offsetOf(C.SDL_FRect, "y") == @offsetOf(FRect, "y"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_FRect, "y")) == @sizeOf(@FieldType(FRect, "y")));
-            std.debug.assert(@offsetOf(C.SDL_FRect, "w") == @offsetOf(FRect, "w"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_FRect, "w")) == @sizeOf(@FieldType(FRect, "w")));
-            std.debug.assert(@offsetOf(C.SDL_FRect, "h") == @offsetOf(FRect, "h"));
-            std.debug.assert(@sizeOf(@FieldType(C.SDL_FRect, "h")) == @sizeOf(@FieldType(FRect, "h")));
+            std.debug.assert(@sizeOf(c.SDL_FRect) == @sizeOf(FRect));
+            std.debug.assert(@offsetOf(c.SDL_FRect, "x") == @offsetOf(FRect, "x"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_FRect, "x")) == @sizeOf(@FieldType(FRect, "x")));
+            std.debug.assert(@offsetOf(c.SDL_FRect, "y") == @offsetOf(FRect, "y"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_FRect, "y")) == @sizeOf(@FieldType(FRect, "y")));
+            std.debug.assert(@offsetOf(c.SDL_FRect, "w") == @offsetOf(FRect, "w"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_FRect, "w")) == @sizeOf(@FieldType(FRect, "w")));
+            std.debug.assert(@offsetOf(c.SDL_FRect, "h") == @offsetOf(FRect, "h"));
+            std.debug.assert(@sizeOf(@FieldType(c.SDL_FRect, "h")) == @sizeOf(@FieldType(FRect, "h")));
         }
 
         /// Get this as a different type of rectangle.
@@ -275,11 +275,11 @@ pub fn Rect(comptime Type: type) type {
         ) bool {
             const a = self.toSdl();
             const b = other.toSdl();
-            return C.SDL_RectsEqualEpsilon(&a, &b, epsilon);
+            return c.SDL_RectsEqualEpsilon(&a, &b, epsilon);
         }
 
         /// Create from an SDL rect.c
-        fn fromSdlFRect(rect: C.SDL_FRect) FRect {
+        fn fromSdlFRect(rect: c.SDL_FRect) FRect {
             return .{
                 .x = @floatCast(rect.x),
                 .y = @floatCast(rect.y),
@@ -289,7 +289,7 @@ pub fn Rect(comptime Type: type) type {
         }
 
         /// Create from an SDL rect.
-        fn fromSdlIRect(rect: C.SDL_Rect) IRect {
+        fn fromSdlIRect(rect: c.SDL_Rect) IRect {
             return .{
                 .x = @intCast(rect.x),
                 .y = @intCast(rect.y),
@@ -305,8 +305,8 @@ pub fn Rect(comptime Type: type) type {
         ) ?FRect {
             const a = self.toSdl();
             const b = other.toSdl();
-            var ret: C.SDL_FRect = undefined;
-            if (!C.SDL_GetRectIntersectionFloat(&a, &b, &ret))
+            var ret: c.SDL_FRect = undefined;
+            if (!c.SDL_GetRectIntersectionFloat(&a, &b, &ret))
                 return null;
             return fromSdl(ret);
         }
@@ -318,8 +318,8 @@ pub fn Rect(comptime Type: type) type {
         ) ?IRect {
             const a = self.toSdl();
             const b = other.toSdl();
-            var ret: C.SDL_Rect = undefined;
-            if (!C.SDL_GetRectIntersection(&a, &b, &ret))
+            var ret: c.SDL_Rect = undefined;
+            if (!c.SDL_GetRectIntersection(&a, &b, &ret))
                 return null;
             return fromSdl(ret);
         }
@@ -332,7 +332,7 @@ pub fn Rect(comptime Type: type) type {
             const rect = self.toSdl();
             var p1 = line[0].toSdl();
             var p2 = line[1].toSdl();
-            if (!C.SDL_GetRectAndLineIntersectionFloat(&rect, &p1.x, &p1.y, &p2.x, &p2.y))
+            if (!c.SDL_GetRectAndLineIntersectionFloat(&rect, &p1.x, &p1.y, &p2.x, &p2.y))
                 return null;
             return [_]FPoint{ FPoint.fromSdl(p1), FPoint.fromSdl(p2) };
         }
@@ -345,7 +345,7 @@ pub fn Rect(comptime Type: type) type {
             const rect = self.toSdl();
             var p1 = line[0].toSdl();
             var p2 = line[1].toSdl();
-            if (!C.SDL_GetRectAndLineIntersection(&rect, &p1.x, &p1.y, &p2.x, &p2.y))
+            if (!c.SDL_GetRectAndLineIntersection(&rect, &p1.x, &p1.y, &p2.x, &p2.y))
                 return null;
             return [_]IPoint{ IPoint.fromSdl(p1), IPoint.fromSdl(p2) };
         }
@@ -431,8 +431,8 @@ pub fn Rect(comptime Type: type) type {
         ) !FRect {
             const a = self.toSdl();
             const b = other.toSdl();
-            var ret: C.SDL_FRect = undefined;
-            try errors.wrapCallBool(C.SDL_GetRectUnionFloat(&a, &b, &ret));
+            var ret: c.SDL_FRect = undefined;
+            try errors.wrapCallBool(c.SDL_GetRectUnionFloat(&a, &b, &ret));
             return fromSdl(ret);
         }
 
@@ -443,8 +443,8 @@ pub fn Rect(comptime Type: type) type {
         ) !IRect {
             const a = self.toSdl();
             const b = other.toSdl();
-            var ret: C.SDL_Rect = undefined;
-            try errors.wrapCallBool(C.SDL_GetRectUnion(&a, &b, &ret));
+            var ret: c.SDL_Rect = undefined;
+            try errors.wrapCallBool(c.SDL_GetRectUnion(&a, &b, &ret));
             return fromSdl(ret);
         }
 
@@ -455,7 +455,7 @@ pub fn Rect(comptime Type: type) type {
         ) bool {
             const a = self.toSdl();
             const b = other.toSdl();
-            return C.SDL_HasRectIntersectionFloat(&a, &b);
+            return c.SDL_HasRectIntersectionFloat(&a, &b);
         }
 
         /// If two rectangles are intersecting.
@@ -465,7 +465,7 @@ pub fn Rect(comptime Type: type) type {
         ) bool {
             const a = self.toSdl();
             const b = other.toSdl();
-            return C.SDL_HasRectIntersection(&a, &b);
+            return c.SDL_HasRectIntersection(&a, &b);
         }
 
         /// Determine whether a point resides inside a rectangle.
@@ -496,8 +496,8 @@ pub fn Rect(comptime Type: type) type {
         }
 
         /// Get the SDL rect.
-        fn toSdlFRect(self: FRect) C.SDL_FRect {
-            return C.SDL_FRect{
+        fn toSdlFRect(self: FRect) c.SDL_FRect {
+            return c.SDL_FRect{
                 .x = @floatCast(self.x),
                 .y = @floatCast(self.y),
                 .w = @floatCast(self.w),
@@ -506,8 +506,8 @@ pub fn Rect(comptime Type: type) type {
         }
 
         /// Get the SDL rect.
-        fn toSdlIRect(self: IRect) C.SDL_Rect {
-            return C.SDL_Rect{
+        fn toSdlIRect(self: IRect) c.SDL_Rect {
+            return c.SDL_Rect{
                 .x = @intCast(self.x),
                 .y = @intCast(self.y),
                 .w = @intCast(self.w),

--- a/src/render.zig
+++ b/src/render.zig
@@ -1,37 +1,37 @@
 // This file was generated using `zig build bindings`. Do not manually edit!
 
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// The access pattern allowed for a texture.
 pub const TextureAccess = enum(c_uint) {
     /// Changes rarely, not lockable.
-    Static = C.SDL_TEXTUREACCESS_STATIC,
+    Static = c.SDL_TEXTUREACCESS_STATIC,
     /// Changes frequently, lockable.
-    Streaming = C.SDL_TEXTUREACCESS_STREAMING,
+    Streaming = c.SDL_TEXTUREACCESS_STREAMING,
     /// Texture can be used as a render target.
-    Target = C.SDL_TEXTUREACCESS_TARGET,
+    Target = c.SDL_TEXTUREACCESS_TARGET,
 };
 
 /// How the logical size is mapped to the output.
 pub const LogicalPresentation = enum(c_uint) {
     /// The rendered content is stretched to the output resolution.
-    Stretch = C.SDL_LOGICAL_PRESENTATION_STRETCH,
+    Stretch = c.SDL_LOGICAL_PRESENTATION_STRETCH,
     /// The rendered content is fit to the largest dimension and the other dimension is letterboxed with black bars.
-    LetterBox = C.SDL_LOGICAL_PRESENTATION_LETTERBOX,
+    LetterBox = c.SDL_LOGICAL_PRESENTATION_LETTERBOX,
     /// The rendered content is fit to the smallest dimension and the other dimension extends beyond the output bounds.
-    Overscan = C.SDL_LOGICAL_PRESENTATION_OVERSCAN,
+    Overscan = c.SDL_LOGICAL_PRESENTATION_OVERSCAN,
     /// The rendered content is scaled up by integer multiples to fit the output resolution.
-    IntegerScale = C.SDL_LOGICAL_PRESENTATION_INTEGER_SCALE,
+    IntegerScale = c.SDL_LOGICAL_PRESENTATION_INTEGER_SCALE,
 };
 
 /// A structure representing rendering state.
 pub const Renderer = struct {
-    value: *C.SDL_Renderer,
+    value: *c.SDL_Renderer,
 
     /// Get the number of 2D rendering drivers available for the current display.
     pub fn numDrivers() usize {
-        const ret = C.SDL_GetNumRenderDrivers();
+        const ret = c.SDL_GetNumRenderDrivers();
         return @intCast(ret);
     }
 
@@ -39,7 +39,7 @@ pub const Renderer = struct {
     pub fn getDriverName(
         index: usize,
     ) ?[:0]const u8 {
-        const ret = C.SDL_GetRenderDriver(
+        const ret = c.SDL_GetRenderDriver(
             @intCast(index),
         );
         if (ret == null)
@@ -54,9 +54,9 @@ pub const Renderer = struct {
         height: usize,
         window_flags: video.WindowFlags,
     ) !struct { window: video.Window, renderer: Renderer } {
-        var window: ?*C.SDL_Window = undefined;
-        var renderer: ?*C.SDL_Renderer = undefined;
-        const ret = C.SDL_CreateWindowAndRenderer(
+        var window: ?*c.SDL_Window = undefined;
+        var renderer: ?*c.SDL_Renderer = undefined;
+        const ret = c.SDL_CreateWindowAndRenderer(
             title,
             @intCast(width),
             @intCast(height),
@@ -74,7 +74,7 @@ pub const Renderer = struct {
         window: video.Window,
         renderer_name: ?[:0]const u8,
     ) !Renderer {
-        const ret = C.SDL_CreateRenderer(
+        const ret = c.SDL_CreateRenderer(
             window.value,
             if (renderer_name) |str_capture| str_capture.ptr else null,
         );
@@ -87,7 +87,7 @@ pub const Renderer = struct {
     pub fn initWithProperties(
         props: properties.Group,
     ) !Renderer {
-        const ret = C.SDL_CreateRendererWithProperties(
+        const ret = c.SDL_CreateRendererWithProperties(
             props.value,
         );
         if (ret == null)
@@ -99,7 +99,7 @@ pub const Renderer = struct {
     pub fn initSoftwareRenderer(
         target_surface: surface.Surface,
     ) !Renderer {
-        const ret = C.SDL_CreateSoftwareRenderer(
+        const ret = c.SDL_CreateSoftwareRenderer(
             target_surface.value,
         );
         if (ret == null)
@@ -111,7 +111,7 @@ pub const Renderer = struct {
     pub fn getRenderer(
         window: video.Window,
     ) !Renderer {
-        const ret = C.SDL_GetRenderer(
+        const ret = c.SDL_GetRenderer(
             window.value,
         );
         if (ret == null)
@@ -123,7 +123,7 @@ pub const Renderer = struct {
     pub fn getWindow(
         self: Renderer,
     ) !video.Window {
-        const ret = C.SDL_GetRenderWindow(
+        const ret = c.SDL_GetRenderWindow(
             self.value,
         );
         if (ret == null)
@@ -135,7 +135,7 @@ pub const Renderer = struct {
     pub fn getName(
         self: Renderer,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetRendererName(
+        const ret = c.SDL_GetRendererName(
             self.value,
         );
         if (ret == null)
@@ -147,7 +147,7 @@ pub const Renderer = struct {
     pub fn getProperties(
         self: Renderer,
     ) ![]properties.Group {
-        const ret = C.SDL_GetRendererProperties(
+        const ret = c.SDL_GetRendererProperties(
             self.value,
         );
         if (ret == 0)
@@ -161,7 +161,7 @@ pub const Renderer = struct {
     ) !struct { width: usize, height: usize } {
         var w: c_int = undefined;
         var h: c_int = undefined;
-        const ret = C.SDL_GetRenderOutputSize(
+        const ret = c.SDL_GetRenderOutputSize(
             self.value,
             &w,
             &h,
@@ -177,7 +177,7 @@ pub const Renderer = struct {
     ) !struct { width: usize, height: usize } {
         var w: c_int = undefined;
         var h: c_int = undefined;
-        const ret = C.SDL_GetCurrentRenderOutputSize(
+        const ret = c.SDL_GetCurrentRenderOutputSize(
             self.value,
             &w,
             &h,
@@ -195,7 +195,7 @@ pub const Renderer = struct {
         width: usize,
         height: usize,
     ) !Texture {
-        const ret = C.SDL_CreateTexture(
+        const ret = c.SDL_CreateTexture(
             self.value,
             format.value,
             @intFromEnum(texture_access),
@@ -212,7 +212,7 @@ pub const Renderer = struct {
         self: Renderer,
         surface_to_copy: surface.Surface,
     ) !Texture {
-        const ret = C.SDL_CreateTextureFromSurface(
+        const ret = c.SDL_CreateTextureFromSurface(
             self.value,
             surface_to_copy.value,
         );
@@ -226,7 +226,7 @@ pub const Renderer = struct {
         self: Renderer,
         props: properties.Group,
     ) !Texture {
-        const ret = C.SDL_CreateTextureWithProperties(
+        const ret = c.SDL_CreateTextureWithProperties(
             self.value,
             props.value,
         );
@@ -240,7 +240,7 @@ pub const Renderer = struct {
         self: Renderer,
         target: ?Texture,
     ) !void {
-        const ret = C.SDL_SetRenderTarget(
+        const ret = c.SDL_SetRenderTarget(
             self.value,
             if (target) |target_val| target_val.value else null,
         );
@@ -252,7 +252,7 @@ pub const Renderer = struct {
     pub fn getTarget(
         self: Renderer,
     ) ?Texture {
-        const ret = C.SDL_GetRenderTarget(
+        const ret = c.SDL_GetRenderTarget(
             self.value,
         );
         if (ret == null)
@@ -267,11 +267,11 @@ pub const Renderer = struct {
         height: usize,
         presentation_mode: ?LogicalPresentation,
     ) !void {
-        const ret = C.SDL_SetRenderLogicalPresentation(
+        const ret = c.SDL_SetRenderLogicalPresentation(
             self.value,
             @intCast(width),
             @intCast(height),
-            if (presentation_mode) |val| @intFromEnum(val) else C.SDL_LOGICAL_PRESENTATION_DISABLED,
+            if (presentation_mode) |val| @intFromEnum(val) else c.SDL_LOGICAL_PRESENTATION_DISABLED,
         );
         if (!ret)
             return error.SdlError;
@@ -283,8 +283,8 @@ pub const Renderer = struct {
     ) !struct { width: usize, height: usize, presentation_mode: ?LogicalPresentation } {
         var w: c_int = undefined;
         var h: c_int = undefined;
-        var presentation_mode: C.SDL_RendererLogicalPresentation = undefined;
-        const ret = C.SDL_GetRenderLogicalPresentation(
+        var presentation_mode: c.SDL_RendererLogicalPresentation = undefined;
+        const ret = c.SDL_GetRenderLogicalPresentation(
             self.value,
             &w,
             &h,
@@ -292,15 +292,15 @@ pub const Renderer = struct {
         );
         if (!ret)
             return error.SdlError;
-        return .{ .width = @intCast(w), .height = @intCast(h), .presentation_mode = if (presentation_mode == C.SDL_LOGICAL_PRESENTATION_DISABLED) null else @enumFromInt(presentation_mode) };
+        return .{ .width = @intCast(w), .height = @intCast(h), .presentation_mode = if (presentation_mode == c.SDL_LOGICAL_PRESENTATION_DISABLED) null else @enumFromInt(presentation_mode) };
     }
 
     /// Get the final presentation rectangle for rendering.
     pub fn getLogicalPresentationRect(
         self: Renderer,
     ) !rect.FRect {
-        var presentation_rect: C.SDL_FRect = undefined;
-        const ret = C.SDL_GetRenderLogicalPresentationRect(
+        var presentation_rect: c.SDL_FRect = undefined;
+        const ret = c.SDL_GetRenderLogicalPresentationRect(
             self.value,
             &presentation_rect,
         );
@@ -317,7 +317,7 @@ pub const Renderer = struct {
     ) !struct { x: f32, y: f32 } {
         var render_x: f32 = undefined;
         var render_y: f32 = undefined;
-        const ret = C.SDL_RenderCoordinatesFromWindow(
+        const ret = c.SDL_RenderCoordinatesFromWindow(
             self.value,
             @floatCast(x),
             @floatCast(y),
@@ -337,7 +337,7 @@ pub const Renderer = struct {
     ) !struct { x: f32, y: f32 } {
         var window_x: f32 = undefined;
         var window_y: f32 = undefined;
-        const ret = C.SDL_RenderCoordinatesToWindow(
+        const ret = c.SDL_RenderCoordinatesToWindow(
             self.value,
             @floatCast(x),
             @floatCast(y),
@@ -354,8 +354,8 @@ pub const Renderer = struct {
         self: Renderer,
         viewport: ?rect.IRect,
     ) !void {
-        const viewport_sdl: ?C.SDL_Rect = if (viewport == null) null else viewport.?.toSdl();
-        const ret = C.SDL_SetRenderViewport(
+        const viewport_sdl: ?c.SDL_Rect = if (viewport == null) null else viewport.?.toSdl();
+        const ret = c.SDL_SetRenderViewport(
             self.value,
             if (viewport_sdl == null) null else &(viewport_sdl.?),
         );
@@ -367,8 +367,8 @@ pub const Renderer = struct {
     pub fn getViewport(
         self: Renderer,
     ) ?rect.Rect {
-        var viewport: C.SDL_Rect = undefined;
-        const ret = C.SDL_GetRenderViewport(
+        var viewport: c.SDL_Rect = undefined;
+        const ret = c.SDL_GetRenderViewport(
             self.value,
             &viewport,
         );
@@ -381,7 +381,7 @@ pub const Renderer = struct {
     pub fn viewportSet(
         self: Renderer,
     ) bool {
-        const ret = C.SDL_RenderViewportSet(
+        const ret = c.SDL_RenderViewportSet(
             self.value,
         );
         return ret;
@@ -391,8 +391,8 @@ pub const Renderer = struct {
     pub fn getSafeArea(
         self: Renderer,
     ) ?rect.Rect {
-        var area: C.SDL_Rect = undefined;
-        const ret = C.SDL_GetRenderSafeArea(
+        var area: c.SDL_Rect = undefined;
+        const ret = c.SDL_GetRenderSafeArea(
             self.value,
             &area,
         );
@@ -406,8 +406,8 @@ pub const Renderer = struct {
         self: Renderer,
         clipping: ?rect.IRect,
     ) !void {
-        const clipping_sdl: ?C.SDL_Rect = if (clipping == null) null else clipping.?.toSdl();
-        const ret = C.SDL_SetRenderClipRect(
+        const clipping_sdl: ?c.SDL_Rect = if (clipping == null) null else clipping.?.toSdl();
+        const ret = c.SDL_SetRenderClipRect(
             self.value,
             if (clipping_sdl == null) null else &(clipping_sdl.?),
         );
@@ -419,8 +419,8 @@ pub const Renderer = struct {
     pub fn getClipRect(
         self: Renderer,
     ) ?rect.Rect {
-        var clipping: C.SDL_Rect = undefined;
-        const ret = C.SDL_GetRenderClipRect(
+        var clipping: c.SDL_Rect = undefined;
+        const ret = c.SDL_GetRenderClipRect(
             self.value,
             &clipping,
         );
@@ -435,7 +435,7 @@ pub const Renderer = struct {
     pub fn clipEnabled(
         self: Renderer,
     ) bool {
-        const ret = C.SDL_RenderClipEnabled(
+        const ret = c.SDL_RenderClipEnabled(
             self.value,
         );
         return ret;
@@ -447,7 +447,7 @@ pub const Renderer = struct {
         x: f32,
         y: f32,
     ) !void {
-        const ret = C.SDL_SetRenderScale(
+        const ret = c.SDL_SetRenderScale(
             self.value,
             @floatCast(x),
             @floatCast(y),
@@ -462,7 +462,7 @@ pub const Renderer = struct {
     ) !struct { x: f32, y: f32 } {
         var x: f32 = undefined;
         var y: f32 = undefined;
-        const ret = C.SDL_GetRenderScale(
+        const ret = c.SDL_GetRenderScale(
             self.value,
             &x,
             &y,
@@ -477,7 +477,7 @@ pub const Renderer = struct {
         self: Renderer,
         color: pixels.Color,
     ) !void {
-        const ret = C.SDL_SetRenderDrawColor(
+        const ret = c.SDL_SetRenderDrawColor(
             self.value,
             color.r,
             color.g,
@@ -493,7 +493,7 @@ pub const Renderer = struct {
         self: Renderer,
         color: pixels.FColor,
     ) !void {
-        const ret = C.SDL_SetRenderDrawColorFloat(
+        const ret = c.SDL_SetRenderDrawColorFloat(
             self.value,
             color.r,
             color.g,
@@ -512,7 +512,7 @@ pub const Renderer = struct {
         var g: u8 = undefined;
         var b: u8 = undefined;
         var a: u8 = undefined;
-        const ret = C.SDL_GetRenderDrawColor(
+        const ret = c.SDL_GetRenderDrawColor(
             self.value,
             &r,
             &g,
@@ -532,7 +532,7 @@ pub const Renderer = struct {
         var g: f32 = undefined;
         var b: f32 = undefined;
         var a: f32 = undefined;
-        const ret = C.SDL_GetRenderDrawColorFloat(
+        const ret = c.SDL_GetRenderDrawColorFloat(
             self.value,
             &r,
             &g,
@@ -549,7 +549,7 @@ pub const Renderer = struct {
         self: Renderer,
         scale: f32,
     ) !void {
-        const ret = C.SDL_SetRenderColorScale(
+        const ret = c.SDL_SetRenderColorScale(
             self.value,
             @floatCast(scale),
         );
@@ -562,7 +562,7 @@ pub const Renderer = struct {
         self: Renderer,
     ) !f32 {
         var scale: f32 = undefined;
-        const ret = C.SDL_GetRenderColorScale(
+        const ret = c.SDL_GetRenderColorScale(
             self.value,
             &scale,
         );
@@ -576,9 +576,9 @@ pub const Renderer = struct {
         self: Renderer,
         mode: ?blend_mode.Mode,
     ) !void {
-        const ret = C.SDL_SetRenderDrawBlendMode(
+        const ret = c.SDL_SetRenderDrawBlendMode(
             self.value,
-            if (mode) |mode_val| mode_val.value else C.SDL_BLENDMODE_NONE,
+            if (mode) |mode_val| mode_val.value else c.SDL_BLENDMODE_NONE,
         );
         if (!ret)
             return error.SdlError;
@@ -588,14 +588,14 @@ pub const Renderer = struct {
     pub fn getDrawBlendMode(
         self: Renderer,
     ) !?blend_mode.Mode {
-        var mode: C.SDL_BlendMode = undefined;
-        const ret = C.SDL_GetRenderDrawBlendMode(
+        var mode: c.SDL_BlendMode = undefined;
+        const ret = c.SDL_GetRenderDrawBlendMode(
             self.value,
             &mode,
         );
         if (!ret)
             return error.SdlError;
-        if (mode == C.SDL_BLENDMODE_NONE)
+        if (mode == c.SDL_BLENDMODE_NONE)
             return null;
         return .{ .value = mode };
     }
@@ -604,7 +604,7 @@ pub const Renderer = struct {
     pub fn clear(
         self: Renderer,
     ) !void {
-        const ret = C.SDL_RenderClear(
+        const ret = c.SDL_RenderClear(
             self.value,
         );
         if (!ret)
@@ -616,7 +616,7 @@ pub const Renderer = struct {
         self: Renderer,
         p1: rect.FPoint,
     ) !void {
-        const ret = C.SDL_RenderPoint(
+        const ret = c.SDL_RenderPoint(
             self.value,
             p1.x,
             p1.y,
@@ -630,7 +630,7 @@ pub const Renderer = struct {
         self: Renderer,
         points: []const rect.FPoint,
     ) !void {
-        const ret = C.SDL_RenderPoints(
+        const ret = c.SDL_RenderPoints(
             self.value,
             @ptrCast(points.ptr),
             @intCast(points.len),
@@ -645,7 +645,7 @@ pub const Renderer = struct {
         p1: rect.FPoint,
         p2: rect.FPoint,
     ) !void {
-        const ret = C.SDL_RenderLine(
+        const ret = c.SDL_RenderLine(
             self.value,
             p1.x,
             p1.y,
@@ -661,7 +661,7 @@ pub const Renderer = struct {
         self: Renderer,
         points: []const rect.FPoint,
     ) !void {
-        const ret = C.SDL_RenderLines(
+        const ret = c.SDL_RenderLines(
             self.value,
             @ptrCast(points.ptr),
             @intCast(points.len),
@@ -675,8 +675,8 @@ pub const Renderer = struct {
         self: Renderer,
         dst: ?rect.FRect,
     ) !void {
-        const dst_sdl: ?C.SDL_FRect = if (dst == null) null else dst.?.toSdl();
-        const ret = C.SDL_RenderRect(
+        const dst_sdl: ?c.SDL_FRect = if (dst == null) null else dst.?.toSdl();
+        const ret = c.SDL_RenderRect(
             self.value,
             if (dst_sdl == null) null else &(dst_sdl.?),
         );
@@ -689,7 +689,7 @@ pub const Renderer = struct {
         self: Renderer,
         rects: []const rect.FRect,
     ) !void {
-        const ret = C.SDL_RenderRects(
+        const ret = c.SDL_RenderRects(
             self.value,
             @ptrCast(rects.ptr),
             @intCast(rects.len),
@@ -703,8 +703,8 @@ pub const Renderer = struct {
         self: Renderer,
         dst: ?rect.FRect,
     ) !void {
-        const dst_sdl: ?C.SDL_FRect = if (dst == null) null else dst.?.toSdl();
-        const ret = C.SDL_RenderFillRect(
+        const dst_sdl: ?c.SDL_FRect = if (dst == null) null else dst.?.toSdl();
+        const ret = c.SDL_RenderFillRect(
             self.value,
             if (dst_sdl == null) null else &(dst_sdl.?),
         );
@@ -717,7 +717,7 @@ pub const Renderer = struct {
         self: Renderer,
         rects: []const rect.FRect,
     ) !void {
-        const ret = C.SDL_RenderFillRects(
+        const ret = c.SDL_RenderFillRects(
             self.value,
             @ptrCast(rects.ptr),
             @intCast(rects.len),
@@ -733,9 +733,9 @@ pub const Renderer = struct {
         src_rect: ?rect.FRect,
         dst_rect: ?rect.FRect,
     ) !void {
-        const src_rect_sdl: ?C.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
-        const dst_rect_sdl: ?C.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
-        const ret = C.SDL_RenderTexture(
+        const src_rect_sdl: ?c.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
+        const dst_rect_sdl: ?c.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
+        const ret = c.SDL_RenderTexture(
             self.value,
             texture.value,
             if (src_rect_sdl == null) null else &(src_rect_sdl.?),
@@ -755,17 +755,17 @@ pub const Renderer = struct {
         center: ?rect.FPoint,
         flip_mode: ?surface.FlipMode,
     ) !void {
-        const src_rect_sdl: ?C.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
-        const dst_rect_sdl: ?C.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
-        const center_sdl: ?C.SDL_FPoint = if (center == null) null else center.?.toSdl();
-        const ret = C.SDL_RenderTextureRotated(
+        const src_rect_sdl: ?c.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
+        const dst_rect_sdl: ?c.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
+        const center_sdl: ?c.SDL_FPoint = if (center == null) null else center.?.toSdl();
+        const ret = c.SDL_RenderTextureRotated(
             self.value,
             texture.value,
             if (src_rect_sdl == null) null else &(src_rect_sdl.?),
             if (dst_rect_sdl == null) null else &(dst_rect_sdl.?),
             @floatCast(angle),
             if (center_sdl == null) null else &(center_sdl.?),
-            if (flip_mode) |val| @intFromEnum(val) else C.SDL_FLIP_NONE,
+            if (flip_mode) |val| @intFromEnum(val) else c.SDL_FLIP_NONE,
         );
         if (!ret)
             return error.SdlError;
@@ -779,9 +779,9 @@ pub const Renderer = struct {
         scale: f32,
         dst_rect: ?rect.FRect,
     ) !void {
-        const src_rect_sdl: ?C.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
-        const dst_rect_sdl: ?C.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
-        const ret = C.SDL_RenderTextureTiled(
+        const src_rect_sdl: ?c.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
+        const dst_rect_sdl: ?c.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
+        const ret = c.SDL_RenderTextureTiled(
             self.value,
             texture.value,
             if (src_rect_sdl == null) null else &(src_rect_sdl.?),
@@ -804,9 +804,9 @@ pub const Renderer = struct {
         scale: f32,
         dst_rect: ?rect.FRect,
     ) !void {
-        const src_rect_sdl: ?C.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
-        const dst_rect_sdl: ?C.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
-        const ret = C.SDL_RenderTexture9Grid(
+        const src_rect_sdl: ?c.SDL_FRect = if (src_rect == null) null else src_rect.?.toSdl();
+        const dst_rect_sdl: ?c.SDL_FRect = if (dst_rect == null) null else dst_rect.?.toSdl();
+        const ret = c.SDL_RenderTexture9Grid(
             self.value,
             texture.value,
             if (src_rect_sdl == null) null else &(src_rect_sdl.?),
@@ -830,7 +830,7 @@ pub const Renderer = struct {
         indices: ?[*]const c_int,
         num_indices: usize,
     ) !void {
-        const ret = C.SDL_RenderGeometry(
+        const ret = c.SDL_RenderGeometry(
             self.value,
             if (texture) |texture_val| texture_val.value else null,
             vertices,
@@ -857,7 +857,7 @@ pub const Renderer = struct {
         num_indices: usize,
         bytes_per_index: usize,
     ) !void {
-        const ret = C.SDL_RenderGeometryRaw(
+        const ret = c.SDL_RenderGeometryRaw(
             self.value,
             if (texture) |texture_val| texture_val.value else null,
             xy_positions,
@@ -880,8 +880,8 @@ pub const Renderer = struct {
         self: Renderer,
         capture_area: ?rect.IRect,
     ) !surface.Surface {
-        const capture_area_sdl: ?C.SDL_Rect = if (capture_area == null) null else capture_area.?.toSdl();
-        const ret = C.SDL_RenderReadPixels(
+        const capture_area_sdl: ?c.SDL_Rect = if (capture_area == null) null else capture_area.?.toSdl();
+        const ret = c.SDL_RenderReadPixels(
             self.value,
             if (capture_area_sdl == null) null else &(capture_area_sdl.?),
         );
@@ -894,7 +894,7 @@ pub const Renderer = struct {
     pub fn present(
         self: Renderer,
     ) !void {
-        const ret = C.SDL_RenderPresent(
+        const ret = c.SDL_RenderPresent(
             self.value,
         );
         if (!ret)
@@ -905,7 +905,7 @@ pub const Renderer = struct {
     pub fn deinit(
         self: Renderer,
     ) void {
-        const ret = C.SDL_DestroyRenderer(
+        const ret = c.SDL_DestroyRenderer(
             self.value,
         );
         _ = ret;
@@ -915,7 +915,7 @@ pub const Renderer = struct {
     pub fn flush(
         self: Renderer,
     ) !void {
-        const ret = C.SDL_FlushRenderer(
+        const ret = c.SDL_FlushRenderer(
             self.value,
         );
         if (!ret)
@@ -926,7 +926,7 @@ pub const Renderer = struct {
     pub fn getMetalLayer(
         self: Renderer,
     ) ?*anyopaque {
-        const ret = C.SDL_GetRenderMetalLayer(
+        const ret = c.SDL_GetRenderMetalLayer(
             self.value,
         );
         return ret;
@@ -936,7 +936,7 @@ pub const Renderer = struct {
     pub fn getMetalCommandEncoder(
         self: Renderer,
     ) ?*anyopaque {
-        const ret = C.SDL_GetRenderMetalCommandEncoder(
+        const ret = c.SDL_GetRenderMetalCommandEncoder(
             self.value,
         );
         return ret;
@@ -949,7 +949,7 @@ pub const Renderer = struct {
         wait_semaphore: i64,
         signal_semaphore: i64,
     ) !void {
-        const ret = C.SDL_AddVulkanRenderSemaphores(
+        const ret = c.SDL_AddVulkanRenderSemaphores(
             self.value,
             @intCast(wait_stage_mask),
             @intCast(wait_semaphore),
@@ -964,7 +964,7 @@ pub const Renderer = struct {
         self: Renderer,
         vsync: ?VSync,
     ) !void {
-        const ret = C.SDL_SetRenderVSync(self.value, VSync.toSdl(vsync));
+        const ret = c.SDL_SetRenderVSync(self.value, VSync.toSdl(vsync));
         if (!ret)
             return error.SdlError;
     }
@@ -974,7 +974,7 @@ pub const Renderer = struct {
         self: Renderer,
     ) !?VSync {
         var vsync: c_int = undefined;
-        const ret = C.SDL_GetRenderVSync(self.value, &vsync);
+        const ret = c.SDL_GetRenderVSync(self.value, &vsync);
         if (!ret)
             return error.SdlError;
         return VSync.fromSdl(vsync);
@@ -983,13 +983,13 @@ pub const Renderer = struct {
 
 /// An efficient driver-specific representation of pixel data.
 pub const Texture = struct {
-    value: *C.SDL_Texture,
+    value: *c.SDL_Texture,
 
     /// Get the properties associated with a texture.
     pub fn getProperties(
         self: Texture,
     ) !properties.Group {
-        const ret = C.SDL_GetTextureProperties(
+        const ret = c.SDL_GetTextureProperties(
             self.value,
         );
         if (ret == 0)
@@ -1001,7 +1001,7 @@ pub const Texture = struct {
     pub fn getRenderer(
         self: Texture,
     ) !Renderer {
-        const ret = C.SDL_GetRendererFromTexture(
+        const ret = c.SDL_GetRendererFromTexture(
             self.value,
         );
         if (ret == null)
@@ -1015,7 +1015,7 @@ pub const Texture = struct {
     ) !struct { width: f32, height: f32 } {
         var w: f32 = undefined;
         var h: f32 = undefined;
-        const ret = C.SDL_GetTextureSize(
+        const ret = c.SDL_GetTextureSize(
             self.value,
             &w,
             &h,
@@ -1032,7 +1032,7 @@ pub const Texture = struct {
         g: u8,
         b: u8,
     ) !void {
-        const ret = C.SDL_SetTextureColorMod(
+        const ret = c.SDL_SetTextureColorMod(
             self.value,
             @intCast(r),
             @intCast(g),
@@ -1049,7 +1049,7 @@ pub const Texture = struct {
         g: f32,
         b: f32,
     ) !void {
-        const ret = C.SDL_SetTextureColorModFloat(
+        const ret = c.SDL_SetTextureColorModFloat(
             self.value,
             @floatCast(r),
             @floatCast(g),
@@ -1066,7 +1066,7 @@ pub const Texture = struct {
         var r: u8 = undefined;
         var g: u8 = undefined;
         var b: u8 = undefined;
-        const ret = C.SDL_GetTextureColorMod(
+        const ret = c.SDL_GetTextureColorMod(
             self.value,
             &r,
             &g,
@@ -1084,7 +1084,7 @@ pub const Texture = struct {
         var r: f32 = undefined;
         var g: f32 = undefined;
         var b: f32 = undefined;
-        const ret = C.SDL_GetTextureColorModFloat(
+        const ret = c.SDL_GetTextureColorModFloat(
             self.value,
             &r,
             &g,
@@ -1100,7 +1100,7 @@ pub const Texture = struct {
         self: Texture,
         alpha: u8,
     ) !void {
-        const ret = C.SDL_SetTextureAlphaMod(
+        const ret = c.SDL_SetTextureAlphaMod(
             self.value,
             @intCast(alpha),
         );
@@ -1113,7 +1113,7 @@ pub const Texture = struct {
         self: Texture,
         alpha: f32,
     ) !void {
-        const ret = C.SDL_SetTextureAlphaModFloat(
+        const ret = c.SDL_SetTextureAlphaModFloat(
             self.value,
             @floatCast(alpha),
         );
@@ -1126,7 +1126,7 @@ pub const Texture = struct {
         self: Texture,
     ) !u8 {
         var alpha: u8 = undefined;
-        const ret = C.SDL_GetTextureAlphaMod(
+        const ret = c.SDL_GetTextureAlphaMod(
             self.value,
             &alpha,
         );
@@ -1140,7 +1140,7 @@ pub const Texture = struct {
         self: Texture,
     ) !f32 {
         var alpha: f32 = undefined;
-        const ret = C.SDL_GetTextureAlphaModFloat(
+        const ret = c.SDL_GetTextureAlphaModFloat(
             self.value,
             &alpha,
         );
@@ -1154,7 +1154,7 @@ pub const Texture = struct {
         self: Texture,
         mode: blend_mode.Mode,
     ) !void {
-        const ret = C.SDL_SetTextureBlendMode(
+        const ret = c.SDL_SetTextureBlendMode(
             self.value,
             mode.value,
         );
@@ -1166,14 +1166,14 @@ pub const Texture = struct {
     pub fn getBlendMode(
         self: Texture,
     ) !?blend_mode.Mode {
-        var mode: C.SDL_BlendMode = undefined;
-        const ret = C.SDL_GetTextureBlendMode(
+        var mode: c.SDL_BlendMode = undefined;
+        const ret = c.SDL_GetTextureBlendMode(
             self.value,
             &mode,
         );
         if (!ret)
             return error.SdlError;
-        if (mode == C.SDL_BLENDMODE_INVALID)
+        if (mode == c.SDL_BLENDMODE_INVALID)
             return null;
         return .{ .value = mode };
     }
@@ -1183,7 +1183,7 @@ pub const Texture = struct {
         self: Texture,
         mode: surface.ScaleMode,
     ) !void {
-        const ret = C.SDL_SetTextureScaleMode(
+        const ret = c.SDL_SetTextureScaleMode(
             self.value,
             @intFromEnum(mode),
         );
@@ -1195,8 +1195,8 @@ pub const Texture = struct {
     pub fn getScaleMode(
         self: Texture,
     ) !surface.ScaleMode {
-        var mode: C.SDL_ScaleMode = undefined;
-        const ret = C.SDL_GetTextureScaleMode(
+        var mode: c.SDL_ScaleMode = undefined;
+        const ret = c.SDL_GetTextureScaleMode(
             self.value,
             &mode,
         );
@@ -1211,8 +1211,8 @@ pub const Texture = struct {
         update_area: ?rect.IRect,
         data: []const u8,
     ) !void {
-        const update_area_sdl: ?C.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
-        const ret = C.SDL_UpdateTexture(
+        const update_area_sdl: ?c.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
+        const ret = c.SDL_UpdateTexture(
             self.value,
             if (update_area_sdl == null) null else &(update_area_sdl.?),
             data.ptr,
@@ -1230,8 +1230,8 @@ pub const Texture = struct {
         u_data: []const u8,
         v_data: []const u8,
     ) !void {
-        const update_area_sdl: ?C.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
-        const ret = C.SDL_UpdateYUVTexture(
+        const update_area_sdl: ?c.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
+        const ret = c.SDL_UpdateYUVTexture(
             self.value,
             if (update_area_sdl == null) null else &(update_area_sdl.?),
             y_data.ptr,
@@ -1252,8 +1252,8 @@ pub const Texture = struct {
         y_data: []const u8,
         uv_data: []const u8,
     ) !void {
-        const update_area_sdl: ?C.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
-        const ret = C.SDL_UpdateNVTexture(
+        const update_area_sdl: ?c.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
+        const ret = c.SDL_UpdateNVTexture(
             self.value,
             if (update_area_sdl == null) null else &(update_area_sdl.?),
             y_data.ptr,
@@ -1270,10 +1270,10 @@ pub const Texture = struct {
         self: Texture,
         update_area: ?rect.IRect,
     ) ![]u8 {
-        const update_area_sdl: ?C.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
+        const update_area_sdl: ?c.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
         var data: ?*anyopaque = undefined;
         var pitch: c_int = undefined;
-        const ret = C.SDL_LockTexture(
+        const ret = c.SDL_LockTexture(
             self.value,
             if (update_area_sdl == null) null else &(update_area_sdl.?),
             &data,
@@ -1289,9 +1289,9 @@ pub const Texture = struct {
         self: Texture,
         update_area: ?rect.IRect,
     ) !surface.Surface {
-        const update_area_sdl: ?C.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
-        var target_surface: C.SDL_Surface = undefined;
-        const ret = C.SDL_LockTextureToSurface(
+        const update_area_sdl: ?c.SDL_Rect = if (update_area == null) null else update_area.?.toSdl();
+        var target_surface: c.SDL_Surface = undefined;
+        const ret = c.SDL_LockTextureToSurface(
             self.value,
             if (update_area_sdl == null) null else &(update_area_sdl.?),
             &target_surface,
@@ -1305,7 +1305,7 @@ pub const Texture = struct {
     pub fn unlock(
         self: Texture,
     ) void {
-        const ret = C.SDL_UnlockTexture(
+        const ret = c.SDL_UnlockTexture(
             self.value,
         );
         _ = ret;
@@ -1315,7 +1315,7 @@ pub const Texture = struct {
     pub fn deinit(
         self: Texture,
     ) void {
-        const ret = C.SDL_DestroyTexture(
+        const ret = c.SDL_DestroyTexture(
             self.value,
         );
         _ = ret;
@@ -1323,7 +1323,7 @@ pub const Texture = struct {
 
     /// Get the pixel format for the texture.
     pub fn getPixelFormat(self: Texture) ?pixels.Format {
-        return if (self.value.format == C.SDL_PIXELFORMAT_UNKNOWN) null else @enumFromInt(self.value.format);
+        return if (self.value.format == c.SDL_PIXELFORMAT_UNKNOWN) null else @enumFromInt(self.value.format);
     }
 
     /// Get the width of the texture.
@@ -1372,7 +1372,7 @@ pub const VSync = union(enum) {
 };
 
 /// The name of the software renderer.
-pub const software_renderer_name = C.SDL_SOFTWARE_RENDERER;
+pub const software_renderer_name = c.SDL_SOFTWARE_RENDERER;
 
 const blend_mode = @import("blend_mode.zig");
 const video = @import("video.zig");

--- a/src/scancode.zig
+++ b/src/scancode.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// The SDL keyboard scancode representation.
@@ -12,66 +12,66 @@ const std = @import("std");
 ///
 /// ## Version
 /// This enum is available since SDL 3.2.0.
-pub const Scancode = enum(C.SDL_Scancode) {
-    a = C.SDL_SCANCODE_A,
-    b = C.SDL_SCANCODE_B,
-    c = C.SDL_SCANCODE_C,
-    d = C.SDL_SCANCODE_D,
-    e = C.SDL_SCANCODE_E,
-    f = C.SDL_SCANCODE_F,
-    g = C.SDL_SCANCODE_G,
-    h = C.SDL_SCANCODE_H,
-    i = C.SDL_SCANCODE_I,
-    j = C.SDL_SCANCODE_J,
-    k = C.SDL_SCANCODE_K,
-    l = C.SDL_SCANCODE_L,
-    m = C.SDL_SCANCODE_M,
-    n = C.SDL_SCANCODE_N,
-    o = C.SDL_SCANCODE_O,
-    p = C.SDL_SCANCODE_P,
-    q = C.SDL_SCANCODE_Q,
-    r = C.SDL_SCANCODE_R,
-    s = C.SDL_SCANCODE_S,
-    t = C.SDL_SCANCODE_T,
-    u = C.SDL_SCANCODE_U,
-    v = C.SDL_SCANCODE_V,
-    w = C.SDL_SCANCODE_W,
-    x = C.SDL_SCANCODE_X,
-    y = C.SDL_SCANCODE_Y,
-    z = C.SDL_SCANCODE_Z,
-    one = C.SDL_SCANCODE_1,
-    two = C.SDL_SCANCODE_2,
-    three = C.SDL_SCANCODE_3,
-    four = C.SDL_SCANCODE_4,
-    five = C.SDL_SCANCODE_5,
-    six = C.SDL_SCANCODE_6,
-    seven = C.SDL_SCANCODE_7,
-    eight = C.SDL_SCANCODE_8,
-    nine = C.SDL_SCANCODE_9,
-    zero = C.SDL_SCANCODE_0,
-    return_key = C.SDL_SCANCODE_RETURN,
-    escape = C.SDL_SCANCODE_ESCAPE,
-    backspace = C.SDL_SCANCODE_BACKSPACE,
-    tab = C.SDL_SCANCODE_TAB,
-    space = C.SDL_SCANCODE_SPACE,
-    minus = C.SDL_SCANCODE_MINUS,
-    equals = C.SDL_SCANCODE_EQUALS,
-    left_bracket = C.SDL_SCANCODE_LEFTBRACKET,
-    right_bracket = C.SDL_SCANCODE_RIGHTBRACKET,
+pub const Scancode = enum(c.SDL_Scancode) {
+    a = c.SDL_SCANCODE_A,
+    b = c.SDL_SCANCODE_B,
+    c = c.SDL_SCANCODE_C,
+    d = c.SDL_SCANCODE_D,
+    e = c.SDL_SCANCODE_E,
+    f = c.SDL_SCANCODE_F,
+    g = c.SDL_SCANCODE_G,
+    h = c.SDL_SCANCODE_H,
+    i = c.SDL_SCANCODE_I,
+    j = c.SDL_SCANCODE_J,
+    k = c.SDL_SCANCODE_K,
+    l = c.SDL_SCANCODE_L,
+    m = c.SDL_SCANCODE_M,
+    n = c.SDL_SCANCODE_N,
+    o = c.SDL_SCANCODE_O,
+    p = c.SDL_SCANCODE_P,
+    q = c.SDL_SCANCODE_Q,
+    r = c.SDL_SCANCODE_R,
+    s = c.SDL_SCANCODE_S,
+    t = c.SDL_SCANCODE_T,
+    u = c.SDL_SCANCODE_U,
+    v = c.SDL_SCANCODE_V,
+    w = c.SDL_SCANCODE_W,
+    x = c.SDL_SCANCODE_X,
+    y = c.SDL_SCANCODE_Y,
+    z = c.SDL_SCANCODE_Z,
+    one = c.SDL_SCANCODE_1,
+    two = c.SDL_SCANCODE_2,
+    three = c.SDL_SCANCODE_3,
+    four = c.SDL_SCANCODE_4,
+    five = c.SDL_SCANCODE_5,
+    six = c.SDL_SCANCODE_6,
+    seven = c.SDL_SCANCODE_7,
+    eight = c.SDL_SCANCODE_8,
+    nine = c.SDL_SCANCODE_9,
+    zero = c.SDL_SCANCODE_0,
+    return_key = c.SDL_SCANCODE_RETURN,
+    escape = c.SDL_SCANCODE_ESCAPE,
+    backspace = c.SDL_SCANCODE_BACKSPACE,
+    tab = c.SDL_SCANCODE_TAB,
+    space = c.SDL_SCANCODE_SPACE,
+    minus = c.SDL_SCANCODE_MINUS,
+    equals = c.SDL_SCANCODE_EQUALS,
+    left_bracket = c.SDL_SCANCODE_LEFTBRACKET,
+    right_bracket = c.SDL_SCANCODE_RIGHTBRACKET,
 
     /// Located at the lower left of the return key on ISO keyboards and at the right end of the QWERTY row on ANSI keyboards.
     /// Produces REVERSE SOLIDUS (backslash) and VERTICAL LINE in a US layout, REVERSE SOLIDUS and VERTICAL LINE in a UK Mac layout,
     /// NUMBER SIGN and TILDE in a UK Windows layout, DOLLAR SIGN and POUND SIGN in a Swiss German layout, NUMBER SIGN and APOSTROPHE in a German layout,
     /// GRAVE ACCENT and POUND SIGN in a French Mac layout, and ASTERISK and MICRO SIGN in a French Windows layout.
-    backslash = C.SDL_SCANCODE_BACKSLASH,
+    backslash = c.SDL_SCANCODE_BACKSLASH,
 
     /// ISO USB keyboards actually use this code instead of 49 for the same key, but all OSes I've seen treat the two codes identically.
     /// So, as an implementor, unless your keyboard generates both of those codes and your OS treats them differently,
     /// you should generate SDL_SCANCODE_BACKSLASH instead of this code.
     /// As a user, you should not rely on this code because SDL will never generate it with most (all?) keyboards.
-    non_us_hash = C.SDL_SCANCODE_NONUSHASH,
-    semicolon = C.SDL_SCANCODE_SEMICOLON,
-    apostrophe = C.SDL_SCANCODE_APOSTROPHE,
+    non_us_hash = c.SDL_SCANCODE_NONUSHASH,
+    semicolon = c.SDL_SCANCODE_SEMICOLON,
+    apostrophe = c.SDL_SCANCODE_APOSTROPHE,
 
     /// Located in the top left corner (on both ANSI and ISO keyboards).
     /// Produces GRAVE ACCENT and TILDE in a US Windows layout and in US and UK Mac layouts on ANSI keyboards, GRAVE ACCENT and NOT SIGN in a UK Windows layout,
@@ -79,335 +79,335 @@ pub const Scancode = enum(C.SDL_Scancode) {
     /// CIRCUMFLEX ACCENT and DEGREE SIGN in a German layout (Mac: only on ISO keyboards), SUPERSCRIPT TWO and TILDE in a French Windows layout,
     /// COMMERCIAL AT and NUMBER SIGN in a French Mac layout on ISO keyboards, and LESS-THAN SIGN and GREATER-THAN SIGN in a Swiss German, German,
     /// or French Mac layout on ANSI keyboards.
-    grave = C.SDL_SCANCODE_GRAVE,
-    comma = C.SDL_SCANCODE_COMMA,
-    period = C.SDL_SCANCODE_PERIOD,
-    slash = C.SDL_SCANCODE_SLASH,
-    caps_lock = C.SDL_SCANCODE_CAPSLOCK,
-    func1 = C.SDL_SCANCODE_F1,
-    func2 = C.SDL_SCANCODE_F2,
-    func3 = C.SDL_SCANCODE_F3,
-    func4 = C.SDL_SCANCODE_F4,
-    func5 = C.SDL_SCANCODE_F5,
-    func6 = C.SDL_SCANCODE_F6,
-    func7 = C.SDL_SCANCODE_F7,
-    func8 = C.SDL_SCANCODE_F8,
-    func9 = C.SDL_SCANCODE_F9,
-    func10 = C.SDL_SCANCODE_F10,
-    func11 = C.SDL_SCANCODE_F11,
-    func12 = C.SDL_SCANCODE_F12,
-    print_screen = C.SDL_SCANCODE_PRINTSCREEN,
-    scroll_lock = C.SDL_SCANCODE_SCROLLLOCK,
-    pause = C.SDL_SCANCODE_PAUSE,
+    grave = c.SDL_SCANCODE_GRAVE,
+    comma = c.SDL_SCANCODE_COMMA,
+    period = c.SDL_SCANCODE_PERIOD,
+    slash = c.SDL_SCANCODE_SLASH,
+    caps_lock = c.SDL_SCANCODE_CAPSLOCK,
+    func1 = c.SDL_SCANCODE_F1,
+    func2 = c.SDL_SCANCODE_F2,
+    func3 = c.SDL_SCANCODE_F3,
+    func4 = c.SDL_SCANCODE_F4,
+    func5 = c.SDL_SCANCODE_F5,
+    func6 = c.SDL_SCANCODE_F6,
+    func7 = c.SDL_SCANCODE_F7,
+    func8 = c.SDL_SCANCODE_F8,
+    func9 = c.SDL_SCANCODE_F9,
+    func10 = c.SDL_SCANCODE_F10,
+    func11 = c.SDL_SCANCODE_F11,
+    func12 = c.SDL_SCANCODE_F12,
+    print_screen = c.SDL_SCANCODE_PRINTSCREEN,
+    scroll_lock = c.SDL_SCANCODE_SCROLLLOCK,
+    pause = c.SDL_SCANCODE_PAUSE,
 
     /// Insert on PC, help on some Mac keyboards (but does send code 73, not 117).
-    insert = C.SDL_SCANCODE_INSERT,
-    home = C.SDL_SCANCODE_HOME,
-    pageup = C.SDL_SCANCODE_PAGEUP,
-    delete = C.SDL_SCANCODE_DELETE,
-    end = C.SDL_SCANCODE_END,
-    pagedown = C.SDL_SCANCODE_PAGEDOWN,
-    right = C.SDL_SCANCODE_RIGHT,
-    left = C.SDL_SCANCODE_LEFT,
-    down = C.SDL_SCANCODE_DOWN,
-    up = C.SDL_SCANCODE_UP,
+    insert = c.SDL_SCANCODE_INSERT,
+    home = c.SDL_SCANCODE_HOME,
+    pageup = c.SDL_SCANCODE_PAGEUP,
+    delete = c.SDL_SCANCODE_DELETE,
+    end = c.SDL_SCANCODE_END,
+    pagedown = c.SDL_SCANCODE_PAGEDOWN,
+    right = c.SDL_SCANCODE_RIGHT,
+    left = c.SDL_SCANCODE_LEFT,
+    down = c.SDL_SCANCODE_DOWN,
+    up = c.SDL_SCANCODE_UP,
 
     /// Num lock on PC, clear on Mac keyboards.
-    num_lock_clear = C.SDL_SCANCODE_NUMLOCKCLEAR,
-    kp_divide = C.SDL_SCANCODE_KP_DIVIDE,
-    kp_multiply = C.SDL_SCANCODE_KP_MULTIPLY,
-    kp_minus = C.SDL_SCANCODE_KP_MINUS,
-    kp_plus = C.SDL_SCANCODE_KP_PLUS,
-    kp_enter = C.SDL_SCANCODE_KP_ENTER,
-    kp_1 = C.SDL_SCANCODE_KP_1,
-    kp_2 = C.SDL_SCANCODE_KP_2,
-    kp_3 = C.SDL_SCANCODE_KP_3,
-    kp_4 = C.SDL_SCANCODE_KP_4,
-    kp_5 = C.SDL_SCANCODE_KP_5,
-    kp_6 = C.SDL_SCANCODE_KP_6,
-    kp_7 = C.SDL_SCANCODE_KP_7,
-    kp_8 = C.SDL_SCANCODE_KP_8,
-    kp_9 = C.SDL_SCANCODE_KP_9,
-    kp_0 = C.SDL_SCANCODE_KP_0,
-    kp_period = C.SDL_SCANCODE_KP_PERIOD,
+    num_lock_clear = c.SDL_SCANCODE_NUMLOCKCLEAR,
+    kp_divide = c.SDL_SCANCODE_KP_DIVIDE,
+    kp_multiply = c.SDL_SCANCODE_KP_MULTIPLY,
+    kp_minus = c.SDL_SCANCODE_KP_MINUS,
+    kp_plus = c.SDL_SCANCODE_KP_PLUS,
+    kp_enter = c.SDL_SCANCODE_KP_ENTER,
+    kp_1 = c.SDL_SCANCODE_KP_1,
+    kp_2 = c.SDL_SCANCODE_KP_2,
+    kp_3 = c.SDL_SCANCODE_KP_3,
+    kp_4 = c.SDL_SCANCODE_KP_4,
+    kp_5 = c.SDL_SCANCODE_KP_5,
+    kp_6 = c.SDL_SCANCODE_KP_6,
+    kp_7 = c.SDL_SCANCODE_KP_7,
+    kp_8 = c.SDL_SCANCODE_KP_8,
+    kp_9 = c.SDL_SCANCODE_KP_9,
+    kp_0 = c.SDL_SCANCODE_KP_0,
+    kp_period = c.SDL_SCANCODE_KP_PERIOD,
 
     /// This is the additional key that ISO keyboards have over ANSI ones, located between left shift and Y.
     /// Produces GRAVE ACCENT and TILDE in a US or UK Mac layout, REVERSE SOLIDUS (backslash) and VERTICAL LINE in a US or UK Windows layout,
     /// and LESS-THAN SIGN and GREATER-THAN SIGN in a Swiss German, German, or French layout.
-    non_us_backslash = C.SDL_SCANCODE_NONUSBACKSLASH,
+    non_us_backslash = c.SDL_SCANCODE_NONUSBACKSLASH,
 
     /// Windows contextual menu, compose.
-    application = C.SDL_SCANCODE_APPLICATION,
+    application = c.SDL_SCANCODE_APPLICATION,
 
     /// The USB document says this is a status flag, not a physical key, but some Mac keyboards do have a power key.
-    power = C.SDL_SCANCODE_POWER,
-    kp_equals = C.SDL_SCANCODE_KP_EQUALS,
-    func13 = C.SDL_SCANCODE_F13,
-    func14 = C.SDL_SCANCODE_F14,
-    func15 = C.SDL_SCANCODE_F15,
-    func16 = C.SDL_SCANCODE_F16,
-    func17 = C.SDL_SCANCODE_F17,
-    func18 = C.SDL_SCANCODE_F18,
-    func19 = C.SDL_SCANCODE_F19,
-    func20 = C.SDL_SCANCODE_F20,
-    func21 = C.SDL_SCANCODE_F21,
-    func22 = C.SDL_SCANCODE_F22,
-    func23 = C.SDL_SCANCODE_F23,
-    func24 = C.SDL_SCANCODE_F24,
-    execute = C.SDL_SCANCODE_EXECUTE,
+    power = c.SDL_SCANCODE_POWER,
+    kp_equals = c.SDL_SCANCODE_KP_EQUALS,
+    func13 = c.SDL_SCANCODE_F13,
+    func14 = c.SDL_SCANCODE_F14,
+    func15 = c.SDL_SCANCODE_F15,
+    func16 = c.SDL_SCANCODE_F16,
+    func17 = c.SDL_SCANCODE_F17,
+    func18 = c.SDL_SCANCODE_F18,
+    func19 = c.SDL_SCANCODE_F19,
+    func20 = c.SDL_SCANCODE_F20,
+    func21 = c.SDL_SCANCODE_F21,
+    func22 = c.SDL_SCANCODE_F22,
+    func23 = c.SDL_SCANCODE_F23,
+    func24 = c.SDL_SCANCODE_F24,
+    execute = c.SDL_SCANCODE_EXECUTE,
 
     /// AL Integrated Help Center.
-    help = C.SDL_SCANCODE_HELP,
+    help = c.SDL_SCANCODE_HELP,
 
     /// Menu (show menu).
-    menu = C.SDL_SCANCODE_MENU,
-    select = C.SDL_SCANCODE_SELECT,
+    menu = c.SDL_SCANCODE_MENU,
+    select = c.SDL_SCANCODE_SELECT,
 
     /// AC Stop.
-    stop = C.SDL_SCANCODE_STOP,
+    stop = c.SDL_SCANCODE_STOP,
 
     /// AC Redo/Repeat.
-    again = C.SDL_SCANCODE_AGAIN,
+    again = c.SDL_SCANCODE_AGAIN,
 
     /// AC Undo.
-    undo = C.SDL_SCANCODE_UNDO,
+    undo = c.SDL_SCANCODE_UNDO,
 
     /// AC Cut.
-    cut = C.SDL_SCANCODE_CUT,
+    cut = c.SDL_SCANCODE_CUT,
 
     /// AC Copy.
-    copy = C.SDL_SCANCODE_COPY,
+    copy = c.SDL_SCANCODE_COPY,
 
     /// AC Paste.
-    paste = C.SDL_SCANCODE_PASTE,
+    paste = c.SDL_SCANCODE_PASTE,
 
     /// AC Find.
-    find = C.SDL_SCANCODE_FIND,
-    mute = C.SDL_SCANCODE_MUTE,
-    volume_up = C.SDL_SCANCODE_VOLUMEUP,
-    volume_down = C.SDL_SCANCODE_VOLUMEDOWN,
-    kp_comma = C.SDL_SCANCODE_KP_COMMA,
-    kp_equals_as_400 = C.SDL_SCANCODE_KP_EQUALSAS400,
+    find = c.SDL_SCANCODE_FIND,
+    mute = c.SDL_SCANCODE_MUTE,
+    volume_up = c.SDL_SCANCODE_VOLUMEUP,
+    volume_down = c.SDL_SCANCODE_VOLUMEDOWN,
+    kp_comma = c.SDL_SCANCODE_KP_COMMA,
+    kp_equals_as_400 = c.SDL_SCANCODE_KP_EQUALSAS400,
 
     /// Used on Asian keyboards, see footnotes in USB doc.
-    international1 = C.SDL_SCANCODE_INTERNATIONAL1,
-    international2 = C.SDL_SCANCODE_INTERNATIONAL2,
+    international1 = c.SDL_SCANCODE_INTERNATIONAL1,
+    international2 = c.SDL_SCANCODE_INTERNATIONAL2,
 
     /// Yen.
-    international3 = C.SDL_SCANCODE_INTERNATIONAL3,
-    international4 = C.SDL_SCANCODE_INTERNATIONAL4,
-    international5 = C.SDL_SCANCODE_INTERNATIONAL5,
-    international6 = C.SDL_SCANCODE_INTERNATIONAL6,
-    international7 = C.SDL_SCANCODE_INTERNATIONAL7,
-    international8 = C.SDL_SCANCODE_INTERNATIONAL8,
-    international9 = C.SDL_SCANCODE_INTERNATIONAL9,
+    international3 = c.SDL_SCANCODE_INTERNATIONAL3,
+    international4 = c.SDL_SCANCODE_INTERNATIONAL4,
+    international5 = c.SDL_SCANCODE_INTERNATIONAL5,
+    international6 = c.SDL_SCANCODE_INTERNATIONAL6,
+    international7 = c.SDL_SCANCODE_INTERNATIONAL7,
+    international8 = c.SDL_SCANCODE_INTERNATIONAL8,
+    international9 = c.SDL_SCANCODE_INTERNATIONAL9,
 
     /// Hangul/English toggle.
-    lang1 = C.SDL_SCANCODE_LANG1,
+    lang1 = c.SDL_SCANCODE_LANG1,
 
     /// Hanja conversion.
-    lang2 = C.SDL_SCANCODE_LANG2,
+    lang2 = c.SDL_SCANCODE_LANG2,
 
     /// Katakana.
-    lang3 = C.SDL_SCANCODE_LANG3,
+    lang3 = c.SDL_SCANCODE_LANG3,
 
     /// Hiragana.
-    lang4 = C.SDL_SCANCODE_LANG4,
+    lang4 = c.SDL_SCANCODE_LANG4,
 
     /// Zenkaku/Hankaku.
-    lang5 = C.SDL_SCANCODE_LANG5,
+    lang5 = c.SDL_SCANCODE_LANG5,
 
     /// Reserved.
-    lang6 = C.SDL_SCANCODE_LANG6,
+    lang6 = c.SDL_SCANCODE_LANG6,
 
     /// Reserved.
-    lang7 = C.SDL_SCANCODE_LANG7,
+    lang7 = c.SDL_SCANCODE_LANG7,
 
     /// Reserved.
-    lang8 = C.SDL_SCANCODE_LANG8,
+    lang8 = c.SDL_SCANCODE_LANG8,
 
     /// Reserved.
-    lang9 = C.SDL_SCANCODE_LANG9,
+    lang9 = c.SDL_SCANCODE_LANG9,
 
     /// Erase-Eaze.
-    alt_erase = C.SDL_SCANCODE_ALTERASE,
-    sysreq = C.SDL_SCANCODE_SYSREQ,
+    alt_erase = c.SDL_SCANCODE_ALTERASE,
+    sysreq = c.SDL_SCANCODE_SYSREQ,
 
     /// AC Cancel.
-    cancel = C.SDL_SCANCODE_CANCEL,
-    clear = C.SDL_SCANCODE_CLEAR,
-    prior = C.SDL_SCANCODE_PRIOR,
-    return2 = C.SDL_SCANCODE_RETURN2,
-    separator = C.SDL_SCANCODE_SEPARATOR,
-    out = C.SDL_SCANCODE_OUT,
-    oper = C.SDL_SCANCODE_OPER,
-    clear_again = C.SDL_SCANCODE_CLEARAGAIN,
-    cr_sel = C.SDL_SCANCODE_CRSEL,
-    ex_sel = C.SDL_SCANCODE_EXSEL,
-    kp_00 = C.SDL_SCANCODE_KP_00,
-    kp_000 = C.SDL_SCANCODE_KP_000,
-    thousands_separator = C.SDL_SCANCODE_THOUSANDSSEPARATOR,
-    decimals_eparator = C.SDL_SCANCODE_DECIMALSEPARATOR,
-    currency_unit = C.SDL_SCANCODE_CURRENCYUNIT,
-    currency_subunit = C.SDL_SCANCODE_CURRENCYSUBUNIT,
-    kp_left_paren = C.SDL_SCANCODE_KP_LEFTPAREN,
-    kp_right_paren = C.SDL_SCANCODE_KP_RIGHTPAREN,
-    kp_left_brace = C.SDL_SCANCODE_KP_LEFTBRACE,
-    kp_right_brace = C.SDL_SCANCODE_KP_RIGHTBRACE,
-    kp_tab = C.SDL_SCANCODE_KP_TAB,
-    kp_backspace = C.SDL_SCANCODE_KP_BACKSPACE,
-    kp_a = C.SDL_SCANCODE_KP_A,
-    kp_b = C.SDL_SCANCODE_KP_B,
-    kp_c = C.SDL_SCANCODE_KP_C,
-    kp_d = C.SDL_SCANCODE_KP_D,
-    kp_e = C.SDL_SCANCODE_KP_E,
-    kp_f = C.SDL_SCANCODE_KP_F,
-    kp_xor = C.SDL_SCANCODE_KP_XOR,
-    kp_power = C.SDL_SCANCODE_KP_POWER,
-    kp_percent = C.SDL_SCANCODE_KP_PERCENT,
-    kp_less = C.SDL_SCANCODE_KP_LESS,
-    kp_greater = C.SDL_SCANCODE_KP_GREATER,
-    kp_ampersand = C.SDL_SCANCODE_KP_AMPERSAND,
-    kp_dbl_ampersand = C.SDL_SCANCODE_KP_DBLAMPERSAND,
-    kp_vertical_bar = C.SDL_SCANCODE_KP_VERTICALBAR,
-    kp_dbl_vertical_bar = C.SDL_SCANCODE_KP_DBLVERTICALBAR,
-    kp_colon = C.SDL_SCANCODE_KP_COLON,
-    kp_hash = C.SDL_SCANCODE_KP_HASH,
-    kp_space = C.SDL_SCANCODE_KP_SPACE,
-    kp_at = C.SDL_SCANCODE_KP_AT,
-    kp_exclam = C.SDL_SCANCODE_KP_EXCLAM,
-    kp_mem_store = C.SDL_SCANCODE_KP_MEMSTORE,
-    kp_mem_recall = C.SDL_SCANCODE_KP_MEMRECALL,
-    kp_mem_clear = C.SDL_SCANCODE_KP_MEMCLEAR,
-    kp_mem_add = C.SDL_SCANCODE_KP_MEMADD,
-    kp_mem_subtract = C.SDL_SCANCODE_KP_MEMSUBTRACT,
-    kp_mem_multiply = C.SDL_SCANCODE_KP_MEMMULTIPLY,
-    kp_mem_divide = C.SDL_SCANCODE_KP_MEMDIVIDE,
-    kp_plus_minus = C.SDL_SCANCODE_KP_PLUSMINUS,
-    kp_clear = C.SDL_SCANCODE_KP_CLEAR,
-    kp_clear_entry = C.SDL_SCANCODE_KP_CLEARENTRY,
-    kp_binary = C.SDL_SCANCODE_KP_BINARY,
-    kp_octal = C.SDL_SCANCODE_KP_OCTAL,
-    kp_decimal = C.SDL_SCANCODE_KP_DECIMAL,
-    kp_hexadecimal = C.SDL_SCANCODE_KP_HEXADECIMAL,
-    left_ctrl = C.SDL_SCANCODE_LCTRL,
-    left_shift = C.SDL_SCANCODE_LSHIFT,
+    cancel = c.SDL_SCANCODE_CANCEL,
+    clear = c.SDL_SCANCODE_CLEAR,
+    prior = c.SDL_SCANCODE_PRIOR,
+    return2 = c.SDL_SCANCODE_RETURN2,
+    separator = c.SDL_SCANCODE_SEPARATOR,
+    out = c.SDL_SCANCODE_OUT,
+    oper = c.SDL_SCANCODE_OPER,
+    clear_again = c.SDL_SCANCODE_CLEARAGAIN,
+    cr_sel = c.SDL_SCANCODE_CRSEL,
+    ex_sel = c.SDL_SCANCODE_EXSEL,
+    kp_00 = c.SDL_SCANCODE_KP_00,
+    kp_000 = c.SDL_SCANCODE_KP_000,
+    thousands_separator = c.SDL_SCANCODE_THOUSANDSSEPARATOR,
+    decimals_eparator = c.SDL_SCANCODE_DECIMALSEPARATOR,
+    currency_unit = c.SDL_SCANCODE_CURRENCYUNIT,
+    currency_subunit = c.SDL_SCANCODE_CURRENCYSUBUNIT,
+    kp_left_paren = c.SDL_SCANCODE_KP_LEFTPAREN,
+    kp_right_paren = c.SDL_SCANCODE_KP_RIGHTPAREN,
+    kp_left_brace = c.SDL_SCANCODE_KP_LEFTBRACE,
+    kp_right_brace = c.SDL_SCANCODE_KP_RIGHTBRACE,
+    kp_tab = c.SDL_SCANCODE_KP_TAB,
+    kp_backspace = c.SDL_SCANCODE_KP_BACKSPACE,
+    kp_a = c.SDL_SCANCODE_KP_A,
+    kp_b = c.SDL_SCANCODE_KP_B,
+    kp_c = c.SDL_SCANCODE_KP_C,
+    kp_d = c.SDL_SCANCODE_KP_D,
+    kp_e = c.SDL_SCANCODE_KP_E,
+    kp_f = c.SDL_SCANCODE_KP_F,
+    kp_xor = c.SDL_SCANCODE_KP_XOR,
+    kp_power = c.SDL_SCANCODE_KP_POWER,
+    kp_percent = c.SDL_SCANCODE_KP_PERCENT,
+    kp_less = c.SDL_SCANCODE_KP_LESS,
+    kp_greater = c.SDL_SCANCODE_KP_GREATER,
+    kp_ampersand = c.SDL_SCANCODE_KP_AMPERSAND,
+    kp_dbl_ampersand = c.SDL_SCANCODE_KP_DBLAMPERSAND,
+    kp_vertical_bar = c.SDL_SCANCODE_KP_VERTICALBAR,
+    kp_dbl_vertical_bar = c.SDL_SCANCODE_KP_DBLVERTICALBAR,
+    kp_colon = c.SDL_SCANCODE_KP_COLON,
+    kp_hash = c.SDL_SCANCODE_KP_HASH,
+    kp_space = c.SDL_SCANCODE_KP_SPACE,
+    kp_at = c.SDL_SCANCODE_KP_AT,
+    kp_exclam = c.SDL_SCANCODE_KP_EXCLAM,
+    kp_mem_store = c.SDL_SCANCODE_KP_MEMSTORE,
+    kp_mem_recall = c.SDL_SCANCODE_KP_MEMRECALL,
+    kp_mem_clear = c.SDL_SCANCODE_KP_MEMCLEAR,
+    kp_mem_add = c.SDL_SCANCODE_KP_MEMADD,
+    kp_mem_subtract = c.SDL_SCANCODE_KP_MEMSUBTRACT,
+    kp_mem_multiply = c.SDL_SCANCODE_KP_MEMMULTIPLY,
+    kp_mem_divide = c.SDL_SCANCODE_KP_MEMDIVIDE,
+    kp_plus_minus = c.SDL_SCANCODE_KP_PLUSMINUS,
+    kp_clear = c.SDL_SCANCODE_KP_CLEAR,
+    kp_clear_entry = c.SDL_SCANCODE_KP_CLEARENTRY,
+    kp_binary = c.SDL_SCANCODE_KP_BINARY,
+    kp_octal = c.SDL_SCANCODE_KP_OCTAL,
+    kp_decimal = c.SDL_SCANCODE_KP_DECIMAL,
+    kp_hexadecimal = c.SDL_SCANCODE_KP_HEXADECIMAL,
+    left_ctrl = c.SDL_SCANCODE_LCTRL,
+    left_shift = c.SDL_SCANCODE_LSHIFT,
 
     /// Alt, option.
-    left_alt = C.SDL_SCANCODE_LALT,
+    left_alt = c.SDL_SCANCODE_LALT,
 
     /// Windows, command (apple), meta.
-    left_gui = C.SDL_SCANCODE_LGUI,
-    right_ctrl = C.SDL_SCANCODE_RCTRL,
-    right_shift = C.SDL_SCANCODE_RSHIFT,
+    left_gui = c.SDL_SCANCODE_LGUI,
+    right_ctrl = c.SDL_SCANCODE_RCTRL,
+    right_shift = c.SDL_SCANCODE_RSHIFT,
 
     /// Alt gr, option.
-    right_alt = C.SDL_SCANCODE_RALT,
+    right_alt = c.SDL_SCANCODE_RALT,
 
     /// Windows, command (apple), meta.
-    right_gui = C.SDL_SCANCODE_RGUI,
+    right_gui = c.SDL_SCANCODE_RGUI,
 
     /// I'm not sure if this is really not covered by any of the above, but since there's a special `keycode.KeyModifier.mode` for it I'm adding it here.
-    mode = C.SDL_SCANCODE_MODE,
+    mode = c.SDL_SCANCODE_MODE,
 
     /// Sleep.
-    sleep = C.SDL_SCANCODE_SLEEP,
+    sleep = c.SDL_SCANCODE_SLEEP,
 
     /// Wake.
-    wake = C.SDL_SCANCODE_WAKE,
+    wake = c.SDL_SCANCODE_WAKE,
 
     /// Channel increment.
-    channel_increment = C.SDL_SCANCODE_CHANNEL_INCREMENT,
+    channel_increment = c.SDL_SCANCODE_CHANNEL_INCREMENT,
 
     /// Channel decrement.
-    channel_decrement = C.SDL_SCANCODE_CHANNEL_DECREMENT,
+    channel_decrement = c.SDL_SCANCODE_CHANNEL_DECREMENT,
 
     /// Play.
-    media_play = C.SDL_SCANCODE_MEDIA_PLAY,
+    media_play = c.SDL_SCANCODE_MEDIA_PLAY,
 
     /// Pause.
-    media_pause = C.SDL_SCANCODE_MEDIA_PAUSE,
+    media_pause = c.SDL_SCANCODE_MEDIA_PAUSE,
 
     /// Record.
-    media_record = C.SDL_SCANCODE_MEDIA_RECORD,
+    media_record = c.SDL_SCANCODE_MEDIA_RECORD,
 
     /// Fast forward.
-    media_fast_forward = C.SDL_SCANCODE_MEDIA_FAST_FORWARD,
+    media_fast_forward = c.SDL_SCANCODE_MEDIA_FAST_FORWARD,
 
     /// Rewind.
-    media_rewind = C.SDL_SCANCODE_MEDIA_REWIND,
+    media_rewind = c.SDL_SCANCODE_MEDIA_REWIND,
 
     /// Next track.
-    media_next_track = C.SDL_SCANCODE_MEDIA_NEXT_TRACK,
+    media_next_track = c.SDL_SCANCODE_MEDIA_NEXT_TRACK,
 
     /// Previous track.
-    media_previous_track = C.SDL_SCANCODE_MEDIA_PREVIOUS_TRACK,
+    media_previous_track = c.SDL_SCANCODE_MEDIA_PREVIOUS_TRACK,
 
     /// Stop.
-    media_stop = C.SDL_SCANCODE_MEDIA_STOP,
+    media_stop = c.SDL_SCANCODE_MEDIA_STOP,
 
     /// Eject.
-    media_eject = C.SDL_SCANCODE_MEDIA_EJECT,
+    media_eject = c.SDL_SCANCODE_MEDIA_EJECT,
 
     /// Play/pause.
-    media_play_pause = C.SDL_SCANCODE_MEDIA_PLAY_PAUSE,
+    media_play_pause = c.SDL_SCANCODE_MEDIA_PLAY_PAUSE,
 
     /// Media select.
-    media_select = C.SDL_SCANCODE_MEDIA_SELECT,
+    media_select = c.SDL_SCANCODE_MEDIA_SELECT,
 
     /// AC New.
-    ac_new = C.SDL_SCANCODE_AC_NEW,
+    ac_new = c.SDL_SCANCODE_AC_NEW,
 
     /// AC Open.
-    ac_open = C.SDL_SCANCODE_AC_OPEN,
+    ac_open = c.SDL_SCANCODE_AC_OPEN,
 
     /// AC Close.
-    ac_close = C.SDL_SCANCODE_AC_CLOSE,
+    ac_close = c.SDL_SCANCODE_AC_CLOSE,
 
     /// AC Exist.
-    ac_exit = C.SDL_SCANCODE_AC_EXIT,
+    ac_exit = c.SDL_SCANCODE_AC_EXIT,
 
     /// AC Save.
-    ac_save = C.SDL_SCANCODE_AC_SAVE,
+    ac_save = c.SDL_SCANCODE_AC_SAVE,
 
     /// AC Print.
-    ac_print = C.SDL_SCANCODE_AC_PRINT,
+    ac_print = c.SDL_SCANCODE_AC_PRINT,
 
     /// AC Properties.
-    ac_properties = C.SDL_SCANCODE_AC_PROPERTIES,
+    ac_properties = c.SDL_SCANCODE_AC_PROPERTIES,
 
     /// AC Search.
-    ac_search = C.SDL_SCANCODE_AC_SEARCH,
+    ac_search = c.SDL_SCANCODE_AC_SEARCH,
 
     /// AC Home.
-    ac_home = C.SDL_SCANCODE_AC_HOME,
+    ac_home = c.SDL_SCANCODE_AC_HOME,
 
     /// AC Back.
-    ac_back = C.SDL_SCANCODE_AC_BACK,
+    ac_back = c.SDL_SCANCODE_AC_BACK,
 
     /// AC Forward.
-    ac_forward = C.SDL_SCANCODE_AC_FORWARD,
+    ac_forward = c.SDL_SCANCODE_AC_FORWARD,
 
     /// AC Stop.
-    ac_stop = C.SDL_SCANCODE_AC_STOP,
+    ac_stop = c.SDL_SCANCODE_AC_STOP,
 
     /// AC Refresh.
-    ac_refresh = C.SDL_SCANCODE_AC_REFRESH,
+    ac_refresh = c.SDL_SCANCODE_AC_REFRESH,
 
     /// AC Bookmarks.
-    ac_bookmarks = C.SDL_SCANCODE_AC_BOOKMARKS,
+    ac_bookmarks = c.SDL_SCANCODE_AC_BOOKMARKS,
 
     /// Usually situated below the display on phones and used as a multi-function feature key for selecting a software defined function shown on the bottom left of the display.
-    soft_left = C.SDL_SCANCODE_SOFTLEFT,
+    soft_left = c.SDL_SCANCODE_SOFTLEFT,
 
     /// Usually situated below the display on phones and used as a multi-function feature key for selecting a software defined function shown on the bottom right of the display.
-    soft_right = C.SDL_SCANCODE_SOFTRIGHT,
+    soft_right = c.SDL_SCANCODE_SOFTRIGHT,
 
     /// Used for accepting phone calls.
-    call = C.SDL_SCANCODE_CALL,
+    call = c.SDL_SCANCODE_CALL,
 
     /// Used for rejecting phone calls.
-    end_call = C.SDL_SCANCODE_ENDCALL,
+    end_call = c.SDL_SCANCODE_ENDCALL,
 
     /// Create an unmanaged scancode from a scancode enum.
     ///
@@ -422,7 +422,7 @@ pub const Scancode = enum(C.SDL_Scancode) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn toSdl(self: Scancode) C.SDL_Scancode {
+    pub fn toSdl(self: Scancode) c.SDL_Scancode {
         return @intFromEnum(self);
     }
 
@@ -439,7 +439,7 @@ pub const Scancode = enum(C.SDL_Scancode) {
     ///
     /// ## Version
     /// This function is provided by zig-sdl3.
-    pub fn fromSdl(key_code: C.SDL_Scancode) Scancode {
+    pub fn fromSdl(key_code: c.SDL_Scancode) Scancode {
         return @enumFromInt(key_code);
     }
 };

--- a/src/sdl3.zig
+++ b/src/sdl3.zig
@@ -136,7 +136,7 @@ pub const blend_mode = @import("blend_mode.zig");
 ///
 /// Under most circumstances, you will never need to use this.
 /// This should only really be used for functions not yet implemented in zig-sdl3.
-pub const c = @import("c.zig").C;
+pub const c = @import("c.zig").c;
 
 /// CPU feature detection for SDL.
 ///

--- a/src/sdl3.zig
+++ b/src/sdl3.zig
@@ -743,7 +743,7 @@ pub const AppResult = enum(c_uint) {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const AppEventCallback = *const fn (app_state: ?*anyopaque, event: [*c]c.SDL_Event) callconv(.C) c_uint;
+pub const AppEventCallback = *const fn (app_state: ?*anyopaque, event: [*c]c.SDL_Event) callconv(.c) c_uint;
 
 /// Function pointer typedef for `SDL_AppInit()`.
 ///
@@ -762,7 +762,7 @@ pub const AppEventCallback = *const fn (app_state: ?*anyopaque, event: [*c]c.SDL
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const AppInitCallback = *const fn (app_state: [*c]?*anyopaque, arg_count: c_int, arg_values: [*c][*c]u8) callconv(.C) c_uint;
+pub const AppInitCallback = *const fn (app_state: [*c]?*anyopaque, arg_count: c_int, arg_values: [*c][*c]u8) callconv(.c) c_uint;
 
 /// Function pointer typedef for `SDL_AppIterate()`.
 ///
@@ -779,7 +779,7 @@ pub const AppInitCallback = *const fn (app_state: [*c]?*anyopaque, arg_count: c_
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const AppIterateCallback = *const fn (app_state: ?*anyopaque) callconv(.C) c_uint;
+pub const AppIterateCallback = *const fn (app_state: ?*anyopaque) callconv(.c) c_uint;
 
 /// Function pointer typedef for `SDL_AppQuit()`.
 ///
@@ -794,7 +794,7 @@ pub const AppIterateCallback = *const fn (app_state: ?*anyopaque) callconv(.C) c
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const AppQuitCallback = *const fn (app_state: ?*anyopaque, result: c_uint) callconv(.C) void;
+pub const AppQuitCallback = *const fn (app_state: ?*anyopaque, result: c_uint) callconv(.c) void;
 
 // Add all tests from subsystems.
 test {

--- a/src/sensor.zig
+++ b/src/sensor.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const init = @import("init.zig");
 const properties = @import("properties.zig");
@@ -13,7 +13,7 @@ const stdinc = @import("stdinc.zig");
 ///
 /// ## Version
 /// This macro is available since SDL 3.2.0.
-pub const gravity: f32 = C.SDL_STANDARD_GRAVITY;
+pub const gravity: f32 = c.SDL_STANDARD_GRAVITY;
 
 /// The different sensors defined by SDL.
 ///
@@ -56,32 +56,32 @@ pub const gravity: f32 = C.SDL_STANDARD_GRAVITY;
 /// This enum is available since SDL 3.2.0.
 pub const Type = enum(c_int) {
     /// Unknown sensor type.
-    unknown = C.SDL_SENSOR_UNKNOWN,
+    unknown = c.SDL_SENSOR_UNKNOWN,
     /// Accelerometer.
-    accelerometer = C.SDL_SENSOR_ACCEL,
+    accelerometer = c.SDL_SENSOR_ACCEL,
     /// Gyroscope.
-    gyroscope = C.SDL_SENSOR_GYRO,
+    gyroscope = c.SDL_SENSOR_GYRO,
     /// Accelerometer for left Joy-Con controller and Wii nunchuk.
-    accelerometer_left = C.SDL_SENSOR_ACCEL_L,
+    accelerometer_left = c.SDL_SENSOR_ACCEL_L,
     /// Gyroscope for left Joy-Con controller.
-    gyroscope_left = C.SDL_SENSOR_GYRO_L,
+    gyroscope_left = c.SDL_SENSOR_GYRO_L,
     /// Accelerometer for right Joy-Con controller.
-    accelerometer_right = C.SDL_SENSOR_ACCEL_R,
+    accelerometer_right = c.SDL_SENSOR_ACCEL_R,
     /// Gyroscope for right Joy-Con controller.
-    gyroscope_right = C.SDL_SENSOR_GYRO_R,
+    gyroscope_right = c.SDL_SENSOR_GYRO_R,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_SensorType) ?Type {
-        if (value == C.SDL_SENSOR_INVALID)
+    pub fn fromSdl(value: c.SDL_SensorType) ?Type {
+        if (value == c.SDL_SENSOR_INVALID)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?Type) C.SDL_SensorType {
+    pub fn toSdl(self: ?Type) c.SDL_SensorType {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_SENSOR_INVALID;
+        return c.SDL_SENSOR_INVALID;
     }
 };
 
@@ -90,11 +90,11 @@ pub const Type = enum(c_int) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_SensorID,
+    value: c.SDL_SensorID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_SensorID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_SensorID) == @sizeOf(ID));
     }
 
     /// Return the SDL_Sensor associated with an instance ID.
@@ -110,10 +110,10 @@ pub const ID = packed struct {
     pub fn getSensor(
         self: ID,
     ) !Sensor {
-        const ret = C.SDL_GetSensorFromID(
+        const ret = c.SDL_GetSensorFromID(
             self.value,
         );
-        return Sensor{ .value = try errors.wrapNull(*C.SDL_Sensor, ret) };
+        return Sensor{ .value = try errors.wrapNull(*c.SDL_Sensor, ret) };
     }
 
     /// Get the implementation dependent name of a sensor.
@@ -132,7 +132,7 @@ pub const ID = packed struct {
     pub fn getName(
         self: ID,
     ) ?[:0]const u8 {
-        const ret = C.SDL_GetSensorNameForID(
+        const ret = c.SDL_GetSensorNameForID(
             self.value,
         );
         if (ret == null)
@@ -156,7 +156,7 @@ pub const ID = packed struct {
     pub fn getNonPortableType(
         self: ID,
     ) ?c_int {
-        const ret = C.SDL_GetSensorNonPortableTypeForID(
+        const ret = c.SDL_GetSensorNonPortableTypeForID(
             self.value,
         );
         if (ret == -1)
@@ -180,7 +180,7 @@ pub const ID = packed struct {
     pub fn getType(
         self: ID,
     ) ?Type {
-        const ret = C.SDL_GetSensorTypeForID(
+        const ret = c.SDL_GetSensorTypeForID(
             self.value,
         );
         return Type.fromSdl(ret);
@@ -192,7 +192,7 @@ pub const ID = packed struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Sensor = packed struct {
-    value: *C.SDL_Sensor,
+    value: *c.SDL_Sensor,
 
     /// Close a sensor previously opened with `Sensor.init()`.
     ///
@@ -204,7 +204,7 @@ pub const Sensor = packed struct {
     pub fn deinit(
         self: Sensor,
     ) void {
-        C.SDL_CloseSensor(
+        c.SDL_CloseSensor(
             self.value,
         );
     }
@@ -224,7 +224,7 @@ pub const Sensor = packed struct {
         self: Sensor,
         data: []f32,
     ) !void {
-        const ret = C.SDL_GetSensorData(
+        const ret = c.SDL_GetSensorData(
             self.value,
             data.ptr,
             @intCast(data.len),
@@ -245,10 +245,10 @@ pub const Sensor = packed struct {
     pub fn getId(
         self: Sensor,
     ) !ID {
-        const ret = C.SDL_GetSensorID(
+        const ret = c.SDL_GetSensorID(
             self.value,
         );
-        return ID{ .value = try errors.wrapCall(C.SDL_SensorID, ret, 0) };
+        return ID{ .value = try errors.wrapCall(c.SDL_SensorID, ret, 0) };
     }
 
     /// Get the implementation dependent name of a sensor.
@@ -261,7 +261,7 @@ pub const Sensor = packed struct {
     pub fn getName(
         self: Sensor,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetSensorName(
+        const ret = c.SDL_GetSensorName(
             self.value,
         );
         return errors.wrapCallCString(ret);
@@ -280,7 +280,7 @@ pub const Sensor = packed struct {
     pub fn getNonPortableType(
         self: Sensor,
     ) c_int {
-        const ret = C.SDL_GetSensorNonPortableType(
+        const ret = c.SDL_GetSensorNonPortableType(
             self.value,
         );
         return @intCast(ret);
@@ -299,10 +299,10 @@ pub const Sensor = packed struct {
     pub fn getProperties(
         self: Sensor,
     ) !properties.Group {
-        const ret = C.SDL_GetSensorProperties(
+        const ret = c.SDL_GetSensorProperties(
             self.value,
         );
-        return properties.Group{ .value = try errors.wrapCall(C.SDL_PropertiesID, ret, 0) };
+        return properties.Group{ .value = try errors.wrapCall(c.SDL_PropertiesID, ret, 0) };
     }
 
     /// Get the type of a sensor.
@@ -318,7 +318,7 @@ pub const Sensor = packed struct {
     pub fn getType(
         self: Sensor,
     ) ?Type {
-        const ret = C.SDL_GetSensorType(
+        const ret = c.SDL_GetSensorType(
             self.value,
         );
         return Type.fromSdl(ret).?; // Sensor should not be null so this should not happen.
@@ -337,10 +337,10 @@ pub const Sensor = packed struct {
     pub fn init(
         id: ID,
     ) !Sensor {
-        const ret = C.SDL_OpenSensor(
+        const ret = c.SDL_OpenSensor(
             id.value,
         );
-        return Sensor{ .value = try errors.wrapNull(*C.SDL_Sensor, ret) };
+        return Sensor{ .value = try errors.wrapNull(*c.SDL_Sensor, ret) };
     }
 };
 
@@ -354,7 +354,7 @@ pub const Sensor = packed struct {
 /// This function is available since SDL 3.2.0.
 pub fn getSensors() ![]ID {
     var count: c_int = undefined;
-    const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(C.SDL_SensorID, C.SDL_GetSensors(
+    const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(c.SDL_SensorID, c.SDL_GetSensors(
         &count,
     )));
     return ret[0..@intCast(count)];
@@ -370,7 +370,7 @@ pub fn getSensors() ![]ID {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn update() void {
-    C.SDL_UpdateSensors();
+    c.SDL_UpdateSensors();
 }
 
 // Sensor related tests.

--- a/src/stdinc.zig
+++ b/src/stdinc.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -7,11 +7,11 @@ const std = @import("std");
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Environment = packed struct {
-    value: *C.SDL_Environment,
+    value: *c.SDL_Environment,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(*C.SDL_Environment) == @sizeOf(Environment));
+        std.debug.assert(@sizeOf(*c.SDL_Environment) == @sizeOf(Environment));
     }
 };
 
@@ -30,7 +30,7 @@ fn sdlAlloc(ptr: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr:
     _ = ptr;
     _ = alignment;
     _ = ret_addr;
-    const ret = C.SDL_malloc(len);
+    const ret = c.SDL_malloc(len);
     if (ret) |val| {
         return @as([*]u8, @alignCast(@ptrCast(val)));
     }
@@ -50,7 +50,7 @@ fn sdlRemap(ptr: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len
     _ = ptr;
     _ = alignment;
     _ = ret_addr;
-    const ret = C.SDL_realloc(memory.ptr, new_len);
+    const ret = c.SDL_realloc(memory.ptr, new_len);
     if (ret) |val| {
         return @as([*]u8, @alignCast(@ptrCast(val)));
     }
@@ -61,7 +61,7 @@ fn sdlFree(ptr: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr
     _ = ptr;
     _ = alignment;
     _ = ret_addr;
-    C.SDL_free(memory.ptr);
+    c.SDL_free(memory.ptr);
 }
 
 /// A callback used to implement `stdinc.calloc()`.
@@ -154,9 +154,9 @@ pub fn free(mem: anytype) void {
     switch (@typeInfo(@TypeOf(mem))) {
         .pointer => |pt| {
             if (pt.size == .slice) {
-                C.SDL_free(@ptrCast(mem.ptr));
+                c.SDL_free(@ptrCast(mem.ptr));
             } else {
-                C.SDL_free(@ptrCast(mem));
+                c.SDL_free(@ptrCast(mem));
             }
         },
         else => @compileError("Invalid argument to SDL free"),
@@ -183,7 +183,7 @@ pub fn getOriginalMemoryFunctions() struct { malloc: MallocFunc, calloc: CallocF
     var calloc_fn: ?CallocFunc = undefined;
     var realloc_fn: ?ReallocFunc = undefined;
     var free_fn: ?FreeFunc = undefined;
-    C.SDL_GetOriginalMemoryFunctions(
+    c.SDL_GetOriginalMemoryFunctions(
         &malloc_fn,
         &calloc_fn,
         &realloc_fn,
@@ -231,7 +231,7 @@ pub fn setMemoryFunctions(
     realloc_fn: ReallocFunc,
     free_fn: FreeFunc,
 ) !void {
-    const ret = C.SDL_SetMemoryFunctions(
+    const ret = c.SDL_SetMemoryFunctions(
         malloc_fn,
         calloc_fn,
         realloc_fn,

--- a/src/stdinc.zig
+++ b/src/stdinc.zig
@@ -81,7 +81,7 @@ fn sdlFree(ptr: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const CallocFunc = *const fn (num_members: usize, size: usize) callconv(.C) ?*anyopaque;
+pub const CallocFunc = *const fn (num_members: usize, size: usize) callconv(.c) ?*anyopaque;
 
 /// A callback used to implement `stdinc.free()`.
 ///
@@ -96,7 +96,7 @@ pub const CallocFunc = *const fn (num_members: usize, size: usize) callconv(.C) 
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const FreeFunc = *const fn (mem: ?*anyopaque) callconv(.C) void;
+pub const FreeFunc = *const fn (mem: ?*anyopaque) callconv(.c) void;
 
 /// A callback used to implement `stdinc.malloc()`.
 ///
@@ -114,7 +114,7 @@ pub const FreeFunc = *const fn (mem: ?*anyopaque) callconv(.C) void;
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const MallocFunc = *const fn (size: usize) callconv(.C) ?*anyopaque;
+pub const MallocFunc = *const fn (size: usize) callconv(.c) ?*anyopaque;
 
 /// A callback used to implement `stdinc.realloc()`.
 ///
@@ -133,7 +133,7 @@ pub const MallocFunc = *const fn (size: usize) callconv(.C) ?*anyopaque;
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const ReallocFunc = *const fn (mem: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque;
+pub const ReallocFunc = *const fn (mem: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque;
 
 /// Free allocated memory.
 ///
@@ -248,7 +248,7 @@ const Allocation = struct {
     buf: void,
 };
 
-fn allocCalloc(num_members: usize, size: usize) callconv(.C) ?*anyopaque {
+fn allocCalloc(num_members: usize, size: usize) callconv(.c) ?*anyopaque {
     const custom_allocator_val = custom_allocator orelse return null;
     const total_buf = custom_allocator_val.alloc(u8, size * num_members + @sizeOf(Allocation)) catch return null;
     const allocation: *Allocation = @ptrCast(@alignCast(total_buf.ptr));
@@ -256,14 +256,14 @@ fn allocCalloc(num_members: usize, size: usize) callconv(.C) ?*anyopaque {
     return &allocation.buf;
 }
 
-fn allocFree(mem: ?*anyopaque) callconv(.C) void {
+fn allocFree(mem: ?*anyopaque) callconv(.c) void {
     const raw_ptr = mem orelse return;
     const custom_allocator_val = custom_allocator orelse return;
     const allocation: *Allocation = @alignCast(@fieldParentPtr("buf", @as(*void, @ptrCast(raw_ptr))));
     custom_allocator_val.free(@as([*]u8, @ptrCast(raw_ptr))[0..allocation.size]);
 }
 
-fn allocMalloc(size: usize) callconv(.C) ?*anyopaque {
+fn allocMalloc(size: usize) callconv(.c) ?*anyopaque {
     const custom_allocator_val = custom_allocator orelse return null;
     const total_buf = custom_allocator_val.alloc(u8, size + @sizeOf(Allocation)) catch return null;
     const allocation: *Allocation = @ptrCast(@alignCast(total_buf.ptr));
@@ -271,7 +271,7 @@ fn allocMalloc(size: usize) callconv(.C) ?*anyopaque {
     return &allocation.buf;
 }
 
-fn allocRealloc(mem: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque {
+fn allocRealloc(mem: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
     const raw_ptr = mem orelse return null;
     const custom_allocator_val = custom_allocator orelse return null;
     var allocation: *Allocation = @alignCast(@fieldParentPtr("buf", @as(*void, @ptrCast(raw_ptr))));

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -140,27 +140,27 @@ pub const Path = struct {
 /// This struct is available since SDL 3.2.0.
 pub const Interface = struct {
     /// Called when storage is closed.
-    deinit: *const fn (user_data: ?*anyopaque) callconv(.C) bool,
+    deinit: *const fn (user_data: ?*anyopaque) callconv(.c) bool,
     /// Returns whether the storage is currently ready for access.
-    ready: ?*const fn (user_data: ?*anyopaque) callconv(.C) bool,
+    ready: ?*const fn (user_data: ?*anyopaque) callconv(.c) bool,
     /// Enumerate a directory, optional for write-only storage.
-    enumerate: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, callback: ?filesystem.EnumerateDirectoryCallback, callback_user_data: ?*anyopaque) callconv(.C) bool,
+    enumerate: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, callback: ?filesystem.EnumerateDirectoryCallback, callback_user_data: ?*anyopaque) callconv(.c) bool,
     /// Get path information, optional for write-only storage.
-    info: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, info: [*c]c.SDL_PathInfo) callconv(.C) bool,
+    info: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, info: [*c]c.SDL_PathInfo) callconv(.c) bool,
     /// Read a file from storage, optional for write-only storage.
-    read_file: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, destination: ?*anyopaque, length: u64) callconv(.C) bool,
+    read_file: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, destination: ?*anyopaque, length: u64) callconv(.c) bool,
     /// Write a file to storage, optional for read-only storage.
-    write_file: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, source: ?*const anyopaque, length: u64) callconv(.C) bool,
+    write_file: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8, source: ?*const anyopaque, length: u64) callconv(.c) bool,
     /// Create a directory, optional for read-only storage.
-    mkdir: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8) callconv(.C) bool,
+    mkdir: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8) callconv(.c) bool,
     /// Remove a file or empty directory, optional for read-only storage.
-    remove: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8) callconv(.C) bool,
+    remove: ?*const fn (user_data: ?*anyopaque, path: [*c]const u8) callconv(.c) bool,
     /// Rename a path, optional for read-only storage.
-    rename: ?*const fn (user_data: ?*anyopaque, old_path: [*c]const u8, new_path: [*c]const u8) callconv(.C) bool,
+    rename: ?*const fn (user_data: ?*anyopaque, old_path: [*c]const u8, new_path: [*c]const u8) callconv(.c) bool,
     /// Copy a file, optional for read-only storage.
-    copy: ?*const fn (user_data: ?*anyopaque, old_path: [*c]const u8, new_path: [*c]const u8) callconv(.C) bool,
+    copy: ?*const fn (user_data: ?*anyopaque, old_path: [*c]const u8, new_path: [*c]const u8) callconv(.c) bool,
     /// Get the space remaining, optional for read-only storage.
-    space_remaining: ?*const fn (user_data: ?*anyopaque) callconv(.C) u64,
+    space_remaining: ?*const fn (user_data: ?*anyopaque) callconv(.c) u64,
 };
 
 /// An abstract interface for filesystem access.
@@ -359,7 +359,7 @@ pub const Storage = packed struct {
     };
 
     /// Callback for getting all directory items.
-    fn getAllDirectoryItemsCb(user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.C) c.SDL_EnumerationResult {
+    fn getAllDirectoryItemsCb(user_data: ?*anyopaque, dir_name: [*c]const u8, name: [*c]const u8) callconv(.c) c.SDL_EnumerationResult {
         _ = dir_name;
         const data_ptr: *GetAllData = @ptrCast(@alignCast(user_data));
         const name_str = std.mem.span(name);

--- a/src/surface.zig
+++ b/src/surface.zig
@@ -1,5 +1,5 @@
 const blend_mode = @import("blend_mode.zig");
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const io_stream = @import("io_stream.zig");
 const pixels = @import("pixels.zig");
@@ -25,21 +25,21 @@ pub const Flags = struct {
     simd_aligned: bool,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_SurfaceFlags) Flags {
+    pub fn fromSdl(flags: c.SDL_SurfaceFlags) Flags {
         return .{
-            .preallocated = (flags & C.SDL_SURFACE_PREALLOCATED) != 0,
-            .lock_needed = (flags & C.SDL_SURFACE_LOCK_NEEDED) != 0,
-            .locked = (flags & C.SDL_SURFACE_LOCKED) != 0,
-            .simd_aligned = (flags & C.SDL_SURFACE_SIMD_ALIGNED) != 0,
+            .preallocated = (flags & c.SDL_SURFACE_PREALLOCATED) != 0,
+            .lock_needed = (flags & c.SDL_SURFACE_LOCK_NEEDED) != 0,
+            .locked = (flags & c.SDL_SURFACE_LOCKED) != 0,
+            .simd_aligned = (flags & c.SDL_SURFACE_SIMD_ALIGNED) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: Flags) C.SDL_SurfaceFlags {
-        return (if (self.preallocated) @as(C.SDL_SurfaceFlags, C.SDL_SURFACE_PREALLOCATED) else 0) |
-            (if (self.lock_needed) @as(C.SDL_SurfaceFlags, C.SDL_SURFACE_LOCK_NEEDED) else 0) |
-            (if (self.locked) @as(C.SDL_SurfaceFlags, C.SDL_SURFACE_LOCKED) else 0) |
-            (if (self.simd_aligned) @as(C.SDL_SurfaceFlags, C.SDL_SURFACE_SIMD_ALIGNED) else 0) |
+    pub fn toSdl(self: Flags) c.SDL_SurfaceFlags {
+        return (if (self.preallocated) @as(c.SDL_SurfaceFlags, c.SDL_SURFACE_PREALLOCATED) else 0) |
+            (if (self.lock_needed) @as(c.SDL_SurfaceFlags, c.SDL_SURFACE_LOCK_NEEDED) else 0) |
+            (if (self.locked) @as(c.SDL_SurfaceFlags, c.SDL_SURFACE_LOCKED) else 0) |
+            (if (self.simd_aligned) @as(c.SDL_SurfaceFlags, c.SDL_SURFACE_SIMD_ALIGNED) else 0) |
             0;
     }
 };
@@ -50,22 +50,22 @@ pub const Flags = struct {
 /// This enum is available since SDL 3.2.0.
 pub const FlipMode = enum(c_uint) {
     /// Flip horizontally.
-    horizontal = C.SDL_FLIP_HORIZONTAL,
+    horizontal = c.SDL_FLIP_HORIZONTAL,
     /// Flip vertically.
-    vertical = C.SDL_FLIP_VERTICAL,
+    vertical = c.SDL_FLIP_VERTICAL,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(value: C.SDL_FlipMode) ?FlipMode {
-        if (value == C.SDL_FLIP_NONE)
+    pub fn fromSdl(value: c.SDL_FlipMode) ?FlipMode {
+        if (value == c.SDL_FLIP_NONE)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?FlipMode) C.SDL_FlipMode {
+    pub fn toSdl(self: ?FlipMode) c.SDL_FlipMode {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_FLIP_NONE;
+        return c.SDL_FLIP_NONE;
     }
 };
 
@@ -75,9 +75,9 @@ pub const FlipMode = enum(c_uint) {
 /// This enum is available since SDL 3.2.0.
 pub const ScaleMode = enum(c_uint) {
     /// Nearest pixel sampling.
-    nearest = C.SDL_SCALEMODE_NEAREST,
+    nearest = c.SDL_SCALEMODE_NEAREST,
     /// Linear pixel sampling.
-    linear = C.SDL_SCALEMODE_LINEAR,
+    linear = c.SDL_SCALEMODE_LINEAR,
     // Pixel art and invalid from SDL 3.4.0?
 
 };
@@ -104,11 +104,11 @@ pub const ScaleMode = enum(c_uint) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Surface = packed struct {
-    value: *C.SDL_Surface,
+    value: *c.SDL_Surface,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(Surface) == @sizeOf(*C.SDL_Surface));
+        std.debug.assert(@sizeOf(Surface) == @sizeOf(*c.SDL_Surface));
     }
 
     /// Surface properties.
@@ -135,20 +135,20 @@ pub const Surface = packed struct {
         /// Convert from an SDL group.
         pub fn fromSdl(value: properties.Group) Properties {
             return .{
-                .sdr_white_point = if (value.get(C.SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT)) |val| val.float else null,
-                .hdr_headroom = if (value.get(C.SDL_PROP_SURFACE_HDR_HEADROOM_FLOAT)) |val| val.float else null,
-                .tonemap_operator = if (value.get(C.SDL_PROP_SURFACE_TONEMAP_OPERATOR_STRING)) |val| val.string else null,
+                .sdr_white_point = if (value.get(c.SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT)) |val| val.float else null,
+                .hdr_headroom = if (value.get(c.SDL_PROP_SURFACE_HDR_HEADROOM_FLOAT)) |val| val.float else null,
+                .tonemap_operator = if (value.get(c.SDL_PROP_SURFACE_TONEMAP_OPERATOR_STRING)) |val| val.string else null,
             };
         }
 
         /// Convert to an SDL group.
         pub fn toSdl(self: Properties, value: properties.Group) !void {
             if (self.sdr_white_point) |val|
-                try value.set(C.SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT, .{ .float = val });
+                try value.set(c.SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT, .{ .float = val });
             if (self.hdr_headroom) |val|
-                try value.set(C.SDL_PROP_SURFACE_HDR_HEADROOM_FLOAT, .{ .float = val });
+                try value.set(c.SDL_PROP_SURFACE_HDR_HEADROOM_FLOAT, .{ .float = val });
             if (self.tonemap_operator) |val|
-                try value.set(C.SDL_PROP_SURFACE_TONEMAP_OPERATOR_STRING, .{ .string = val });
+                try value.set(c.SDL_PROP_SURFACE_TONEMAP_OPERATOR_STRING, .{ .string = val });
         }
     };
 
@@ -173,7 +173,7 @@ pub const Surface = packed struct {
         self: Surface,
         image: Surface,
     ) !void {
-        const ret = C.SDL_AddSurfaceAlternateImage(
+        const ret = c.SDL_AddSurfaceAlternateImage(
             self.value,
             image.value,
         );
@@ -245,14 +245,14 @@ pub const Surface = packed struct {
         dest: Surface,
         point_to_copy_to: ?rect.IPoint,
     ) !void {
-        const area_to_copy_sdl: C.SDL_Rect = if (area_to_copy) |val| val.toSdl() else undefined;
-        const point_to_copy_to_sdl: C.SDL_Rect = if (point_to_copy_to) |val| .{
+        const area_to_copy_sdl: c.SDL_Rect = if (area_to_copy) |val| val.toSdl() else undefined;
+        const point_to_copy_to_sdl: c.SDL_Rect = if (point_to_copy_to) |val| .{
             .x = @intCast(val.x),
             .y = @intCast(val.y),
             .w = undefined,
             .h = undefined,
         } else undefined;
-        const ret = C.SDL_BlitSurface(
+        const ret = c.SDL_BlitSurface(
             self.value,
             if (area_to_copy != null) &area_to_copy_sdl else null,
             dest.value,
@@ -297,9 +297,9 @@ pub const Surface = packed struct {
         dest: Surface,
         area_to_copy_to: ?rect.IRect,
     ) !void {
-        const area_to_copy_from_sdl: C.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
-        const area_to_copy_to_sdl: C.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
-        const ret = C.SDL_BlitSurface9Grid(
+        const area_to_copy_from_sdl: c.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
+        const area_to_copy_to_sdl: c.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
+        const ret = c.SDL_BlitSurface9Grid(
             self.value,
             if (area_to_copy_from != null) &area_to_copy_from_sdl else null,
             @intCast(left_width),
@@ -335,9 +335,9 @@ pub const Surface = packed struct {
         area_to_copy_to: ?rect.IRect,
         scale_mode: ScaleMode,
     ) !void {
-        const area_to_copy_from_sdl: C.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
-        const area_to_copy_to_sdl: C.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
-        const ret = C.SDL_BlitSurfaceScaled(
+        const area_to_copy_from_sdl: c.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
+        const area_to_copy_to_sdl: c.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
+        const ret = c.SDL_BlitSurfaceScaled(
             self.value,
             if (area_to_copy_from != null) &area_to_copy_from_sdl else null,
             dest.value,
@@ -369,9 +369,9 @@ pub const Surface = packed struct {
         dest: Surface,
         area_to_copy_to: ?rect.IRect,
     ) !void {
-        const area_to_copy_from_sdl: C.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
-        const area_to_copy_to_sdl: C.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
-        const ret = C.SDL_BlitSurfaceTiled(
+        const area_to_copy_from_sdl: c.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
+        const area_to_copy_to_sdl: c.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
+        const ret = c.SDL_BlitSurfaceTiled(
             self.value,
             if (area_to_copy_from != null) &area_to_copy_from_sdl else null,
             dest.value,
@@ -404,9 +404,9 @@ pub const Surface = packed struct {
         dest: Surface,
         area_to_copy_to: ?rect.IRect,
     ) !void {
-        const area_to_copy_from_sdl: C.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
-        const area_to_copy_to_sdl: C.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
-        const ret = C.SDL_BlitSurfaceTiledWithScale(
+        const area_to_copy_from_sdl: c.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
+        const area_to_copy_to_sdl: c.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
+        const ret = c.SDL_BlitSurfaceTiledWithScale(
             self.value,
             if (area_to_copy_from != null) &area_to_copy_from_sdl else null,
             scale_amount,
@@ -438,9 +438,9 @@ pub const Surface = packed struct {
         dest: Surface,
         area_to_copy_to: ?rect.IRect,
     ) !void {
-        const area_to_copy_from_sdl: C.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
-        const area_to_copy_to_sdl: C.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
-        const ret = C.SDL_BlitSurfaceUnchecked(
+        const area_to_copy_from_sdl: c.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
+        const area_to_copy_to_sdl: c.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
+        const ret = c.SDL_BlitSurfaceUnchecked(
             self.value,
             if (area_to_copy_from != null) &area_to_copy_from_sdl else null,
             dest.value,
@@ -473,9 +473,9 @@ pub const Surface = packed struct {
         area_to_copy_to: ?rect.IRect,
         scale_mode: ScaleMode,
     ) !void {
-        const area_to_copy_from_sdl: C.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
-        const area_to_copy_to_sdl: C.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
-        const ret = C.SDL_BlitSurfaceUncheckedScaled(
+        const area_to_copy_from_sdl: c.SDL_Rect = if (area_to_copy_from) |val| val.toSdl() else undefined;
+        const area_to_copy_to_sdl: c.SDL_Rect = if (area_to_copy_to) |val| val.toSdl() else undefined;
+        const ret = c.SDL_BlitSurfaceUncheckedScaled(
             self.value,
             if (area_to_copy_from != null) &area_to_copy_from_sdl else null,
             dest.value,
@@ -505,7 +505,7 @@ pub const Surface = packed struct {
         self: Surface,
         color: pixels.FColor,
     ) !void {
-        const ret = C.SDL_ClearSurface(
+        const ret = c.SDL_ClearSurface(
             self.value,
             color.r,
             color.g,
@@ -542,11 +542,11 @@ pub const Surface = packed struct {
         self: Surface,
         format: pixels.Format,
     ) !Surface {
-        const ret = C.SDL_ConvertSurface(
+        const ret = c.SDL_ConvertSurface(
             self.value,
             format.value,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Copy an existing surface to a new surface of the specified format and colorspace.
@@ -579,14 +579,14 @@ pub const Surface = packed struct {
         colorspace: pixels.Colorspace,
         color_properties: ?properties.Group,
     ) !Surface {
-        const ret = C.SDL_ConvertSurfaceAndColorspace(
+        const ret = c.SDL_ConvertSurfaceAndColorspace(
             self.value,
             format.value,
             if (palette) |palette_val| palette_val.value else null,
             colorspace.value,
             if (color_properties) |val| val.value else 0,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Create a palette and associate it with a surface.
@@ -616,10 +616,10 @@ pub const Surface = packed struct {
     pub fn createPalette(
         self: Surface,
     ) !pixels.Palette {
-        const ret = C.SDL_CreateSurfacePalette(
+        const ret = c.SDL_CreateSurfacePalette(
             self.value,
         );
-        return pixels.Palette{ .value = try errors.wrapNull(*C.SDL_Palette, ret) };
+        return pixels.Palette{ .value = try errors.wrapNull(*c.SDL_Palette, ret) };
     }
 
     /// Free a surface.
@@ -635,7 +635,7 @@ pub const Surface = packed struct {
     pub fn deinit(
         self: Surface,
     ) void {
-        C.SDL_DestroySurface(
+        c.SDL_DestroySurface(
             self.value,
         );
     }
@@ -661,10 +661,10 @@ pub const Surface = packed struct {
     pub fn duplicate(
         self: Surface,
     ) !Surface {
-        const ret = C.SDL_DuplicateSurface(
+        const ret = c.SDL_DuplicateSurface(
             self.value,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Perform a fast fill of a rectangle with a specific color.
@@ -691,8 +691,8 @@ pub const Surface = packed struct {
         area: ?rect.IRect,
         color: pixels.Pixel,
     ) !void {
-        const area_sdl: C.SDL_Rect = if (area) |val| val.toSdl() else undefined;
-        const ret = C.SDL_FillSurfaceRect(
+        const area_sdl: c.SDL_Rect = if (area) |val| val.toSdl() else undefined;
+        const ret = c.SDL_FillSurfaceRect(
             self.value,
             if (area != null) &area_sdl else null,
             color.value,
@@ -724,7 +724,7 @@ pub const Surface = packed struct {
         rects: []const rect.IRect,
         color: pixels.Pixel,
     ) !void {
-        const ret = C.SDL_FillSurfaceRects(
+        const ret = c.SDL_FillSurfaceRects(
             self.value,
             @ptrCast(rects.ptr),
             @intCast(rects.len),
@@ -748,7 +748,7 @@ pub const Surface = packed struct {
         self: Surface,
         flip_mode: FlipMode,
     ) !void {
-        const ret = C.SDL_FlipSurface(
+        const ret = c.SDL_FlipSurface(
             self.value,
             @intFromEnum(flip_mode),
         );
@@ -772,7 +772,7 @@ pub const Surface = packed struct {
         self: Surface,
     ) !u8 {
         var alpha: u8 = undefined;
-        const ret = C.SDL_GetSurfaceAlphaMod(
+        const ret = c.SDL_GetSurfaceAlphaMod(
             self.value,
             &alpha,
         );
@@ -796,8 +796,8 @@ pub const Surface = packed struct {
     pub fn getBlendMode(
         self: Surface,
     ) !blend_mode.Mode {
-        var mode: C.SDL_BlendMode = undefined;
-        const ret = C.SDL_GetSurfaceBlendMode(
+        var mode: c.SDL_BlendMode = undefined;
+        const ret = c.SDL_GetSurfaceBlendMode(
             self.value,
             &mode,
         );
@@ -824,8 +824,8 @@ pub const Surface = packed struct {
     pub fn getClipRect(
         self: Surface,
     ) !rect.IRect {
-        var val: C.SDL_Rect = undefined;
-        const ret = C.SDL_GetSurfaceClipRect(
+        var val: c.SDL_Rect = undefined;
+        const ret = c.SDL_GetSurfaceClipRect(
             self.value,
             &val,
         );
@@ -855,7 +855,7 @@ pub const Surface = packed struct {
         self: Surface,
     ) !pixels.Pixel {
         var key: u32 = undefined;
-        const ret = C.SDL_GetSurfaceColorKey(
+        const ret = c.SDL_GetSurfaceColorKey(
             self.value,
             &key,
         );
@@ -882,7 +882,7 @@ pub const Surface = packed struct {
         var r: u8 = undefined;
         var g: u8 = undefined;
         var b: u8 = undefined;
-        const ret = C.SDL_GetSurfaceColorMod(
+        const ret = c.SDL_GetSurfaceColorMod(
             self.value,
             &r,
             &g,
@@ -912,7 +912,7 @@ pub const Surface = packed struct {
     pub fn getColorspace(
         self: Surface,
     ) pixels.Colorspace {
-        const ret = C.SDL_GetSurfaceColorspace(
+        const ret = c.SDL_GetSurfaceColorspace(
             self.value,
         );
         return pixels.Colorspace{ .value = ret };
@@ -990,8 +990,8 @@ pub const Surface = packed struct {
         self: Surface,
     ) ![]Surface {
         var count: c_int = undefined;
-        const ret = C.SDL_GetSurfaceImages(self.value, &count);
-        return @as([*]Surface, @ptrCast(try errors.wrapNull(*[*c]C.SDL_Surface, ret)))[0..@intCast(count)];
+        const ret = c.SDL_GetSurfaceImages(self.value, &count);
+        return @as([*]Surface, @ptrCast(try errors.wrapNull(*[*c]c.SDL_Surface, ret)))[0..@intCast(count)];
     }
 
     /// Get the palette used by a surface.
@@ -1010,7 +1010,7 @@ pub const Surface = packed struct {
     pub fn getPalette(
         self: Surface,
     ) ?pixels.Palette {
-        const ret = C.SDL_GetSurfacePalette(
+        const ret = c.SDL_GetSurfacePalette(
             self.value,
         );
         if (ret == null)
@@ -1069,10 +1069,10 @@ pub const Surface = packed struct {
     pub fn getProperties(
         self: Surface,
     ) !Properties {
-        const ret = C.SDL_GetSurfaceProperties(
+        const ret = c.SDL_GetSurfaceProperties(
             self.value,
         );
-        const group = properties.Group{ .value = try errors.wrapCall(C.SDL_PropertiesID, ret, 0) };
+        const group = properties.Group{ .value = try errors.wrapCall(c.SDL_PropertiesID, ret, 0) };
         return Properties.fromSdl(group);
     }
 
@@ -1124,7 +1124,7 @@ pub const Surface = packed struct {
     pub fn hasAlternateImage(
         self: Surface,
     ) bool {
-        const ret = C.SDL_SurfaceHasAlternateImages(
+        const ret = c.SDL_SurfaceHasAlternateImages(
             self.value,
         );
         return ret;
@@ -1146,7 +1146,7 @@ pub const Surface = packed struct {
     pub fn hasColorKey(
         self: Surface,
     ) bool {
-        const ret = C.SDL_SurfaceHasColorKey(
+        const ret = c.SDL_SurfaceHasColorKey(
             self.value,
         );
         return ret;
@@ -1168,7 +1168,7 @@ pub const Surface = packed struct {
     pub fn hasRle(
         self: Surface,
     ) bool {
-        const ret = C.SDL_SurfaceHasRLE(
+        const ret = c.SDL_SurfaceHasRLE(
             self.value,
         );
         return ret;
@@ -1216,12 +1216,12 @@ pub const Surface = packed struct {
         height: usize,
         format: pixels.Format,
     ) !Surface {
-        const ret = C.SDL_CreateSurface(
+        const ret = c.SDL_CreateSurface(
             @intCast(width),
             @intCast(height),
             format.value,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Allocate a new surface with a specific pixel format and data in the format.
@@ -1254,14 +1254,14 @@ pub const Surface = packed struct {
         format: pixels.Format,
         pixel_data: ?[]const u8,
     ) !Surface {
-        const ret = C.SDL_CreateSurfaceFrom(
+        const ret = c.SDL_CreateSurfaceFrom(
             @intCast(width),
             @intCast(height),
             format.value,
             if (pixel_data) |val| @constCast(val.ptr) else null,
             if (pixel_data) |val| @intCast(val.len / height) else 0,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Load a BMP image from a file.
@@ -1284,10 +1284,10 @@ pub const Surface = packed struct {
     pub fn initFromBmpFile(
         path: [:0]const u8,
     ) !Surface {
-        const ret = C.SDL_LoadBMP(
+        const ret = c.SDL_LoadBMP(
             path.ptr,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Create a surface from a BMP image from a seekable stream.
@@ -1312,11 +1312,11 @@ pub const Surface = packed struct {
         stream: io_stream.Stream,
         close_stream_after: bool,
     ) !Surface {
-        const ret = C.SDL_LoadBMP_IO(
+        const ret = c.SDL_LoadBMP_IO(
             stream.value,
             close_stream_after,
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Set up a surface for directly accessing the pixels.
@@ -1341,7 +1341,7 @@ pub const Surface = packed struct {
     pub fn lock(
         self: Surface,
     ) !void {
-        const ret = C.SDL_LockSurface(
+        const ret = c.SDL_LockSurface(
             self.value,
         );
         return errors.wrapCallBool(ret);
@@ -1379,7 +1379,7 @@ pub const Surface = packed struct {
         g: u8,
         b: u8,
     ) pixels.Pixel {
-        const ret = C.SDL_MapSurfaceRGB(
+        const ret = c.SDL_MapSurfaceRGB(
             self.value,
             r,
             g,
@@ -1422,7 +1422,7 @@ pub const Surface = packed struct {
         b: u8,
         a: u8,
     ) pixels.Pixel {
-        const ret = C.SDL_MapSurfaceRGBA(
+        const ret = c.SDL_MapSurfaceRGBA(
             self.value,
             r,
             g,
@@ -1445,7 +1445,7 @@ pub const Surface = packed struct {
     pub fn mustLock(
         self: Surface,
     ) bool {
-        return C.SDL_MUSTLOCK(self.value);
+        return c.SDL_MUSTLOCK(self.value);
     }
 
     /// Premultiply the alpha in a surface.
@@ -1466,7 +1466,7 @@ pub const Surface = packed struct {
         self: Surface,
         linear: bool,
     ) !void {
-        const ret = C.SDL_PremultiplySurfaceAlpha(
+        const ret = c.SDL_PremultiplySurfaceAlpha(
             self.value,
             linear,
         );
@@ -1502,7 +1502,7 @@ pub const Surface = packed struct {
         var g: u8 = undefined;
         var b: u8 = undefined;
         var a: u8 = undefined;
-        const ret = C.SDL_ReadSurfacePixel(
+        const ret = c.SDL_ReadSurfacePixel(
             self.value,
             @intCast(x),
             @intCast(y),
@@ -1542,7 +1542,7 @@ pub const Surface = packed struct {
         var g: f32 = undefined;
         var b: f32 = undefined;
         var a: f32 = undefined;
-        const ret = C.SDL_ReadSurfacePixelFloat(
+        const ret = c.SDL_ReadSurfacePixelFloat(
             self.value,
             @intCast(x),
             @intCast(y),
@@ -1571,7 +1571,7 @@ pub const Surface = packed struct {
     pub fn removeAlternateImages(
         self: Surface,
     ) void {
-        C.SDL_RemoveSurfaceAlternateImages(
+        c.SDL_RemoveSurfaceAlternateImages(
             self.value,
         );
     }
@@ -1596,7 +1596,7 @@ pub const Surface = packed struct {
         self: Surface,
         path: [:0]const u8,
     ) !void {
-        const ret = C.SDL_SaveBMP(
+        const ret = c.SDL_SaveBMP(
             self.value,
             path.ptr,
         );
@@ -1625,7 +1625,7 @@ pub const Surface = packed struct {
         stream: io_stream.Stream,
         close_stream_after: bool,
     ) !void {
-        const ret = C.SDL_SaveBMP_IO(
+        const ret = c.SDL_SaveBMP_IO(
             self.value,
             stream.value,
             close_stream_after,
@@ -1658,13 +1658,13 @@ pub const Surface = packed struct {
         height: usize,
         scale_mode: ScaleMode,
     ) !Surface {
-        const ret = C.SDL_ScaleSurface(
+        const ret = c.SDL_ScaleSurface(
             self.value,
             @intCast(width),
             @intCast(height),
             @bitCast(@intFromEnum(scale_mode)),
         );
-        return Surface{ .value = try errors.wrapNull(*C.SDL_Surface, ret) };
+        return Surface{ .value = try errors.wrapNull(*c.SDL_Surface, ret) };
     }
 
     /// Set an additional alpha value used in blit operations.
@@ -1686,7 +1686,7 @@ pub const Surface = packed struct {
         self: Surface,
         alpha: u8,
     ) !void {
-        const ret = C.SDL_SetSurfaceAlphaMod(
+        const ret = c.SDL_SetSurfaceAlphaMod(
             self.value,
             @intCast(alpha),
         );
@@ -1711,7 +1711,7 @@ pub const Surface = packed struct {
         self: Surface,
         mode: blend_mode.Mode,
     ) !void {
-        const ret = C.SDL_SetSurfaceBlendMode(
+        const ret = c.SDL_SetSurfaceBlendMode(
             self.value,
             mode.value,
         );
@@ -1741,8 +1741,8 @@ pub const Surface = packed struct {
         self: Surface,
         val: ?rect.IRect,
     ) bool {
-        const val_sdl: C.SDL_Rect = if (val) |v| v.toSdl() else undefined;
-        const ret = C.SDL_SetSurfaceClipRect(
+        const val_sdl: c.SDL_Rect = if (val) |v| v.toSdl() else undefined;
+        const ret = c.SDL_SetSurfaceClipRect(
             self.value,
             if (val != null) &val_sdl else null,
         );
@@ -1770,7 +1770,7 @@ pub const Surface = packed struct {
         self: Surface,
         pixel: ?pixels.Pixel,
     ) !void {
-        const ret = C.SDL_SetSurfaceColorKey(
+        const ret = c.SDL_SetSurfaceColorKey(
             self.value,
             pixel != null,
             if (pixel) |val| val.value else 0,
@@ -1801,7 +1801,7 @@ pub const Surface = packed struct {
         g: u8,
         b: u8,
     ) !void {
-        const ret = C.SDL_SetSurfaceColorMod(
+        const ret = c.SDL_SetSurfaceColorMod(
             self.value,
             r,
             g,
@@ -1828,7 +1828,7 @@ pub const Surface = packed struct {
         self: Surface,
         colorspace: pixels.Colorspace,
     ) !void {
-        const ret = C.SDL_SetSurfaceColorspace(
+        const ret = c.SDL_SetSurfaceColorspace(
             self.value,
             colorspace.value,
         );
@@ -1853,7 +1853,7 @@ pub const Surface = packed struct {
         self: Surface,
         palette: pixels.Palette,
     ) !void {
-        const ret = C.SDL_SetSurfacePalette(
+        const ret = c.SDL_SetSurfacePalette(
             self.value,
             palette.value,
         );
@@ -1875,10 +1875,10 @@ pub const Surface = packed struct {
         self: Surface,
         props: Properties,
     ) !void {
-        const ret = C.SDL_GetSurfaceProperties(
+        const ret = c.SDL_GetSurfaceProperties(
             self.value,
         );
-        const group = properties.Group{ .value = try errors.wrapCall(C.SDL_PropertiesID, ret, 0) };
+        const group = properties.Group{ .value = try errors.wrapCall(c.SDL_PropertiesID, ret, 0) };
         try props.toSdl(group);
     }
 
@@ -1900,7 +1900,7 @@ pub const Surface = packed struct {
         self: Surface,
         enabled: bool,
     ) !void {
-        const ret = C.SDL_SetSurfaceRLE(
+        const ret = c.SDL_SetSurfaceRLE(
             self.value,
             enabled,
         );
@@ -1930,7 +1930,7 @@ pub const Surface = packed struct {
     ) !void {
         const area_to_copy_from_sdl = area_to_copy_from.toSdl();
         const area_to_copy_to_sdl = area_to_copy_to.toSdl();
-        return errors.wrapCallBool(C.SDL_StretchSurface(
+        return errors.wrapCallBool(c.SDL_StretchSurface(
             self.value,
             &area_to_copy_from_sdl,
             dst.value,
@@ -1953,7 +1953,7 @@ pub const Surface = packed struct {
     pub fn unlock(
         self: Surface,
     ) void {
-        C.SDL_UnlockSurface(
+        c.SDL_UnlockSurface(
             self.value,
         );
     }
@@ -1982,7 +1982,7 @@ pub const Surface = packed struct {
         y: usize,
         color: pixels.Color,
     ) !void {
-        const ret = C.SDL_WriteSurfacePixel(
+        const ret = c.SDL_WriteSurfacePixel(
             self.value,
             @intCast(x),
             @intCast(y),
@@ -2016,7 +2016,7 @@ pub const Surface = packed struct {
         y: usize,
         color: pixels.FColor,
     ) !void {
-        const ret = C.SDL_WriteSurfacePixelFloat(
+        const ret = c.SDL_WriteSurfacePixelFloat(
             self.value,
             @intCast(x),
             @intCast(y),
@@ -2053,7 +2053,7 @@ pub fn convertPixels(
     dst_format: pixels.Format,
     dst: []u8,
 ) !void {
-    const ret = C.SDL_ConvertPixels(
+    const ret = c.SDL_ConvertPixels(
         @intCast(width),
         @intCast(height),
         src_format.value,
@@ -2098,7 +2098,7 @@ pub fn convertPixelsAndColorspace(
     dst_properties: ?properties.Group,
     dst: []u8,
 ) !void {
-    const ret = C.SDL_ConvertPixelsAndColorspace(
+    const ret = c.SDL_ConvertPixelsAndColorspace(
         @intCast(width),
         @intCast(height),
         src_format.value,
@@ -2144,7 +2144,7 @@ pub fn premultiplyAlpha(
     dst: []u8,
     linear: bool,
 ) !void {
-    const ret = C.SDL_PremultiplyAlpha(
+    const ret = c.SDL_PremultiplyAlpha(
         @intCast(width),
         @intCast(height),
         src_format.value,

--- a/src/thread.zig
+++ b/src/thread.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const properties = @import("properties.zig");
 const std = @import("std");
@@ -11,7 +11,7 @@ const std = @import("std");
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_ThreadID,
+    value: c.SDL_ThreadID,
 };
 
 /// The SDL thread priority.
@@ -24,10 +24,10 @@ pub const ID = packed struct {
 /// ## Version
 /// This enum is available since SDL 3.2.0.
 pub const Priority = enum(c_uint) {
-    low = C.SDL_THREAD_PRIORITY_LOW,
-    normal = C.SDL_THREAD_PRIORITY_NORMAL,
-    high = C.SDL_THREAD_PRIORITY_HIGH,
-    time_critical = C.SDL_THREAD_PRIORITY_TIME_CRITICAL,
+    low = c.SDL_THREAD_PRIORITY_LOW,
+    normal = c.SDL_THREAD_PRIORITY_NORMAL,
+    high = c.SDL_THREAD_PRIORITY_HIGH,
+    time_critical = c.SDL_THREAD_PRIORITY_TIME_CRITICAL,
 };
 
 /// The SDL thread state.
@@ -46,17 +46,17 @@ pub const State = enum(c_uint) {
     complete,
 
     /// From and SDL value.
-    pub fn fromSdl(value: C.SDL_ThreadState) ?State {
-        if (value == C.SDL_THREAD_UNKNOWN)
+    pub fn fromSdl(value: c.SDL_ThreadState) ?State {
+        if (value == c.SDL_THREAD_UNKNOWN)
             return null;
         return @enumFromInt(value);
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?State) C.SDL_ThreadState {
+    pub fn toSdl(self: ?State) c.SDL_ThreadState {
         if (self) |val|
             return @intFromEnum(val);
-        return C.SDL_THREAD_UNKNOWN;
+        return c.SDL_THREAD_UNKNOWN;
     }
 };
 
@@ -68,7 +68,7 @@ pub const State = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const Thread = packed struct {
-    value: *C.SDL_Thread,
+    value: *c.SDL_Thread,
 
     /// Properties to use for thread creation.
     ///
@@ -87,13 +87,13 @@ pub const Thread = packed struct {
         // Get properties, must free after.
         pub fn toSdl(self: InitProperties) !properties.Group {
             const ret = try properties.Group.init();
-            try ret.set(C.SDL_PROP_THREAD_CREATE_ENTRY_FUNCTION_POINTER, .{ .pointer = @constCast(self.entry_function) });
+            try ret.set(c.SDL_PROP_THREAD_CREATE_ENTRY_FUNCTION_POINTER, .{ .pointer = @constCast(self.entry_function) });
             if (self.name) |val|
-                try ret.set(C.SDL_PROP_THREAD_CREATE_NAME_STRING, .{ .string = val });
+                try ret.set(c.SDL_PROP_THREAD_CREATE_NAME_STRING, .{ .string = val });
             if (self.user_data) |val|
-                try ret.set(C.SDL_PROP_THREAD_CREATE_USERDATA_POINTER, .{ .pointer = val });
+                try ret.set(c.SDL_PROP_THREAD_CREATE_USERDATA_POINTER, .{ .pointer = val });
             if (self.stack_size) |val|
-                try ret.set(C.SDL_PROP_THREAD_CREATE_STACKSIZE_NUMBER, .{ .number = @intCast(val) });
+                try ret.set(c.SDL_PROP_THREAD_CREATE_STACKSIZE_NUMBER, .{ .number = @intCast(val) });
             return ret;
         }
     };
@@ -129,7 +129,7 @@ pub const Thread = packed struct {
     pub fn detach(
         self: Thread,
     ) void {
-        C.SDL_DetachThread(self.value);
+        c.SDL_DetachThread(self.value);
     }
 
     /// Create a new thread with a default stack size.
@@ -161,7 +161,7 @@ pub const Thread = packed struct {
         name: ?[:0]const u8,
         data: ?*anyopaque,
     ) !Thread {
-        return .{ .value = try errors.wrapNull(*C.SDL_Thread, C.SDL_CreateThread(func, if (name) |val| val.ptr else null, data)) };
+        return .{ .value = try errors.wrapNull(*c.SDL_Thread, c.SDL_CreateThread(func, if (name) |val| val.ptr else null, data)) };
     }
 
     /// Create a new thread with with the specified properties.
@@ -206,7 +206,7 @@ pub const Thread = packed struct {
     ) !Thread {
         const init_props = try props.toSdl();
         defer init_props.deinit();
-        return .{ .value = try errors.wrapNull(*C.SDL_Thread, C.SDL_CreateThreadWithProperties(init_props.value)) };
+        return .{ .value = try errors.wrapNull(*c.SDL_Thread, c.SDL_CreateThreadWithProperties(init_props.value)) };
     }
 
     /// Get the thread identifier for the specified thread.
@@ -229,7 +229,7 @@ pub const Thread = packed struct {
     pub fn getId(
         self: Thread,
     ) ID {
-        return .{ .value = C.SDL_GetThreadID(self.value) };
+        return .{ .value = c.SDL_GetThreadID(self.value) };
     }
 
     /// Get the thread name as it was specified in `thread.Thread.init()`.
@@ -245,7 +245,7 @@ pub const Thread = packed struct {
     pub fn getName(
         self: Thread,
     ) ?[:0]const u8 {
-        const ret = C.SDL_GetThreadName(self.value);
+        const ret = c.SDL_GetThreadName(self.value);
         if (ret) |val|
             return std.mem.span(val);
         return null;
@@ -264,7 +264,7 @@ pub const Thread = packed struct {
     pub fn getState(
         self: Thread,
     ) ?State {
-        return State.fromSdl(C.SDL_GetThreadState(self.value));
+        return State.fromSdl(c.SDL_GetThreadState(self.value));
     }
 
     /// Wait for a thread to finish.
@@ -293,7 +293,7 @@ pub const Thread = packed struct {
         self: Thread,
     ) ?c_int {
         var status: c_int = undefined;
-        C.SDL_WaitThread(self.value, &status);
+        c.SDL_WaitThread(self.value, &status);
         if (status == -1)
             return null;
         return status;
@@ -332,7 +332,7 @@ pub const TlsDestructorCallback = *const fn (value: ?*anyopaque) callconv(.C) vo
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const TLSID = struct {
-    value: C.SDL_TLSID,
+    value: c.SDL_TLSID,
 
     /// Initialize thread local storage.
     ///
@@ -364,7 +364,7 @@ pub const TLSID = struct {
     pub fn get(
         self: *TLSID,
     ) !*anyopaque {
-        return errors.wrapNull(*anyopaque, C.SDL_GetTLS(&self.value));
+        return errors.wrapNull(*anyopaque, c.SDL_GetTLS(&self.value));
     }
 
     /// Set the current thread's value associated with a thread local storage ID.
@@ -392,7 +392,7 @@ pub const TLSID = struct {
         value: ?*const anyopaque,
         destructor: ?TlsDestructorCallback,
     ) !void {
-        return errors.wrapCallBool(C.SDL_SetTLS(&self.value, value, destructor));
+        return errors.wrapCallBool(c.SDL_SetTLS(&self.value, value, destructor));
     }
 };
 
@@ -407,7 +407,7 @@ pub const TLSID = struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn cleanupTls() void {
-    C.SDL_CleanupTLS();
+    c.SDL_CleanupTLS();
 }
 
 /// Get the thread identifier for the current thread.
@@ -423,7 +423,7 @@ pub fn cleanupTls() void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getCurrentId() ID {
-    return .{ .value = C.SDL_GetCurrentThreadID() };
+    return .{ .value = c.SDL_GetCurrentThreadID() };
 }
 
 /// Set the priority for the current thread.
@@ -441,7 +441,7 @@ pub fn getCurrentId() ID {
 pub fn setCurrentPriority(
     priority: Priority,
 ) !void {
-    return errors.wrapCallBool(C.SDL_SetCurrentThreadPriority(@intFromEnum(priority)));
+    return errors.wrapCallBool(c.SDL_SetCurrentThreadPriority(@intFromEnum(priority)));
 }
 
 fn threadFunc(user_data: ?*anyopaque) callconv(.C) c_int {

--- a/src/thread.zig
+++ b/src/thread.zig
@@ -310,7 +310,7 @@ pub const Thread = packed struct {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const ThreadFunction = *const fn (user_data: ?*anyopaque) callconv(.C) c_int;
+pub const ThreadFunction = *const fn (user_data: ?*anyopaque) callconv(.c) c_int;
 
 /// The callback used to cleanup data passed to `thread.TLSID.set()`.
 ///
@@ -322,7 +322,7 @@ pub const ThreadFunction = *const fn (user_data: ?*anyopaque) callconv(.C) c_int
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const TlsDestructorCallback = *const fn (value: ?*anyopaque) callconv(.C) void;
+pub const TlsDestructorCallback = *const fn (value: ?*anyopaque) callconv(.c) void;
 
 /// Thread local storage ID.
 ///
@@ -444,12 +444,12 @@ pub fn setCurrentPriority(
     return errors.wrapCallBool(c.SDL_SetCurrentThreadPriority(@intFromEnum(priority)));
 }
 
-fn threadFunc(user_data: ?*anyopaque) callconv(.C) c_int {
+fn threadFunc(user_data: ?*anyopaque) callconv(.c) c_int {
     _ = user_data;
     return 3;
 }
 
-fn tlsDestructor(value: ?*anyopaque) callconv(.C) void {
+fn tlsDestructor(value: ?*anyopaque) callconv(.c) void {
     _ = value;
 }
 

--- a/src/time.zig
+++ b/src/time.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -8,11 +8,11 @@ const std = @import("std");
 /// This enum is available since SDL 3.2.0.
 pub const DateFormat = enum(c_uint) {
     /// Year/Month/Day.
-    year_month_day = C.SDL_DATE_FORMAT_YYYYMMDD,
+    year_month_day = c.SDL_DATE_FORMAT_YYYYMMDD,
     /// Day/Month/Year.
-    day_month_year = C.SDL_DATE_FORMAT_DDMMYYYY,
+    day_month_year = c.SDL_DATE_FORMAT_DDMMYYYY,
     /// Month/Day/Year.
-    month_day_year = C.SDL_DATE_FORMAT_MMDDYYYY,
+    month_day_year = c.SDL_DATE_FORMAT_MMDDYYYY,
 };
 
 /// Day of the week.
@@ -54,9 +54,9 @@ pub const Month = enum(c_int) {
 /// This enum is available since SDL 3.2.0.
 pub const TimeFormat = enum(c_uint) {
     /// 24 hour time.
-    twenty_four_hour = C.SDL_TIME_FORMAT_24HR,
+    twenty_four_hour = c.SDL_TIME_FORMAT_24HR,
     /// 12 hour time.
-    twelve_hour = C.SDL_TIME_FORMAT_12HR,
+    twelve_hour = c.SDL_TIME_FORMAT_12HR,
 };
 
 /// A structure holding a calendar date and time broken down into it's components.
@@ -84,7 +84,7 @@ pub const DateTime = struct {
     utc_offset: i32,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(data: C.SDL_DateTime) DateTime {
+    pub fn fromSdl(data: c.SDL_DateTime) DateTime {
         return .{
             .year = @intCast(data.year),
             .month = @enumFromInt(data.month),
@@ -99,7 +99,7 @@ pub const DateTime = struct {
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: DateTime) C.SDL_DateTime {
+    pub fn toSdl(self: DateTime) c.SDL_DateTime {
         return .{
             .year = @intCast(self.year),
             .month = @intFromEnum(self.month),
@@ -128,8 +128,8 @@ pub const DateTime = struct {
         time: Time,
         local_instead_of_utc: bool,
     ) !DateTime {
-        var date_time: C.SDL_DateTime = undefined;
-        const ret = C.SDL_TimeToDateTime(
+        var date_time: c.SDL_DateTime = undefined;
+        const ret = c.SDL_TimeToDateTime(
             time.value,
             &date_time,
             local_instead_of_utc,
@@ -141,7 +141,7 @@ pub const DateTime = struct {
 
 /// Nanoseconds since the unix epoch.
 pub const Time = struct {
-    value: C.SDL_Time,
+    value: c.SDL_Time,
 
     /// Converts a calendar time to a `time.Time` in nanoseconds since the epoch.
     ///
@@ -159,9 +159,9 @@ pub const Time = struct {
     pub fn fromDateTime(
         date_time: DateTime,
     ) !Time {
-        const date_time_sdl: C.SDL_DateTime = date_time.toSdl();
-        var time: C.SDL_Time = undefined;
-        const ret = C.SDL_DateTimeToTime(
+        const date_time_sdl: c.SDL_DateTime = date_time.toSdl();
+        var time: c.SDL_Time = undefined;
+        const ret = c.SDL_DateTimeToTime(
             &date_time_sdl,
             &time,
         );
@@ -187,7 +187,7 @@ pub const Time = struct {
         low_date_time: u32,
         high_date_time: u32,
     ) Time {
-        const ret = C.SDL_TimeFromWindows(
+        const ret = c.SDL_TimeFromWindows(
             @intCast(low_date_time),
             @intCast(high_date_time),
         );
@@ -202,8 +202,8 @@ pub const Time = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getCurrent() !Time {
-        var time: C.SDL_Time = undefined;
-        const ret = C.SDL_GetCurrentTime(
+        var time: c.SDL_Time = undefined;
+        const ret = c.SDL_GetCurrentTime(
             &time,
         );
         try errors.wrapCallBool(ret);
@@ -228,7 +228,7 @@ pub const Time = struct {
     ) struct { low_date_time: u32, high_date_time: u32 } {
         var low_date_time: u32 = undefined;
         var high_date_time: u32 = undefined;
-        C.SDL_TimeToWindows(
+        c.SDL_TimeToWindows(
             self.value,
             &low_date_time,
             &high_date_time,
@@ -254,7 +254,7 @@ pub fn getDayOfWeek(
     month: Month,
     day: u5,
 ) !Day {
-    const ret = C.SDL_GetDayOfWeek(
+    const ret = c.SDL_GetDayOfWeek(
         @intCast(year),
         @intFromEnum(month),
         @intCast(day),
@@ -279,7 +279,7 @@ pub fn getDayOfYear(
     month: Month,
     day: u5,
 ) !u9 {
-    const ret = C.SDL_GetDayOfYear(
+    const ret = c.SDL_GetDayOfYear(
         @intCast(year),
         @intFromEnum(month),
         @intCast(day),
@@ -302,7 +302,7 @@ pub fn getDaysInMonth(
     year: u31,
     month: Month,
 ) !u5 {
-    const ret = C.SDL_GetDaysInMonth(
+    const ret = c.SDL_GetDaysInMonth(
         @intCast(year),
         @intFromEnum(month),
     );
@@ -322,9 +322,9 @@ pub fn getDaysInMonth(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getLocalePreferences() !struct { date_format: DateFormat, time_format: TimeFormat } {
-    var date_format: C.SDL_DateFormat = undefined;
-    var time_format: C.SDL_TimeFormat = undefined;
-    const ret = C.SDL_GetDateTimeLocalePreferences(
+    var date_format: c.SDL_DateFormat = undefined;
+    var time_format: c.SDL_TimeFormat = undefined;
+    const ret = c.SDL_GetDateTimeLocalePreferences(
         &date_format,
         &time_format,
     );

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -68,7 +68,7 @@ pub const nanoseconds_per_second: comptime_int = c.SDL_NS_PER_SECOND;
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const MillisecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: c.SDL_TimerID, interval_milliseconds: u32) callconv(.C) u32;
+pub const MillisecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: c.SDL_TimerID, interval_milliseconds: u32) callconv(.c) u32;
 
 /// Function prototype for the nanosecond timer callback function.
 ///
@@ -91,7 +91,7 @@ pub const MillisecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: 
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const NanosecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: c.SDL_TimerID, interval_nanoseconds: u64) callconv(.C) u64;
+pub const NanosecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: c.SDL_TimerID, interval_nanoseconds: u64) callconv(.c) u64;
 
 /// Wait a specified number of milliseconds before returning.
 ///
@@ -515,7 +515,7 @@ fn dummyMsCallback(
     user_data: ?*anyopaque,
     timer: c.SDL_TimerID,
     interval_milliseconds: u32,
-) callconv(.C) u32 {
+) callconv(.c) u32 {
     _ = user_data;
     _ = timer;
     _ = interval_milliseconds;
@@ -526,7 +526,7 @@ fn dummyNsCallback(
     user_data: ?*anyopaque,
     timer: c.SDL_TimerID,
     interval_nanoseconds: u64,
-) callconv(.C) u64 {
+) callconv(.c) u64 {
     _ = user_data;
     _ = timer;
     _ = interval_nanoseconds;

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 
@@ -9,7 +9,7 @@ const std = @import("std");
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const microseconds_per_second: comptime_int = C.SDL_US_PER_SECOND;
+pub const microseconds_per_second: comptime_int = c.SDL_US_PER_SECOND;
 
 /// Number of milliseconds in a second.
 ///
@@ -18,7 +18,7 @@ pub const microseconds_per_second: comptime_int = C.SDL_US_PER_SECOND;
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const milliseconds_per_second: comptime_int = C.SDL_MS_PER_SECOND;
+pub const milliseconds_per_second: comptime_int = c.SDL_MS_PER_SECOND;
 
 /// Number of nanoseconds in a microsecond.
 ///
@@ -27,7 +27,7 @@ pub const milliseconds_per_second: comptime_int = C.SDL_MS_PER_SECOND;
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const nanoseconds_per_microsecond: comptime_int = C.SDL_NS_PER_US;
+pub const nanoseconds_per_microsecond: comptime_int = c.SDL_NS_PER_US;
 
 /// Number of nanoseconds in a millisecond.
 ///
@@ -36,7 +36,7 @@ pub const nanoseconds_per_microsecond: comptime_int = C.SDL_NS_PER_US;
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const nanoseconds_per_millisecond: comptime_int = C.SDL_NS_PER_MS;
+pub const nanoseconds_per_millisecond: comptime_int = c.SDL_NS_PER_MS;
 
 /// Number of nanoseconds in a second.
 ///
@@ -45,7 +45,7 @@ pub const nanoseconds_per_millisecond: comptime_int = C.SDL_NS_PER_MS;
 ///
 /// ## Version
 /// This constant is available since SDL 3.2.0.
-pub const nanoseconds_per_second: comptime_int = C.SDL_NS_PER_SECOND;
+pub const nanoseconds_per_second: comptime_int = c.SDL_NS_PER_SECOND;
 
 /// Function prototype for the millisecond timer callback function.
 ///
@@ -68,7 +68,7 @@ pub const nanoseconds_per_second: comptime_int = C.SDL_NS_PER_SECOND;
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const MillisecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: C.SDL_TimerID, interval_milliseconds: u32) callconv(.C) u32;
+pub const MillisecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: c.SDL_TimerID, interval_milliseconds: u32) callconv(.C) u32;
 
 /// Function prototype for the nanosecond timer callback function.
 ///
@@ -91,7 +91,7 @@ pub const MillisecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: 
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const NanosecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: C.SDL_TimerID, interval_nanoseconds: u64) callconv(.C) u64;
+pub const NanosecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: c.SDL_TimerID, interval_nanoseconds: u64) callconv(.C) u64;
 
 /// Wait a specified number of milliseconds before returning.
 ///
@@ -110,7 +110,7 @@ pub const NanosecondsTimerCallback = *const fn (user_data: ?*anyopaque, timer: C
 pub fn delayMilliseconds(
     milliseconds: u32,
 ) void {
-    C.SDL_Delay(
+    c.SDL_Delay(
         @intCast(milliseconds),
     );
 }
@@ -132,7 +132,7 @@ pub fn delayMilliseconds(
 pub fn delayNanoseconds(
     nanoseconds: u64,
 ) void {
-    C.SDL_DelayNS(
+    c.SDL_DelayNS(
         @intCast(nanoseconds),
     );
 }
@@ -154,7 +154,7 @@ pub fn delayNanoseconds(
 pub fn delayNanosecondsPrecise(
     nanoseconds: u64,
 ) void {
-    C.SDL_DelayNS(
+    c.SDL_DelayNS(
         @intCast(nanoseconds),
     );
 }
@@ -188,7 +188,7 @@ pub fn delayNanosecondsPrecise(
 /// }
 /// ```
 pub fn getMillisecondsSinceInit() u64 {
-    const ret = C.SDL_GetTicks();
+    const ret = c.SDL_GetTicks();
     return @intCast(ret);
 }
 
@@ -204,7 +204,7 @@ pub fn getMillisecondsSinceInit() u64 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getNanosecondsSinceInit() u64 {
-    const ret = C.SDL_GetTicksNS();
+    const ret = c.SDL_GetTicksNS();
     return @intCast(ret);
 }
 
@@ -225,7 +225,7 @@ pub fn getNanosecondsSinceInit() u64 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getPerformanceCounter() u64 {
-    const ret = C.SDL_GetPerformanceCounter();
+    const ret = c.SDL_GetPerformanceCounter();
     return @intCast(ret);
 }
 
@@ -240,7 +240,7 @@ pub fn getPerformanceCounter() u64 {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getPerformanceFrequency() u64 {
-    const ret = C.SDL_GetPerformanceFrequency();
+    const ret = c.SDL_GetPerformanceFrequency();
     return @intCast(ret);
 }
 
@@ -263,7 +263,7 @@ pub fn getPerformanceFrequency() u64 {
 pub fn microsecondsToNanoseconds(
     microseconds: u64,
 ) u64 {
-    const ret = C.SDL_US_TO_NS(
+    const ret = c.SDL_US_TO_NS(
         microseconds,
     );
     return ret;
@@ -288,7 +288,7 @@ pub fn microsecondsToNanoseconds(
 pub fn millisecondsToNanoseconds(
     milliseconds: u64,
 ) u64 {
-    const ret = C.SDL_MS_TO_NS(
+    const ret = c.SDL_MS_TO_NS(
         milliseconds,
     );
     return ret;
@@ -313,7 +313,7 @@ pub fn millisecondsToNanoseconds(
 pub fn nanosecondsToMicroseconds(
     nanoseconds: f64,
 ) f64 {
-    const ret = C.SDL_NS_TO_US(
+    const ret = c.SDL_NS_TO_US(
         nanoseconds,
     );
     return ret;
@@ -338,7 +338,7 @@ pub fn nanosecondsToMicroseconds(
 pub fn nanosecondsToMilliseconds(
     nanoseconds: f64,
 ) f64 {
-    const ret = C.SDL_NS_TO_MS(
+    const ret = c.SDL_NS_TO_MS(
         nanoseconds,
     );
     return ret;
@@ -363,7 +363,7 @@ pub fn nanosecondsToMilliseconds(
 pub fn nanosecondsToSeconds(
     nanoseconds: f64,
 ) f64 {
-    const ret = C.SDL_NS_TO_SECONDS(
+    const ret = c.SDL_NS_TO_SECONDS(
         nanoseconds,
     );
     return ret;
@@ -388,7 +388,7 @@ pub fn nanosecondsToSeconds(
 pub fn secondsToNanoseconds(
     seconds: u64,
 ) u64 {
-    const ret = C.SDL_SECONDS_TO_NS(
+    const ret = c.SDL_SECONDS_TO_NS(
         seconds,
     );
     return ret;
@@ -396,17 +396,17 @@ pub fn secondsToNanoseconds(
 
 /// Definition of the timer ID type.
 pub const Timer = struct {
-    value: C.SDL_TimerID,
+    value: c.SDL_TimerID,
 
     /// Create a timer from SDL.
-    pub fn fromSdl(val: C.SDL_TimerID) ?Timer {
+    pub fn fromSdl(val: c.SDL_TimerID) ?Timer {
         if (val == 0)
             return null;
         return .{ .value = val };
     }
 
     /// Conver the timer to SDL.
-    pub fn toSdl(self: ?Timer) C.SDL_TimerID {
+    pub fn toSdl(self: ?Timer) c.SDL_TimerID {
         if (self) |val|
             return val.value;
         return 0;
@@ -425,7 +425,7 @@ pub const Timer = struct {
     pub fn deinit(
         self: Timer,
     ) !void {
-        return errors.wrapCallBool(C.SDL_RemoveTimer(self.value));
+        return errors.wrapCallBool(c.SDL_RemoveTimer(self.value));
     }
 
     /// Call a callback function at a future time in milliseconds.
@@ -461,12 +461,12 @@ pub const Timer = struct {
         callback: MillisecondsTimerCallback,
         user_data: ?*anyopaque,
     ) !Timer {
-        const ret = C.SDL_AddTimer(
+        const ret = c.SDL_AddTimer(
             @intCast(interval_milliseconds),
             callback,
             user_data,
         );
-        return Timer{ .value = try errors.wrapCall(C.SDL_TimerID, ret, 0) };
+        return Timer{ .value = try errors.wrapCall(c.SDL_TimerID, ret, 0) };
     }
 
     /// Call a callback function at a future time in milliseconds.
@@ -502,18 +502,18 @@ pub const Timer = struct {
         callback: NanosecondsTimerCallback,
         user_data: ?*anyopaque,
     ) !Timer {
-        const ret = C.SDL_AddTimerNS(
+        const ret = c.SDL_AddTimerNS(
             @intCast(interval_nanoseconds),
             callback,
             user_data,
         );
-        return Timer{ .value = try errors.wrapCall(C.SDL_TimerID, ret, 0) };
+        return Timer{ .value = try errors.wrapCall(c.SDL_TimerID, ret, 0) };
     }
 };
 
 fn dummyMsCallback(
     user_data: ?*anyopaque,
-    timer: C.SDL_TimerID,
+    timer: c.SDL_TimerID,
     interval_milliseconds: u32,
 ) callconv(.C) u32 {
     _ = user_data;
@@ -524,7 +524,7 @@ fn dummyMsCallback(
 
 fn dummyNsCallback(
     user_data: ?*anyopaque,
-    timer: C.SDL_TimerID,
+    timer: c.SDL_TimerID,
     interval_nanoseconds: u64,
 ) callconv(.C) u64 {
     _ = user_data;

--- a/src/touch.zig
+++ b/src/touch.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const std = @import("std");
 const stdinc = @import("stdinc.zig");
@@ -9,11 +9,11 @@ const stdinc = @import("stdinc.zig");
 /// This enum is available since SDL 3.2.0.
 pub const DeviceType = enum(c_uint) {
     /// Touch screen with window-relative coordinates.
-    direct = C.SDL_TOUCH_DEVICE_DIRECT,
+    direct = c.SDL_TOUCH_DEVICE_DIRECT,
     /// Trackpad with absolute device coordinates.
-    indirect_absolute = C.SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE,
+    indirect_absolute = c.SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE,
     /// Trackpad with screen cursor-relative coordinates.
-    indirect_relative = C.SDL_TOUCH_DEVICE_INDIRECT_RELATIVE,
+    indirect_relative = c.SDL_TOUCH_DEVICE_INDIRECT_RELATIVE,
 };
 
 /// Data about a single finger in a multitouch event.
@@ -36,15 +36,15 @@ pub const Finger = extern struct {
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_Finger) == @sizeOf(Finger));
-        std.debug.assert(@offsetOf(C.SDL_Finger, "id") == @offsetOf(Finger, "id"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_Finger, "id")) == @sizeOf(@FieldType(Finger, "id")));
-        std.debug.assert(@offsetOf(C.SDL_Finger, "x") == @offsetOf(Finger, "x"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_Finger, "x")) == @sizeOf(@FieldType(Finger, "x")));
-        std.debug.assert(@offsetOf(C.SDL_Finger, "y") == @offsetOf(Finger, "y"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_Finger, "y")) == @sizeOf(@FieldType(Finger, "y")));
-        std.debug.assert(@offsetOf(C.SDL_Finger, "pressure") == @offsetOf(Finger, "pressure"));
-        std.debug.assert(@sizeOf(@FieldType(C.SDL_Finger, "pressure")) == @sizeOf(@FieldType(Finger, "pressure")));
+        std.debug.assert(@sizeOf(c.SDL_Finger) == @sizeOf(Finger));
+        std.debug.assert(@offsetOf(c.SDL_Finger, "id") == @offsetOf(Finger, "id"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_Finger, "id")) == @sizeOf(@FieldType(Finger, "id")));
+        std.debug.assert(@offsetOf(c.SDL_Finger, "x") == @offsetOf(Finger, "x"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_Finger, "x")) == @sizeOf(@FieldType(Finger, "x")));
+        std.debug.assert(@offsetOf(c.SDL_Finger, "y") == @offsetOf(Finger, "y"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_Finger, "y")) == @sizeOf(@FieldType(Finger, "y")));
+        std.debug.assert(@offsetOf(c.SDL_Finger, "pressure") == @offsetOf(Finger, "pressure"));
+        std.debug.assert(@sizeOf(@FieldType(c.SDL_Finger, "pressure")) == @sizeOf(@FieldType(Finger, "pressure")));
     }
 };
 
@@ -57,7 +57,7 @@ pub const Finger = extern struct {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const FingerID = packed struct {
-    value: C.SDL_FingerID,
+    value: c.SDL_FingerID,
 };
 
 /// A unique ID for a touch device.
@@ -68,24 +68,24 @@ pub const FingerID = packed struct {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const ID = packed struct {
-    value: C.SDL_TouchID,
+    value: c.SDL_TouchID,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(C.SDL_TouchID) == @sizeOf(ID));
+        std.debug.assert(@sizeOf(c.SDL_TouchID) == @sizeOf(ID));
     }
 
     /// The touch ID for touch events simulated with mouse input.
     ///
     /// ## Version
     /// This constant is available since SDL 3.2.0.
-    pub const mouse = ID{ .value = C.SDL_MOUSE_TOUCHID };
+    pub const mouse = ID{ .value = c.SDL_MOUSE_TOUCHID };
 
     /// The touch ID for touch events simulated with pen input.
     ///
     /// ## Version
     /// This constant is available since SDL 3.2.0.
-    pub const pen = ID{ .value = C.SDL_PEN_TOUCHID };
+    pub const pen = ID{ .value = c.SDL_PEN_TOUCHID };
 
     /// Get a list of active fingers for a given touch device.
     ///
@@ -102,8 +102,8 @@ pub const ID = packed struct {
         self: ID,
     ) ![]*Finger {
         var count: c_int = undefined;
-        const val = C.SDL_GetTouchFingers(self.value, &count);
-        const ret: [*]*Finger = @ptrCast(try errors.wrapCallCPtr([*c]C.SDL_Finger, val));
+        const val = c.SDL_GetTouchFingers(self.value, &count);
+        const ret: [*]*Finger = @ptrCast(try errors.wrapCallCPtr([*c]c.SDL_Finger, val));
         return ret[0..@intCast(count)];
     }
 
@@ -120,7 +120,7 @@ pub const ID = packed struct {
     pub fn getName(
         self: ID,
     ) ![:0]const u8 {
-        return errors.wrapCallCString(C.SDL_GetTouchDeviceName(self.value));
+        return errors.wrapCallCString(c.SDL_GetTouchDeviceName(self.value));
     }
 
     /// Get the type of the given touch device.
@@ -136,8 +136,8 @@ pub const ID = packed struct {
     pub fn getType(
         self: ID,
     ) ?DeviceType {
-        const ret = C.SDL_GetTouchDeviceType(self.value);
-        if (ret == C.SDL_TOUCH_DEVICE_INVALID)
+        const ret = c.SDL_GetTouchDeviceType(self.value);
+        if (ret == c.SDL_TOUCH_DEVICE_INVALID)
             return null;
         return @enumFromInt(ret);
     }
@@ -158,8 +158,8 @@ pub const ID = packed struct {
 /// This function is available since SDL 3.2.0.
 pub fn getDevices() ![]ID {
     var count: c_int = undefined;
-    const val = C.SDL_GetTouchDevices(&count);
-    const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(C.SDL_TouchID, val));
+    const val = c.SDL_GetTouchDevices(&count);
+    const ret: [*]ID = @ptrCast(try errors.wrapCallCPtr(c.SDL_TouchID, val));
     return ret[0..@intCast(count)];
 }
 

--- a/src/tray.zig
+++ b/src/tray.zig
@@ -10,7 +10,7 @@ const surface = @import("surface.zig");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const Callback = *const fn (user_data: ?*anyopaque, entry: ?*c.SDL_TrayEntry) callconv(.C) void;
+pub const Callback = *const fn (user_data: ?*anyopaque, entry: ?*c.SDL_TrayEntry) callconv(.c) void;
 
 /// An opaque handle representing an entry on a system tray object.
 ///

--- a/src/tray.zig
+++ b/src/tray.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 const surface = @import("surface.zig");
 
@@ -10,18 +10,18 @@ const surface = @import("surface.zig");
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const Callback = *const fn (user_data: ?*anyopaque, entry: ?*C.SDL_TrayEntry) callconv(.C) void;
+pub const Callback = *const fn (user_data: ?*anyopaque, entry: ?*c.SDL_TrayEntry) callconv(.C) void;
 
 /// An opaque handle representing an entry on a system tray object.
 ///
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Entry = struct {
-    value: *C.SDL_TrayEntry,
+    value: *c.SDL_TrayEntry,
 
     // Size tests.
     comptime {
-        std.debug.assert(@sizeOf(*C.SDL_TrayEntry) == @sizeOf(Entry));
+        std.debug.assert(@sizeOf(*c.SDL_TrayEntry) == @sizeOf(Entry));
     }
 
     /// Simulate a click on a tray entry.
@@ -37,7 +37,7 @@ pub const Entry = struct {
     pub fn click(
         self: Entry,
     ) void {
-        C.SDL_ClickTrayEntry(self.value);
+        c.SDL_ClickTrayEntry(self.value);
     }
 
     /// Create a submenu for a system tray entry.
@@ -64,7 +64,7 @@ pub const Entry = struct {
         self: Entry,
     ) Menu {
         return .{
-            .value = C.SDL_CreateTraySubmenu(self.value).?,
+            .value = c.SDL_CreateTraySubmenu(self.value).?,
         };
     }
 
@@ -87,7 +87,7 @@ pub const Entry = struct {
     pub fn getChecked(
         self: Entry,
     ) bool {
-        return C.SDL_GetTrayEntryChecked(self.value);
+        return c.SDL_GetTrayEntryChecked(self.value);
     }
 
     /// Gets whether or not an entry is enabled.
@@ -106,7 +106,7 @@ pub const Entry = struct {
     pub fn getEnabled(
         self: Entry,
     ) bool {
-        return C.SDL_GetTrayEntryEnabled(self.value);
+        return c.SDL_GetTrayEntryEnabled(self.value);
     }
 
     /// Gets the label of an entry.
@@ -128,7 +128,7 @@ pub const Entry = struct {
     pub fn getLabel(
         self: Entry,
     ) ?[:0]const u8 {
-        const ret = C.SDL_GetTrayEntryLabel(self.value);
+        const ret = c.SDL_GetTrayEntryLabel(self.value);
         if (ret == null)
             return null;
         return std.mem.span(ret);
@@ -151,7 +151,7 @@ pub const Entry = struct {
         self: Entry,
     ) Menu {
         return .{
-            .value = C.SDL_GetTrayEntryParent(self.value).?,
+            .value = c.SDL_GetTrayEntryParent(self.value).?,
         };
     }
 
@@ -180,7 +180,7 @@ pub const Entry = struct {
         self: Entry,
     ) Menu {
         return .{
-            .value = C.SDL_GetTraySubmenu(self.value).?,
+            .value = c.SDL_GetTraySubmenu(self.value).?,
         };
     }
 
@@ -197,7 +197,7 @@ pub const Entry = struct {
     pub fn remove(
         self: Entry,
     ) void {
-        C.SDL_RemoveTrayEntry(self.value);
+        c.SDL_RemoveTrayEntry(self.value);
     }
 
     /// Sets a callback to be invoked when the entry is selected.
@@ -217,7 +217,7 @@ pub const Entry = struct {
         callback: Callback,
         user_data: ?*anyopaque,
     ) void {
-        C.SDL_SetTrayEntryCallback(self.value, callback, user_data);
+        c.SDL_SetTrayEntryCallback(self.value, callback, user_data);
     }
 
     /// Sets whether or not an entry is checked.
@@ -238,7 +238,7 @@ pub const Entry = struct {
         self: Entry,
         checked: bool,
     ) void {
-        C.SDL_SetTrayEntryChecked(self.value, checked);
+        c.SDL_SetTrayEntryChecked(self.value, checked);
     }
 
     /// Sets whether or not an entry is enabled.
@@ -256,7 +256,7 @@ pub const Entry = struct {
         self: Entry,
         enabled: bool,
     ) void {
-        C.SDL_SetTrayEntryEnabled(self.value, enabled);
+        c.SDL_SetTrayEntryEnabled(self.value, enabled);
     }
 
     /// Sets the label of an entry.
@@ -278,7 +278,7 @@ pub const Entry = struct {
         self: Entry,
         label: [:0]const u8,
     ) void {
-        C.SDL_SetTrayEntryLabel(self.value, label.ptr);
+        c.SDL_SetTrayEntryLabel(self.value, label.ptr);
     }
 };
 
@@ -300,19 +300,19 @@ pub const EntryFlags = struct {
     disabled: bool = false,
 
     /// Convert this to an SDL value.
-    pub fn toSdl(self: EntryFlags) C.SDL_TrayEntryFlags {
-        var ret: C.SDL_TrayEntryFlags = 0;
+    pub fn toSdl(self: EntryFlags) c.SDL_TrayEntryFlags {
+        var ret: c.SDL_TrayEntryFlags = 0;
         switch (self.entry) {
-            .button => ret |= C.SDL_TRAYENTRY_BUTTON,
+            .button => ret |= c.SDL_TRAYENTRY_BUTTON,
             .checkbox => |val| {
-                ret |= C.SDL_TRAYENTRY_CHECKBOX;
+                ret |= c.SDL_TRAYENTRY_CHECKBOX;
                 if (val)
-                    ret |= C.SDL_TRAYENTRY_CHECKED;
+                    ret |= c.SDL_TRAYENTRY_CHECKED;
             },
-            .submenu => ret |= C.SDL_TRAYENTRY_SUBMENU,
+            .submenu => ret |= c.SDL_TRAYENTRY_SUBMENU,
         }
         if (self.disabled)
-            ret |= C.SDL_TRAYENTRY_DISABLED;
+            ret |= c.SDL_TRAYENTRY_DISABLED;
         return ret;
     }
 };
@@ -321,13 +321,13 @@ pub const EntryFlags = struct {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const EntryType = enum(C.SDL_TrayEntryFlags) {
+pub const EntryType = enum(c.SDL_TrayEntryFlags) {
     /// Make the entry a simple button.
-    button = C.SDL_TRAYENTRY_BUTTON,
+    button = c.SDL_TRAYENTRY_BUTTON,
     /// Make the entry a checkbox.
-    checkbox = C.SDL_TRAYENTRY_CHECKBOX,
+    checkbox = c.SDL_TRAYENTRY_CHECKBOX,
     /// Prepare the entry to have a submenu.
-    submenu = C.SDL_TRAYENTRY_SUBMENU,
+    submenu = c.SDL_TRAYENTRY_SUBMENU,
 };
 
 /// An opaque handle representing a menu/submenu on a system tray object.
@@ -335,7 +335,7 @@ pub const EntryType = enum(C.SDL_TrayEntryFlags) {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Menu = struct {
-    value: *C.SDL_TrayMenu,
+    value: *c.SDL_TrayMenu,
 
     /// Returns a list of entries in the menu, in order.
     ///
@@ -355,7 +355,7 @@ pub const Menu = struct {
         self: Menu,
     ) []const Entry {
         var count: c_int = undefined;
-        const ret: [*]const Entry = @ptrCast(C.SDL_GetTrayEntries(self.value, &count).?);
+        const ret: [*]const Entry = @ptrCast(c.SDL_GetTrayEntries(self.value, &count).?);
         return ret[0..@intCast(count)];
     }
 
@@ -378,7 +378,7 @@ pub const Menu = struct {
     pub fn getParentEntry(
         self: Menu,
     ) ?Entry {
-        const ret = C.SDL_GetTrayMenuParentEntry(self.value);
+        const ret = c.SDL_GetTrayMenuParentEntry(self.value);
         if (ret) |val| {
             return .{
                 .value = val,
@@ -406,7 +406,7 @@ pub const Menu = struct {
     pub fn getParentTray(
         self: Menu,
     ) ?Tray {
-        const ret = C.SDL_GetTrayMenuParentTray(self.value);
+        const ret = c.SDL_GetTrayMenuParentTray(self.value);
         if (ret) |val| {
             return .{
                 .value = val,
@@ -443,7 +443,7 @@ pub const Menu = struct {
         label: ?[:0]const u8,
         flags: EntryFlags,
     ) ?Entry {
-        const ret = C.SDL_InsertTrayEntryAt(
+        const ret = c.SDL_InsertTrayEntryAt(
             self.value,
             if (pos) |val| @intCast(val) else -1,
             if (label) |val| val.ptr else null,
@@ -461,7 +461,7 @@ pub const Menu = struct {
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Tray = struct {
-    value: *C.SDL_Tray,
+    value: *c.SDL_Tray,
 
     /// Create a menu for a system tray.
     ///
@@ -487,7 +487,7 @@ pub const Tray = struct {
         self: Tray,
     ) Menu {
         return .{
-            .value = C.SDL_CreateTrayMenu(self.value).?,
+            .value = c.SDL_CreateTrayMenu(self.value).?,
         };
     }
 
@@ -507,7 +507,7 @@ pub const Tray = struct {
     pub fn deinit(
         self: Tray,
     ) void {
-        C.SDL_DestroyTray(self.value);
+        c.SDL_DestroyTray(self.value);
     }
 
     /// Gets a previously created tray menu.
@@ -535,7 +535,7 @@ pub const Tray = struct {
         self: Tray,
     ) Menu {
         return .{
-            .value = C.SDL_GetTrayMenu(self.value).?,
+            .value = c.SDL_GetTrayMenu(self.value).?,
         };
     }
 
@@ -554,7 +554,7 @@ pub const Tray = struct {
         self: Tray,
         icon: ?surface.Surface,
     ) void {
-        C.SDL_SetTrayIcon(self.value, if (icon) |val| val.value else null);
+        c.SDL_SetTrayIcon(self.value, if (icon) |val| val.value else null);
     }
 
     /// Create an icon to be placed in the operating system's tray, or equivalent.
@@ -584,7 +584,7 @@ pub const Tray = struct {
         icon: ?surface.Surface,
         tooltip: ?[:0]const u8,
     ) Tray {
-        return .{ .value = C.SDL_CreateTray(
+        return .{ .value = c.SDL_CreateTray(
             if (icon) |val| val.value else null,
             if (tooltip) |val| val.ptr else null,
         ).? };
@@ -605,7 +605,7 @@ pub const Tray = struct {
         self: Tray,
         tooltip: ?[:0]const u8,
     ) void {
-        C.SDL_SetTrayTooltip(self.value, if (tooltip) |val| val.ptr else null);
+        c.SDL_SetTrayTooltip(self.value, if (tooltip) |val| val.ptr else null);
     }
 };
 
@@ -620,7 +620,7 @@ pub const Tray = struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn update() void {
-    C.SDL_UpdateTrays();
+    c.SDL_UpdateTrays();
 }
 
 // Tray tests.

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const std = @import("std");
 
 /// Functionality to query the current SDL version, both as headers the app was compiled against, and a library the app is linked to.
@@ -8,7 +8,7 @@ pub const Version = packed struct {
     ///
     /// ## Version
     /// This field is available since SDL 3.2.0.
-    pub const compiled_against = Version{ .value = C.SDL_VERSION };
+    pub const compiled_against = Version{ .value = c.SDL_VERSION };
 
     /// A string describing the source at a particular point in development.
     ///
@@ -21,7 +21,7 @@ pub const Version = packed struct {
     ///
     /// ## Version
     /// This field is available since SDL 3.2.0.
-    // pub const revision = C.SDL_REVISION; // This should exist but does not?
+    // pub const revision = c.SDL_REVISION; // This should exist but does not?
 
     /// Check if the SDL version is at least greater than the given one.
     ///
@@ -40,7 +40,7 @@ pub const Version = packed struct {
         minor: u32,
         micro: u32,
     ) bool {
-        const ret = C.SDL_VERSION_ATLEAST(
+        const ret = c.SDL_VERSION_ATLEAST(
             @as(c_int, @intCast(major)),
             @as(c_int, @intCast(minor)),
             @as(c_int, @intCast(micro)),
@@ -63,7 +63,7 @@ pub const Version = packed struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn get() Version {
-        const ret = C.SDL_GetVersion();
+        const ret = c.SDL_GetVersion();
         return Version{ .value = ret };
     }
 
@@ -77,7 +77,7 @@ pub const Version = packed struct {
     pub fn getMajor(
         self: Version,
     ) u32 {
-        const ret = C.SDL_VERSIONNUM_MAJOR(
+        const ret = c.SDL_VERSIONNUM_MAJOR(
             self.value,
         );
         return @intCast(ret);
@@ -93,7 +93,7 @@ pub const Version = packed struct {
     pub fn getMinor(
         self: Version,
     ) u32 {
-        const ret = C.SDL_VERSIONNUM_MINOR(
+        const ret = c.SDL_VERSIONNUM_MINOR(
             self.value,
         );
         return @intCast(ret);
@@ -109,7 +109,7 @@ pub const Version = packed struct {
     pub fn getMicro(
         self: Version,
     ) u32 {
-        const ret = C.SDL_VERSIONNUM_MICRO(
+        const ret = c.SDL_VERSIONNUM_MICRO(
             self.value,
         );
         return @intCast(ret);
@@ -134,7 +134,7 @@ pub const Version = packed struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getRevision() ?[:0]const u8 {
-        const ret = C.SDL_GetRevision();
+        const ret = c.SDL_GetRevision();
         const converted_ret = std.mem.span(ret);
         if (std.mem.eql(u8, converted_ret, ""))
             return null;
@@ -158,7 +158,7 @@ pub const Version = packed struct {
         minor: u32,
         micro: u32,
     ) Version {
-        const ret = C.SDL_VERSIONNUM(
+        const ret = c.SDL_VERSIONNUM(
             @as(c_int, @intCast(major)),
             @as(c_int, @intCast(minor)),
             @as(c_int, @intCast(micro)),

--- a/src/video.zig
+++ b/src/video.zig
@@ -1,4 +1,4 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const errors = @import("errors.zig");
 const pixels = @import("pixels.zig");
 const properties = @import("properties.zig");
@@ -12,9 +12,9 @@ const surface = @import("surface.zig");
 /// This enum is available since SDL 3.2.0.
 pub const SystemTheme = enum(c_uint) {
     /// Light colored theme.
-    Light = C.SDL_SYSTEM_THEME_LIGHT,
+    Light = c.SDL_SYSTEM_THEME_LIGHT,
     /// Dark colored theme.
-    Dark = C.SDL_SYSTEM_THEME_DARK,
+    Dark = c.SDL_SYSTEM_THEME_DARK,
 };
 
 /// This is a unique for a display for the time it is connected to the system, and is never reused for the lifetime of the application.
@@ -25,7 +25,7 @@ pub const SystemTheme = enum(c_uint) {
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
 pub const Display = packed struct {
-    value: C.SDL_DisplayID,
+    value: c.SDL_DisplayID,
 
     /// Display properties.
     ///
@@ -42,8 +42,8 @@ pub const Display = packed struct {
         /// Get properties from SDL.
         pub fn fromSdl(props: properties.Group) Properties {
             return .{
-                .hdr_enabled = if (props.get(C.SDL_PROP_DISPLAY_HDR_ENABLED_BOOLEAN)) |val| val.Boolean else null,
-                .kmsdrm_panel_orientation = if (props.get(C.SDL_PROP_DISPLAY_KMSDRM_PANEL_ORIENTATION_NUMBER)) |val| val.Number else null,
+                .hdr_enabled = if (props.get(c.SDL_PROP_DISPLAY_HDR_ENABLED_BOOLEAN)) |val| val.Boolean else null,
+                .kmsdrm_panel_orientation = if (props.get(c.SDL_PROP_DISPLAY_KMSDRM_PANEL_ORIENTATION_NUMBER)) |val| val.Number else null,
             };
         }
     };
@@ -79,8 +79,8 @@ pub const Display = packed struct {
         refresh_rate: f32,
         include_high_density_modes: bool,
     ) !DisplayMode {
-        var mode: C.SDL_DisplayMode = undefined;
-        const ret = C.SDL_GetClosestFullscreenDisplayMode(
+        var mode: c.SDL_DisplayMode = undefined;
+        const ret = c.SDL_GetClosestFullscreenDisplayMode(
             self.value,
             @intCast(width),
             @intCast(height),
@@ -112,8 +112,8 @@ pub const Display = packed struct {
     pub fn getCurrentMode(
         self: Display,
     ) !DisplayMode {
-        const ret = C.SDL_GetCurrentDisplayMode(self.value);
-        const mode = try errors.wrapNull(C.SDL_DisplayMode, ret);
+        const ret = c.SDL_GetCurrentDisplayMode(self.value);
+        const mode = try errors.wrapNull(c.SDL_DisplayMode, ret);
         return DisplayMode.fromSdl(mode);
     }
 
@@ -133,7 +133,7 @@ pub const Display = packed struct {
     pub fn getCurrentOrientation(
         self: Display,
     ) ?DisplayOrientation {
-        const ret = C.SDL_GetCurrentDisplayOrientation(
+        const ret = c.SDL_GetCurrentDisplayOrientation(
             self.value,
         );
         return DisplayOrientation.fromSdl(ret);
@@ -159,8 +159,8 @@ pub const Display = packed struct {
     pub fn getDesktopMode(
         self: Display,
     ) !DisplayMode {
-        const ret = C.SDL_GetDesktopDisplayMode(self.value);
-        const val = try errors.wrapCallCPtrConst(C.SDL_DisplayMode, ret);
+        const ret = c.SDL_GetDesktopDisplayMode(self.value);
+        const val = try errors.wrapCallCPtrConst(c.SDL_DisplayMode, ret);
         return DisplayMode.fromSdl(val.*);
     }
 
@@ -183,8 +183,8 @@ pub const Display = packed struct {
     pub fn getBounds(
         self: Display,
     ) !rect.IRect {
-        var area: C.SDL_Rect = undefined;
-        const ret = C.SDL_GetDisplayBounds(
+        var area: c.SDL_Rect = undefined;
+        const ret = c.SDL_GetDisplayBounds(
             self.value,
             &area,
         );
@@ -218,7 +218,7 @@ pub const Display = packed struct {
     pub fn getContentScale(
         self: Display,
     ) !f32 {
-        const ret = C.SDL_GetDisplayContentScale(
+        const ret = c.SDL_GetDisplayContentScale(
             self.value,
         );
         return errors.wrapCall(f32, ret, 0.0);
@@ -246,8 +246,8 @@ pub const Display = packed struct {
     pub fn getUsableBounds(
         self: Display,
     ) !rect.IRect {
-        var area: C.SDL_Rect = undefined;
-        const ret = C.SDL_GetDisplayUsableBounds(
+        var area: c.SDL_Rect = undefined;
+        const ret = c.SDL_GetDisplayUsableBounds(
             self.value,
             &area,
         );
@@ -274,7 +274,7 @@ pub const Display = packed struct {
     pub fn getName(
         self: Display,
     ) ![:0]const u8 {
-        const ret = C.SDL_GetDisplayName(
+        const ret = c.SDL_GetDisplayName(
             self.value,
         );
         return try errors.wrapCallCString(ret);
@@ -299,8 +299,8 @@ pub const Display = packed struct {
     pub fn getProperties(
         self: Display,
     ) !Properties {
-        const ret = C.SDL_GetDisplayProperties(self.value);
-        return Properties.fromSdl(properties.Group{ .value = try errors.wrapCall(C.SDL_PropertiesID, ret, 0) });
+        const ret = c.SDL_GetDisplayProperties(self.value);
+        return Properties.fromSdl(properties.Group{ .value = try errors.wrapCall(c.SDL_PropertiesID, ret, 0) });
     }
 
     /// Get a list of currently connected displays.
@@ -319,7 +319,7 @@ pub const Display = packed struct {
     /// TODO!!!
     pub fn getAll() ![*:0]Display {
         var count: c_int = undefined;
-        const ret = try errors.wrapCallCPtr(C.SDL_DisplayID, C.SDL_GetDisplays(&count));
+        const ret = try errors.wrapCallCPtr(c.SDL_DisplayID, c.SDL_GetDisplays(&count));
         return @as([*:0]Display, ret);
     }
 
@@ -341,7 +341,7 @@ pub const Display = packed struct {
     /// * Refresh rate -> Highest to lowest.
     /// * Pixel density -> Lowest to highest.
     ///
-     /// ## Thread Safety
+    /// ## Thread Safety
     /// This function should only be called on the main thread.
     ///
     /// ## Version
@@ -351,7 +351,7 @@ pub const Display = packed struct {
         allocator: std.mem.Allocator,
     ) ![]DisplayMode {
         var count: c_int = undefined;
-        const val = try errors.wrapCallCPtr([*c]C.SDL_DisplayMode, C.SDL_GetFullscreenDisplayModes(self.value, &count));
+        const val = try errors.wrapCallCPtr([*c]c.SDL_DisplayMode, c.SDL_GetFullscreenDisplayModes(self.value, &count));
         var ret = try allocator.alloc(DisplayMode, @intCast(count));
         for (0..count) |ind| {
             ret[ind] = DisplayMode.fromSdl(val[ind].*);
@@ -375,10 +375,10 @@ pub const Display = packed struct {
     pub fn getNaturalOrientation(
         self: Display,
     ) ?DisplayOrientation {
-        const ret = C.SDL_GetNaturalDisplayOrientation(
+        const ret = c.SDL_GetNaturalDisplayOrientation(
             self.value,
         );
-        if (ret == C.SDL_ORIENTATION_UNKNOWN)
+        if (ret == c.SDL_ORIENTATION_UNKNOWN)
             return null;
         return @enumFromInt(ret);
     }
@@ -394,8 +394,8 @@ pub const Display = packed struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getPrimaryDisplay() !Display {
-        const ret = C.SDL_GetPrimaryDisplay();
-        return Display{ .value = try errors.wrapCall(C.SDL_DisplayID, ret, 0) };
+        const ret = c.SDL_GetPrimaryDisplay();
+        return Display{ .value = try errors.wrapCall(c.SDL_DisplayID, ret, 0) };
     }
 };
 
@@ -422,7 +422,7 @@ pub const DisplayMode = struct {
     refresh_rate_denominator: u32,
 
     /// Convert from SDL.
-    pub fn fromSdl(mode: C.SDL_DisplayMode) DisplayMode {
+    pub fn fromSdl(mode: c.SDL_DisplayMode) DisplayMode {
         return .{
             .display = Display.fromSdl(mode.displayID),
             .format = pixels.Format.fromSdl(mode.format),
@@ -436,7 +436,7 @@ pub const DisplayMode = struct {
     }
 
     /// Convert to SDL.
-    pub fn toSdl(self: DisplayMode) C.SDL_DisplayMode {
+    pub fn toSdl(self: DisplayMode) c.SDL_DisplayMode {
         return .{
             .displayID = Display.toSdl(self.display),
             .format = pixels.Format.toSdl(self.format),
@@ -456,33 +456,33 @@ pub const DisplayMode = struct {
 /// This enum is available since SDL 3.2.0.
 pub const DisplayOrientation = enum(c_uint) {
     /// The display is in landscape mode, with the right side up, relative to portrait mode.
-    Landscape = C.SDL_ORIENTATION_LANDSCAPE,
+    Landscape = c.SDL_ORIENTATION_LANDSCAPE,
     /// The display is in landscape mode, with the left side up, relative to portrait mode.
-    LandscapeFlipped = C.SDL_ORIENTATION_LANDSCAPE_FLIPPED,
+    LandscapeFlipped = c.SDL_ORIENTATION_LANDSCAPE_FLIPPED,
     /// The display is in portrait mode.
-    Portrait = C.SDL_ORIENTATION_PORTRAIT,
+    Portrait = c.SDL_ORIENTATION_PORTRAIT,
     /// The display is in portrait mode, upside down.
-    PortraitFlipped = C.SDL_ORIENTATION_PORTRAIT_FLIPPED,
+    PortraitFlipped = c.SDL_ORIENTATION_PORTRAIT_FLIPPED,
 
     /// Convert from SDL.
-    pub fn fromSdl(val: C.SDL_DisplayOrientation) ?DisplayOrientation {
+    pub fn fromSdl(val: c.SDL_DisplayOrientation) ?DisplayOrientation {
         return switch (val) {
-            C.SDL_ORIENTATION_LANDSCAPE => .Landscape,
-            C.SDL_ORIENTATION_LANDSCAPE_FLIPPED => .LandscapeFlipped,
-            C.SDL_ORIENTATION_PORTRAIT => .Portrait,
-            C.SDL_ORIENTATION_PORTRAIT_FLIPPED => .PortraitFlipped,
+            c.SDL_ORIENTATION_LANDSCAPE => .Landscape,
+            c.SDL_ORIENTATION_LANDSCAPE_FLIPPED => .LandscapeFlipped,
+            c.SDL_ORIENTATION_PORTRAIT => .Portrait,
+            c.SDL_ORIENTATION_PORTRAIT_FLIPPED => .PortraitFlipped,
             else => null,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: ?DisplayOrientation) C.SDL_DisplayOrientation {
-        const val = self orelse return C.SDL_ORIENTATION_UNKNOWN;
+    pub fn toSdl(self: ?DisplayOrientation) c.SDL_DisplayOrientation {
+        const val = self orelse return c.SDL_ORIENTATION_UNKNOWN;
         switch (val) {
-            .Landscape => C.SDL_ORIENTATION_LANDSCAPE,
-            .LandscapeFlipped => C.SDL_ORIENTATION_LANDSCAPE_FLIPPED,
-            .Portrait => C.SDL_ORIENTATION_PORTRAIT,
-            .PortraitFlipped => C.SDL_ORIENTATION_PORTRAIT_FLIPPED,
+            .Landscape => c.SDL_ORIENTATION_LANDSCAPE,
+            .LandscapeFlipped => c.SDL_ORIENTATION_LANDSCAPE_FLIPPED,
+            .Portrait => c.SDL_ORIENTATION_PORTRAIT,
+            .PortraitFlipped => c.SDL_ORIENTATION_PORTRAIT_FLIPPED,
         }
     }
 };
@@ -496,7 +496,7 @@ pub const egl = struct {
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const EglAttrib = C.SDL_EGLAttrib;
+    pub const EglAttrib = c.SDL_EGLAttrib;
 
     /// EGL platform attribute initialization callback.
     ///
@@ -536,7 +536,7 @@ pub const egl = struct {
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const EglInt = C.SDL_EGLint;
+    pub const EglInt = c.SDL_EGLint;
 
     /// EGL surface/context attribute initialization callback types.
     ///
@@ -562,7 +562,7 @@ pub const egl = struct {
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const EglIntArrayCallback = *const fn (user_data: ?*anyopaque, display: C.SDL_EGLDisplay, config: C.SDL_EGLConfig) callconv(.C) [*c]EglInt;
+    pub const EglIntArrayCallback = *const fn (user_data: ?*anyopaque, display: c.SDL_EGLDisplay, config: c.SDL_EGLConfig) callconv(.C) [*c]EglInt;
 
     /// Opaque type for an EGL surface.
     ///
@@ -581,7 +581,7 @@ pub const egl = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getCurrentConfig() !EglConfig {
-        const ret = C.SDL_EGL_GetCurrentConfig();
+        const ret = c.SDL_EGL_GetCurrentConfig();
         return errors.wrapNull(EglConfig, ret);
     }
 
@@ -596,7 +596,7 @@ pub const egl = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getCurrentDisplay() !EglDisplay {
-        const ret = C.SDL_EGL_GetCurrentDisplay();
+        const ret = c.SDL_EGL_GetCurrentDisplay();
         return errors.wrapNull(EglDisplay, ret);
     }
 
@@ -621,7 +621,7 @@ pub const egl = struct {
     pub fn getProcAddress(
         proc: [:0]const u8,
     ) !*anyopaque {
-        const ret = C.SDL_EGL_GetProcAddress(proc.ptr);
+        const ret = c.SDL_EGL_GetProcAddress(proc.ptr);
         return errors.wrapNull(*anyopaque, ret);
     }
 
@@ -641,7 +641,7 @@ pub const egl = struct {
     pub fn getWindowSurface(
         window: Window,
     ) !EglSurface {
-        const ret = C.SDL_EGL_GetWindowSurface(window.value);
+        const ret = c.SDL_EGL_GetWindowSurface(window.value);
         return errors.wrapNull(EglSurface, ret);
     }
 
@@ -669,7 +669,7 @@ pub const egl = struct {
         context_attrib_callback: ?EglIntArrayCallback,
         user_data: ?*anyopaque,
     ) void {
-        C.SDL_EGL_SetAttributeCallbacks(
+        c.SDL_EGL_SetAttributeCallbacks(
             platform_attrib_callback,
             surface_attrib_callback,
             context_attrib_callback,
@@ -683,7 +683,6 @@ pub const egl = struct {
 /// ## Version
 /// Provided by zig-sdl3.
 pub const gl = struct {
-
     /// An enumeration of OpenGL configuration attributes.
     ///
     /// ## Remarks
@@ -698,58 +697,58 @@ pub const gl = struct {
     /// This enum is available since SDL 3.2.0.
     pub const Attribute = enum(c_uint) {
         /// The minimum number of bits for the red channel of the color buffer; defaults to 8.
-        red_size = C.SDL_GL_RED_SIZE,
+        red_size = c.SDL_GL_RED_SIZE,
         /// The minimum number of bits for the green channel of the color buffer; defaults to 8.
-        green_size = C.SDL_GL_GREEN_SIZE,
+        green_size = c.SDL_GL_GREEN_SIZE,
         /// The minimum number of bits for the blue channel of the color buffer; defaults to 8.
-        blue_size = C.SDL_GL_BLUE_SIZE,
+        blue_size = c.SDL_GL_BLUE_SIZE,
         /// The minimum number of bits for the alpha channel of the color buffer; defaults to 8.
-        alpha_size = C.SDL_GL_ALPHA_SIZE,
+        alpha_size = c.SDL_GL_ALPHA_SIZE,
         /// The minimum number of bits for frame buffer size; defaults to 0.
-        buffer_size = C.SDL_GL_BUFFER_SIZE,
+        buffer_size = c.SDL_GL_BUFFER_SIZE,
         /// Whether the output is single or double buffered; defaults to double buffering on.
-        double_buffer = C.SDL_GL_DOUBLEBUFFER,
+        double_buffer = c.SDL_GL_DOUBLEBUFFER,
         /// The minimum number of bits in the depth buffer; defaults to 16.
-        depth_size = C.SDL_GL_DEPTH_SIZE,
+        depth_size = c.SDL_GL_DEPTH_SIZE,
         /// The minimum number of bits in the stencil buffer; defaults to 0.
-        stencil_size = C.SDL_GL_STENCIL_SIZE,
+        stencil_size = c.SDL_GL_STENCIL_SIZE,
         /// The minimum number of bits for the red channel of the accumulation buffer; defaults to 0.
-        accum_red_size = C.SDL_GL_ACCUM_RED_SIZE,
+        accum_red_size = c.SDL_GL_ACCUM_RED_SIZE,
         /// The minimum number of bits for the green channel of the accumulation buffer; defaults to 0.
-        accum_green_size = C.SDL_GL_ACCUM_GREEN_SIZE,
+        accum_green_size = c.SDL_GL_ACCUM_GREEN_SIZE,
         /// The minimum number of bits for the blue channel of the accumulation buffer; defaults to 0.
-        accum_blue_size = C.SDL_GL_ACCUM_BLUE_SIZE,
+        accum_blue_size = c.SDL_GL_ACCUM_BLUE_SIZE,
         /// The minimum number of bits for the alpha channel of the accumulation buffer; defaults to 0.
-        accum_alpha_size = C.SDL_GL_ACCUM_ALPHA_SIZE,
+        accum_alpha_size = c.SDL_GL_ACCUM_ALPHA_SIZE,
         /// Whether the output is stereo 3D; defaults to off.
-        stereo = C.SDL_GL_STEREO,
+        stereo = c.SDL_GL_STEREO,
         /// The number of buffers used for multisample anti-aliasing; defaults to 0.
-        multi_sample_buffers = C.SDL_GL_MULTISAMPLEBUFFERS,
+        multi_sample_buffers = c.SDL_GL_MULTISAMPLEBUFFERS,
         /// The number of samples used around the current pixel used for multisample anti-aliasing.
-        multi_sample_samples = C.SDL_GL_MULTISAMPLESAMPLES,
+        multi_sample_samples = c.SDL_GL_MULTISAMPLESAMPLES,
         /// Set to 1 to require hardware acceleration, set to 0 to force software rendering; defaults to allow either.
-        accelerated_visual = C.SDL_GL_ACCELERATED_VISUAL,
+        accelerated_visual = c.SDL_GL_ACCELERATED_VISUAL,
         /// Not used (deprecated).
-        retained_backing = C.SDL_GL_RETAINED_BACKING,
+        retained_backing = c.SDL_GL_RETAINED_BACKING,
         /// OpenGL context major version.
-        context_major_version = C.SDL_GL_CONTEXT_MAJOR_VERSION,
+        context_major_version = c.SDL_GL_CONTEXT_MAJOR_VERSION,
         /// OpenGL context minor version.
-        context_minor_version = C.SDL_GL_CONTEXT_MINOR_VERSION,
+        context_minor_version = c.SDL_GL_CONTEXT_MINOR_VERSION,
         /// Some combination of 0 or more of elements of the `video.gl.ContextFlag` enumeration; defaults to 0.
-        context_flags = C.SDL_GL_CONTEXT_FLAGS,
+        context_flags = c.SDL_GL_CONTEXT_FLAGS,
         /// Type of GL context (Core, Compatibility, ES). See `video.gl.Profile`; default value depends on platform.
-        context_profile_mask = C.SDL_GL_CONTEXT_PROFILE_MASK,
+        context_profile_mask = c.SDL_GL_CONTEXT_PROFILE_MASK,
         /// OpenGL context sharing; defaults to 0.
-        share_with_current_context = C.SDL_GL_SHARE_WITH_CURRENT_CONTEXT,
+        share_with_current_context = c.SDL_GL_SHARE_WITH_CURRENT_CONTEXT,
         /// Requests sRGB capable visual; defaults to 0.
-        framebuffer_srgb_capable = C.SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
+        framebuffer_srgb_capable = c.SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
         /// Sets context the release behavior. See `video.gl.ContextReleaseFlag`; defaults to flush.
-        context_release_behavior = C.SDL_GL_CONTEXT_RELEASE_BEHAVIOR,
+        context_release_behavior = c.SDL_GL_CONTEXT_RELEASE_BEHAVIOR,
         /// Set context reset notification. See `video.gl.ContextResetNotification`; defaults to no_notification.
-        context_reset_notification = C.SDL_GL_CONTEXT_RESET_NOTIFICATION,
-        context_no_error = C.SDL_GL_CONTEXT_NO_ERROR,
-        float_buffers = C.SDL_GL_FLOATBUFFERS,
-        egl_platform = C.SDL_GL_EGL_PLATFORM,
+        context_reset_notification = c.SDL_GL_CONTEXT_RESET_NOTIFICATION,
+        context_no_error = c.SDL_GL_CONTEXT_NO_ERROR,
+        float_buffers = c.SDL_GL_FLOATBUFFERS,
+        egl_platform = c.SDL_GL_EGL_PLATFORM,
     };
 
     /// Possible values to be set for the `video.gl.Attribute.context_profile_mask`.
@@ -758,11 +757,11 @@ pub const gl = struct {
     /// This datatype is available since SDL 3.2.0.
     pub const Profile = enum(u32) {
         /// OpenGL core profile - deprecated functions are disabled.
-        core = @intCast(C.SDL_GL_CONTEXT_PROFILE_CORE),
+        core = @intCast(c.SDL_GL_CONTEXT_PROFILE_CORE),
         /// OpenGL compatibility profile - deprecated functions are allowed.
-        compatibility = @intCast(C.SDL_GL_CONTEXT_PROFILE_COMPATIBILITY),
+        compatibility = @intCast(c.SDL_GL_CONTEXT_PROFILE_COMPATIBILITY),
         /// OpenGL ES profile - only a subset of the base OpenGL functionality is available.
-        es = @intCast(C.SDL_GL_CONTEXT_PROFILE_ES),
+        es = @intCast(c.SDL_GL_CONTEXT_PROFILE_ES),
     };
 
     /// Swap interval.
@@ -783,7 +782,7 @@ pub const gl = struct {
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
     pub const Context = struct {
-        value: *C.SDL_GLContextState,
+        value: *c.SDL_GLContextState,
 
         /// Create an OpenGL context for an OpenGL window, and make it current.
         ///
@@ -804,9 +803,9 @@ pub const gl = struct {
         /// TODO!!!
         pub fn init(
             window: Window,
-        ) !gl.Context { 
-            const ret = C.SDL_GL_CreateContext(window.value);
-            return .{ .value = try errors.wrapNull(*C.SDL_GLContextState, ret) };
+        ) !gl.Context {
+            const ret = c.SDL_GL_CreateContext(window.value);
+            return .{ .value = try errors.wrapNull(*c.SDL_GLContextState, ret) };
         }
 
         /// Delete an OpenGL context.
@@ -822,7 +821,7 @@ pub const gl = struct {
         pub fn deinit(
             self: gl.Context,
         ) bool {
-           return C.SDL_GL_DestroyContext(self.value);
+            return c.SDL_GL_DestroyContext(self.value);
         }
 
         /// Set up an OpenGL context for rendering into an OpenGL window.
@@ -839,10 +838,7 @@ pub const gl = struct {
             self: gl.Context,
             window: Window,
         ) !void {
-            const ret = C.SDL_GL_MakeCurrent(
-                window.value,
-                self.value
-            );
+            const ret = c.SDL_GL_MakeCurrent(window.value, self.value);
             try errors.wrapCallBool(ret);
         }
     };
@@ -851,30 +847,19 @@ pub const gl = struct {
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const ContextFlag = enum(u32) {
-        debug = @intCast(C.SDL_GL_CONTEXT_DEBUG_FLAG),
-        forward_compatible = @intCast(C.SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG),
-        robust_access = @intCast(C.SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG),
-        reset_isolation = @intCast(C.SDL_GL_CONTEXT_RESET_ISOLATION_FLAG) 
-    };
+    pub const ContextFlag = enum(u32) { debug = @intCast(c.SDL_GL_CONTEXT_DEBUG_FLAG), forward_compatible = @intCast(c.SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG), robust_access = @intCast(c.SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG), reset_isolation = @intCast(c.SDL_GL_CONTEXT_RESET_ISOLATION_FLAG) };
 
     /// Possible values to be set for the `video.gl.Attribute.context_release_behavior` attribute.
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const ContextReleaseFlag = enum(u32) {
-        none = @intCast(C.SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE),
-        flush = @intCast(C.SDL_GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH)
-    };
+    pub const ContextReleaseFlag = enum(u32) { none = @intCast(c.SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE), flush = @intCast(c.SDL_GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH) };
 
     /// Possible values to be set `video.gl.Attribute.context_reset_notification` attribute.
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const ContextResetNotification = enum(u32) {
-        no_notification = @intCast(C.SDL_GL_CONTEXT_RESET_NO_NOTIFICATION),
-        lose_context = @intCast(C.SDL_GL_CONTEXT_RESET_LOSE_CONTEXT)
-    };
+    pub const ContextResetNotification = enum(u32) { no_notification = @intCast(c.SDL_GL_CONTEXT_RESET_NO_NOTIFICATION), lose_context = @intCast(c.SDL_GL_CONTEXT_RESET_LOSE_CONTEXT) };
 
     /// Get the actual value for an attribute from the current context.
     ///
@@ -887,8 +872,8 @@ pub const gl = struct {
         attr: gl.Attribute,
     ) !u32 {
         var value: c_int = undefined;
-        const ret = C.SDL_GL_GetAttribute(@intFromEnum(attr), &value);
-        try errors.wrapCallBool(ret); 
+        const ret = c.SDL_GL_GetAttribute(@intFromEnum(attr), &value);
+        try errors.wrapCallBool(ret);
         return @intCast(value);
     }
 
@@ -900,8 +885,8 @@ pub const gl = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getCurrentContext() !gl.Context {
-        const ret = C.SDL_GL_GetCurrentContext();
-        return .{ .value = try errors.wrapNull(*C.SDL_GLContextState, ret) };
+        const ret = c.SDL_GL_GetCurrentContext();
+        return .{ .value = try errors.wrapNull(*c.SDL_GLContextState, ret) };
     }
 
     /// Get the currently active OpenGL window.
@@ -912,8 +897,8 @@ pub const gl = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getCurrentWindow() !Window {
-        const ret = C.SDL_GL_GetCurrentWindow();
-        return Window{ .value = try errors.wrapNull(*C.SDL_Window, ret) };
+        const ret = c.SDL_GL_GetCurrentWindow();
+        return Window{ .value = try errors.wrapNull(*c.SDL_Window, ret) };
     }
 
     /// Get an OpenGL function by name.
@@ -947,8 +932,8 @@ pub const gl = struct {
     /// This will ensure the proper calling convention is followed on platforms where this matters (Win32) thereby avoiding stack corruption.
     pub fn getProcAddress(
         proc: [:0]const u8,
-    ) *C.SDL_FunctionPointer {
-        return C.SDL_GL_GetProcAddress(proc);
+    ) *c.SDL_FunctionPointer {
+        return c.SDL_GL_GetProcAddress(proc);
     }
 
     /// Get the swap interval for the current OpenGL context.
@@ -963,7 +948,7 @@ pub const gl = struct {
     /// This function is available since SDL 3.2.0.
     pub fn getSwapInterval() !SwapInterval {
         var interval: c_int = undefined;
-        const ret = C.SDL_GL_GetSwapInterval(&interval);
+        const ret = c.SDL_GL_GetSwapInterval(&interval);
         try errors.wrapCallBool(ret);
         return @enumFromInt(interval);
     }
@@ -984,7 +969,7 @@ pub const gl = struct {
     pub fn loadLibrary(
         path: [:0]const u8,
     ) !void {
-        const ret = C.SDL_GL_LoadLibrary(path);
+        const ret = c.SDL_GL_LoadLibrary(path);
         try errors.wrapCallBool(ret);
     }
 
@@ -996,7 +981,7 @@ pub const gl = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn resetAttributes() void {
-        C.SDL_GL_ResetAttributes();
+        c.SDL_GL_ResetAttributes();
     }
 
     /// Set an OpenGL window attribute before window creation.
@@ -1014,7 +999,7 @@ pub const gl = struct {
         attr: gl.Attribute,
         value: u32,
     ) !void {
-        const ret = C.SDL_GL_SetAttribute(@intFromEnum(attr), @intCast(value));
+        const ret = c.SDL_GL_SetAttribute(@intFromEnum(attr), @intCast(value));
         try errors.wrapCallBool(ret);
     }
 
@@ -1039,7 +1024,7 @@ pub const gl = struct {
     pub fn setSwapInterval(
         interval: SwapInterval,
     ) !void {
-        const ret = C.SDL_GL_SetSwapInterval(@intFromEnum(interval));
+        const ret = c.SDL_GL_SetSwapInterval(@intFromEnum(interval));
         try errors.wrapCallBool(ret);
     }
 
@@ -1059,7 +1044,7 @@ pub const gl = struct {
     pub fn swapWindow(
         window: Window,
     ) !void {
-        const ret = C.SDL_GL_SwapWindow(window.value);
+        const ret = c.SDL_GL_SwapWindow(window.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -1071,7 +1056,7 @@ pub const gl = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn unloadLibrary() void {
-        C.SDL_GL_UnloadLibrary();
+        c.SDL_GL_UnloadLibrary();
     }
 };
 
@@ -1081,19 +1066,19 @@ pub const gl = struct {
 /// This enum is available since SDL 3.2.0.
 pub const FlashOperation = enum(c_uint) {
     /// Cancel any window flash state.
-    Cancel = C.SDL_FLASH_CANCEL,
+    Cancel = c.SDL_FLASH_CANCEL,
     /// Flash the window briefly to get attention
-    Briefly = C.SDL_FLASH_BRIEFLY,
+    Briefly = c.SDL_FLASH_BRIEFLY,
     /// Flash the window until it gets focus
-    UntilFocused = C.SDL_FLASH_UNTIL_FOCUSED,
+    UntilFocused = c.SDL_FLASH_UNTIL_FOCUSED,
 
     /// Convert from SDL.
-    pub fn fromSdl(val: C.SDL_FlashOperation) FlashOperation {
+    pub fn fromSdl(val: c.SDL_FlashOperation) FlashOperation {
         return @enumFromInt(val);
     }
 
     /// Convert to SDL.
-    pub fn toSdl(self: FlashOperation) C.SDL_FlashOperation {
+    pub fn toSdl(self: FlashOperation) c.SDL_FlashOperation {
         return @intFromEnum(self);
     }
 };
@@ -1105,14 +1090,14 @@ pub const FlashOperation = enum(c_uint) {
 ///
 /// ## Version
 /// This datatype is available since SDL 3.2.0.
-pub const WindowID = C.SDL_WindowID;
+pub const WindowID = c.SDL_WindowID;
 
 /// The struct used as an opaque handle to a window.
 ///
 /// ## Version
 /// This struct is available since SDL 3.2.0.
 pub const Window = packed struct {
-    value: *C.SDL_Window,
+    value: *c.SDL_Window,
 
     /// Supported properties for creating a window.
     ///
@@ -1205,71 +1190,71 @@ pub const Window = packed struct {
         ) !properties.Group {
             const ret = try properties.Group.init();
             if (self.always_on_top) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN, .{ .Boolean = val });
             if (self.borderless) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_BORDERLESS_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_BORDERLESS_BOOLEAN, .{ .Boolean = val });
             if (self.external_graphics_context) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_EXTERNAL_GRAPHICS_CONTEXT_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_EXTERNAL_GRAPHICS_CONTEXT_BOOLEAN, .{ .Boolean = val });
             if (self.focusable) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_FOCUSABLE_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_FOCUSABLE_BOOLEAN, .{ .Boolean = val });
             if (self.fullscreen) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN, .{ .Boolean = val });
             if (self.height) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, .{ .Number = @intCast(val) });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, .{ .Number = @intCast(val) });
             if (self.hidden) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_HIDDEN_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_HIDDEN_BOOLEAN, .{ .Boolean = val });
             if (self.high_pixel_density) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, .{ .Boolean = val });
             if (self.maximized) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_MAXIMIZED_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_MAXIMIZED_BOOLEAN, .{ .Boolean = val });
             if (self.menu) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_MENU_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_MENU_BOOLEAN, .{ .Boolean = val });
             if (self.metal) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_METAL_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_METAL_BOOLEAN, .{ .Boolean = val });
             if (self.minimized) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_MINIMIZED_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_MINIMIZED_BOOLEAN, .{ .Boolean = val });
             if (self.modal) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN, .{ .Boolean = val });
             if (self.mouse_grabbed) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN, .{ .Boolean = val });
             if (self.open_gl) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, .{ .Boolean = val });
             if (self.parent) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_PARENT_POINTER, .{ .Pointer = val.value });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_PARENT_POINTER, .{ .Pointer = val.value });
             if (self.resizable) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, .{ .Boolean = val });
             if (self.title) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_TITLE_STRING, .{ .String = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_TITLE_STRING, .{ .String = val });
             if (self.transparent) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_TRANSPARENT_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_TRANSPARENT_BOOLEAN, .{ .Boolean = val });
             if (self.tooltip) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_TOOLTIP_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_TOOLTIP_BOOLEAN, .{ .Boolean = val });
             if (self.utility) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_UTILITY_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_UTILITY_BOOLEAN, .{ .Boolean = val });
             if (self.vulkan) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_VULKAN_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_VULKAN_BOOLEAN, .{ .Boolean = val });
             if (self.width) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, .{ .Number = @intCast(val) });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, .{ .Number = @intCast(val) });
             if (self.x) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_X_NUMBER, .{ .Number = @intCast(val.toSdl()) });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_X_NUMBER, .{ .Number = @intCast(val.toSdl()) });
             if (self.y) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_Y_NUMBER, .{ .Number = @intCast(val.toSdl()) });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_Y_NUMBER, .{ .Number = @intCast(val.toSdl()) });
             if (self.cocoa_window) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_COCOA_WINDOW_POINTER, .{ .Pointer = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_COCOA_WINDOW_POINTER, .{ .Pointer = val });
             if (self.cocoa_view) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_COCOA_VIEW_POINTER, .{ .Pointer = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_COCOA_VIEW_POINTER, .{ .Pointer = val });
             if (self.wayland_surface_role_custom) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN, .{ .Boolean = val });
             if (self.wayland_create_egl_window) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_WAYLAND_CREATE_EGL_WINDOW_BOOLEAN, .{ .Boolean = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_WAYLAND_CREATE_EGL_WINDOW_BOOLEAN, .{ .Boolean = val });
             if (self.wayland_create_wl_surface) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_WAYLAND_WL_SURFACE_POINTER, .{ .Pointer = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_WAYLAND_WL_SURFACE_POINTER, .{ .Pointer = val });
             if (self.win32_hwnd) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_WIN32_HWND_POINTER, .{ .Pointer = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_WIN32_HWND_POINTER, .{ .Pointer = val });
             if (self.win32_pixel_format_hwnd) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER, .{ .Pointer = val });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER, .{ .Pointer = val });
             if (self.x11_window) |val|
-                ret.set(C.SDL_PROP_WINDOW_CREATE_X11_WINDOW_NUMBER, .{ .Number = @intCast(val) });
+                ret.set(c.SDL_PROP_WINDOW_CREATE_X11_WINDOW_NUMBER, .{ .Number = @intCast(val) });
             return ret;
         }
     };
@@ -1292,8 +1277,8 @@ pub const Window = packed struct {
         ) c_int {
             return switch (self) {
                 .absolute => |val| @intCast(val),
-                .centered => C.SDL_WINDOWPOS_CENTERED,
-                .undefined => C.SDL_WINDOWPOS_UNDEFINED,
+                .centered => c.SDL_WINDOWPOS_CENTERED,
+                .undefined => c.SDL_WINDOWPOS_UNDEFINED,
             };
         }
     };
@@ -1351,7 +1336,7 @@ pub const Window = packed struct {
         height: u32,
         flags: WindowFlags,
     ) !Window {
-        const ret = C.SDL_CreatePopupWindow(
+        const ret = c.SDL_CreatePopupWindow(
             self.value,
             @intCast(offset_x),
             @intCast(offset_y),
@@ -1359,7 +1344,7 @@ pub const Window = packed struct {
             @intCast(height),
             flags.toSdl(),
         );
-        return .{ .value = try errors.wrapNull(*C.SDL_Window, ret) };
+        return .{ .value = try errors.wrapNull(*c.SDL_Window, ret) };
     }
 
     /// Create a window with the specified dimensions and flags.
@@ -1445,13 +1430,13 @@ pub const Window = packed struct {
         height: u32,
         flags: WindowFlags,
     ) !Window {
-        const ret = C.SDL_CreateWindow(
+        const ret = c.SDL_CreateWindow(
             title,
             @intCast(width),
             @intCast(height),
             flags.toSdl(),
         );
-        return .{ .value = try errors.wrapNull(*C.SDL_Window, ret) };
+        return .{ .value = try errors.wrapNull(*c.SDL_Window, ret) };
     }
 
     /// Create a window with the specified properties.
@@ -1487,7 +1472,7 @@ pub const Window = packed struct {
         const group = try props.toProperties();
         errdefer group.deinit();
 
-        const window = try errors.wrapNull(*C.SDL_Window, C.SDL_CreateWindowWithProperties(group.value));
+        const window = try errors.wrapNull(*c.SDL_Window, c.SDL_CreateWindowWithProperties(group.value));
         return .{ .window = window, .properties = group };
     }
 
@@ -1510,7 +1495,7 @@ pub const Window = packed struct {
     pub fn deinit(
         self: Window,
     ) void {
-        C.SDL_DestroyWindow(self.value);
+        c.SDL_DestroyWindow(self.value);
     }
 
     /// Destroy the surface associated with the window.
@@ -1526,7 +1511,7 @@ pub const Window = packed struct {
     pub fn destroySurface(
         self: Window,
     ) !void {
-        const ret = C.SDL_DestroyWindowSurface(self.value);
+        const ret = c.SDL_DestroyWindowSurface(self.value);
         return errors.wrapCallBool(ret);
     }
 
@@ -1545,7 +1530,7 @@ pub const Window = packed struct {
         self: Window,
         operation: FlashOperation,
     ) !void {
-        const ret = C.SDL_FlashWindow(self.value, operation.toSdl());
+        const ret = c.SDL_FlashWindow(self.value, operation.toSdl());
         return errors.wrapCallBool(ret);
     }
 
@@ -1560,9 +1545,9 @@ pub const Window = packed struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn getGrabbed() ?Window {
-        return .{ .value = C.SDL_GetGrabbedWindow() orelse return null };
+        return .{ .value = c.SDL_GetGrabbedWindow() orelse return null };
     }
- 
+
     /// Get the size of a window's client area.
     ///
     /// ## Function Parameters
@@ -1581,7 +1566,7 @@ pub const Window = packed struct {
     ) !struct { min_aspect: f32, max_aspect: f32 } {
         var min_aspect: f32 = undefined;
         var max_aspect: f32 = undefined;
-        const ret = C.SDL_GetWindowAspectRatio(
+        const ret = c.SDL_GetWindowAspectRatio(
             self.value,
             &min_aspect,
             &max_aspect,
@@ -1617,7 +1602,7 @@ pub const Window = packed struct {
         var left: c_int = undefined;
         var bottom: c_int = undefined;
         var right: c_int = undefined;
-        const ret = C.SDL_GetWindowBordersSize(
+        const ret = c.SDL_GetWindowBordersSize(
             self.value,
             &top,
             &left,
@@ -1652,7 +1637,7 @@ pub const Window = packed struct {
     pub fn getDisplayScale(
         self: Window,
     ) !f32 {
-        const ret = C.SDL_GetWindowDisplayScale(self.value);
+        const ret = c.SDL_GetWindowDisplayScale(self.value);
         return errors.wrapCall(f32, ret, 0);
     }
 
@@ -1672,7 +1657,7 @@ pub const Window = packed struct {
     pub fn getFlags(
         self: Window,
     ) WindowFlags {
-        return WindowFlags.fromSdl(C.SDL_GetWindowFlags(self.value));
+        return WindowFlags.fromSdl(c.SDL_GetWindowFlags(self.value));
     }
 
     /// Get a window from a stored ID.
@@ -1694,8 +1679,8 @@ pub const Window = packed struct {
     pub fn fromID(
         id: WindowID,
     ) !Window {
-        const ret = C.SDL_GetWindowFromID(id);
-        return .{ .value = try errors.wrapNull(*C.SDL_Window, ret) };
+        const ret = c.SDL_GetWindowFromID(id);
+        return .{ .value = try errors.wrapNull(*c.SDL_Window, ret) };
     }
 
     /// Query the display mode to use when a window is visible at fullscreen.
@@ -1714,7 +1699,7 @@ pub const Window = packed struct {
     pub fn getFullscreenMode(
         self: Window,
     ) !DisplayMode {
-        const ret = C.SDL_GetWindowFullscreenMode(self.value);
+        const ret = c.SDL_GetWindowFullscreenMode(self.value);
         if (ret) |val| {
             return DisplayMode.fromSdl(val.*);
         }
@@ -1734,7 +1719,7 @@ pub const Window = packed struct {
     pub fn getID(
         self: Window,
     ) !WindowID {
-        const ret = C.SDL_GetWindowID(self.value);
+        const ret = c.SDL_GetWindowID(self.value);
         return errors.wrapCall(WindowID, ret, 0);
     }
 
@@ -1751,7 +1736,7 @@ pub const Window = packed struct {
     pub fn getKeyboardGrab(
         self: Window,
     ) bool {
-        return C.SDL_GetWindowKeyboardGrab(self.value);
+        return c.SDL_GetWindowKeyboardGrab(self.value);
     }
 
     /// Get the maximum size of a window's client area.
@@ -1766,7 +1751,7 @@ pub const Window = packed struct {
     ) struct { width: u32, height: u32 } {
         var width: c_int = undefined;
         var height: c_int = undefined;
-        const ret = C.SDL_GetWindowMaximumSize(self.value, &width, &height);
+        const ret = c.SDL_GetWindowMaximumSize(self.value, &width, &height);
         errors.wrapCallBool(ret);
         return .{ .width = @intCast(width), .height = @intCast(height) };
     }
@@ -1783,9 +1768,9 @@ pub const Window = packed struct {
     ) struct { width: u32, height: u32 } {
         var width: c_int = undefined;
         var height: c_int = undefined;
-        const ret = C.SDL_GetWindowMinimumSize(self.value, &width, &height);
+        const ret = c.SDL_GetWindowMinimumSize(self.value, &width, &height);
         errors.wrapCallBool(ret);
-        return .{ .width = @intCast(width), .height = @intCast(height) };        
+        return .{ .width = @intCast(width), .height = @intCast(height) };
     }
 
     /// Get a window's mouse grab mode.
@@ -1798,7 +1783,7 @@ pub const Window = packed struct {
     pub fn getMouseGrab(
         self: Window,
     ) bool {
-        return C.SDL_GetWindowMouseGrab(self.value);
+        return c.SDL_GetWindowMouseGrab(self.value);
     }
 
     /// Get the mouse confinement rectangle of a window.
@@ -1814,13 +1799,13 @@ pub const Window = packed struct {
     pub fn getMouseRect(
         self: Window,
     ) !rect.IRect {
-        const ret = C.SDL_GetWindowMouseRect(self.value);
-        return rect.IRect.fromSdl(errors.wrapCall(C.SDL_Rect, ret, null));
+        const ret = c.SDL_GetWindowMouseRect(self.value);
+        return rect.IRect.fromSdl(errors.wrapCall(c.SDL_Rect, ret, null));
     }
 
     /// Get the opacity of a window.
     ///
-    /// ## Return Value 
+    /// ## Return Value
     /// Returns the opacity, (0.0f - transparent, 1.0f - opaque).
     ///
     /// ## Remarks
@@ -1834,7 +1819,7 @@ pub const Window = packed struct {
     pub fn getOpacity(
         self: Window,
     ) !f32 {
-        const ret = C.SDL_GetWindowOpacity(self.value);
+        const ret = c.SDL_GetWindowOpacity(self.value);
         return try errors.wrapCall(f32, ret, -1);
     }
 
@@ -1851,7 +1836,7 @@ pub const Window = packed struct {
     pub fn getParent(
         self: Window,
     ) !Window {
-        const ret = C.SDL_GetWindowParent(self.value);
+        const ret = c.SDL_GetWindowParent(self.value);
         if (ret == null)
             return null;
         return .{ .value = ret };
@@ -1874,7 +1859,7 @@ pub const Window = packed struct {
     pub fn getPixelDensity(
         self: Window,
     ) !f32 {
-        const ret = C.SDL_GetWindowPixelDensity(self.value);
+        const ret = c.SDL_GetWindowPixelDensity(self.value);
         return try errors.wrapCall(f32, ret, 0);
     }
 
@@ -1888,7 +1873,7 @@ pub const Window = packed struct {
     pub fn getPixelFormat(
         self: Window,
     ) !pixels.Format {
-        const ret = C.SDL_GetWindowPixelFormat(self.value);
+        const ret = c.SDL_GetWindowPixelFormat(self.value);
         try errors.wrapCall(c_uint, ret, 0);
         return .{ .value = ret };
     }
@@ -1910,13 +1895,13 @@ pub const Window = packed struct {
     ) !struct { x: i32, height: i32 } {
         var x: c_int = undefined;
         var y: c_int = undefined;
-        const ret = C.SDL_GetWindowPosition(self.value, &x, &y);
+        const ret = c.SDL_GetWindowPosition(self.value, &x, &y);
         try errors.wrapCallBool(ret);
         return .{ .x = @intCast(x), .y = @intCast(y) };
     }
 
-        /// Get the size of the window's client area.
-    /// 
+    /// Get the size of the window's client area.
+    ///
     /// ## Return Value
     /// Returns the size of the window's client area.
     ///
@@ -1931,10 +1916,10 @@ pub const Window = packed struct {
     /// This function is available since SDL 3.2.0.
     pub fn getSize(
         self: Window,
-    ) !struct{ width: u32, height: u32 } {
+    ) !struct { width: u32, height: u32 } {
         var width: c_int = undefined;
         var height: c_int = undefined;
-        const ret = C.SDL_GetWindowSize(self.value, &width, &height);
+        const ret = c.SDL_GetWindowSize(self.value, &width, &height);
         try errors.wrapCallBool(ret);
         return .{ .width = @intCast(width), .height = @intCast(height) };
     }
@@ -1955,10 +1940,10 @@ pub const Window = packed struct {
     /// This function is available since SDL 3.2.0.
     pub fn getSizeInPixels(
         self: Window,
-    ) !struct{ width: u32, height: u32 } {
+    ) !struct { width: u32, height: u32 } {
         var width: c_int = undefined;
         var height: c_int = undefined;
-        const ret = C.SDL_GetWindowSizeInPixels(self.value, &width, &height);
+        const ret = c.SDL_GetWindowSizeInPixels(self.value, &width, &height);
         try errors.wrapCallBool(ret);
         return .{ .width = @intCast(width), .height = @intCast(height) };
     }
@@ -1984,10 +1969,10 @@ pub const Window = packed struct {
     pub fn getSurface(
         self: Window,
     ) !surface.Surface {
-        const ret = C.SDL_GetWindowSurface(self.value);
+        const ret = c.SDL_GetWindowSurface(self.value);
         if (ret == null)
             return error.SdlError;
-        
+
         return surface.Surface{ .value = ret };
     }
 
@@ -2001,7 +1986,7 @@ pub const Window = packed struct {
     pub fn hide(
         self: Window,
     ) !void {
-        const ret = C.SDL_HideWindow(self.value);
+        const ret = c.SDL_HideWindow(self.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2026,7 +2011,7 @@ pub const Window = packed struct {
     pub fn maximize(
         self: Window,
     ) !void {
-        const ret = C.SDL_MaximizeWindow(self.window);
+        const ret = c.SDL_MaximizeWindow(self.window);
         try errors.wrapCallBool(ret);
     }
 
@@ -2049,7 +2034,7 @@ pub const Window = packed struct {
     pub fn minimize(
         self: Window,
     ) !void {
-        const ret = C.SDL_MinimizeWindow(self.value);
+        const ret = c.SDL_MinimizeWindow(self.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2067,7 +2052,7 @@ pub const Window = packed struct {
     pub fn raise(
         self: Window,
     ) !void {
-        const ret = C.SDL_RaiseWindow(self.value);
+        const ret = c.SDL_RaiseWindow(self.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2091,9 +2076,9 @@ pub const Window = packed struct {
     pub fn restore(
         self: Window,
     ) !void {
-        const ret = C.SDL_RestoreWindow(self.value);
+        const ret = c.SDL_RestoreWindow(self.value);
         try errors.wrapCallBool(ret);
-    } 
+    }
 
     /// Set the window to always be above the others.
     ///
@@ -2109,7 +2094,7 @@ pub const Window = packed struct {
         self: Window,
         on_top: bool,
     ) !void {
-        const ret = C.SDL_SetWindowAlwaysOnTop(self.value, on_top);
+        const ret = c.SDL_SetWindowAlwaysOnTop(self.value, on_top);
         try errors.wrapCallBool(ret);
     }
 
@@ -2139,7 +2124,7 @@ pub const Window = packed struct {
         min_aspect: f32,
         max_aspect: f32,
     ) !void {
-        const ret = C.SDL_SetWindowAspectRatio(self.value, min_aspect, max_aspect);
+        const ret = c.SDL_SetWindowAspectRatio(self.value, min_aspect, max_aspect);
         try errors.wrapCallBool(ret);
     }
 
@@ -2160,7 +2145,7 @@ pub const Window = packed struct {
         self: Window,
         bordered: bool,
     ) !void {
-        const ret = C.SDL_SetWindowBordered(self.value, bordered);
+        const ret = c.SDL_SetWindowBordered(self.value, bordered);
         try errors.wrapCallBool(ret);
     }
 
@@ -2175,7 +2160,7 @@ pub const Window = packed struct {
         self: Window,
         focusable: bool,
     ) !void {
-        const ret = C.SDL_SetWindowFocusable(self.value, focusable);
+        const ret = c.SDL_SetWindowFocusable(self.value, focusable);
         try errors.wrapCallBool(ret);
     }
 
@@ -2199,12 +2184,12 @@ pub const Window = packed struct {
         self: Window,
         fullscreen: bool,
     ) !void {
-        const ret = C.SDL_SetWindowFullscreen(self.value, fullscreen);
+        const ret = c.SDL_SetWindowFullscreen(self.value, fullscreen);
         try errors.wrapCallBool(ret);
     }
 
     /// Set the display mode to use when a window is visible and fullscreen.
-    /// 
+    ///
     /// ## Remarks
     /// This only affects the display mode used when the window is fullscreen. To change the window size when the window is not fullscreen, use `video.Window.setSize()`.
     ///
@@ -2222,7 +2207,7 @@ pub const Window = packed struct {
         self: Window,
         mode: DisplayMode,
     ) !void {
-        const ret = C.SDL_SetWindowFullscreenMode(self.value, @constCast(&mode.toSdl()));
+        const ret = c.SDL_SetWindowFullscreenMode(self.value, @constCast(&mode.toSdl()));
         try errors.wrapCallBool(ret);
     }
 
@@ -2243,7 +2228,7 @@ pub const Window = packed struct {
         self: Window,
         icon: surface.Surface,
     ) !void {
-        const ret = C.SDL_SetWindowFullscreenMode(self.value, icon.value);
+        const ret = c.SDL_SetWindowFullscreenMode(self.value, icon.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2269,7 +2254,7 @@ pub const Window = packed struct {
         self: Window,
         grabbed: bool,
     ) !void {
-        const ret = C.SDL_SetWindowKeyboardGrab(self.value, grabbed);
+        const ret = c.SDL_SetWindowKeyboardGrab(self.value, grabbed);
         try errors.wrapCallBool(ret);
     }
 
@@ -2285,7 +2270,7 @@ pub const Window = packed struct {
         max_width: u32,
         max_height: u32,
     ) !void {
-        const ret = C.SDL_SetWindowMaximumSize(self.value, &@intCast(max_width), &@intCast(max_height));
+        const ret = c.SDL_SetWindowMaximumSize(self.value, &@intCast(max_width), &@intCast(max_height));
         try errors.wrapCallBool(ret);
     }
 
@@ -2301,7 +2286,7 @@ pub const Window = packed struct {
         min_width: u32,
         min_height: u32,
     ) !void {
-        const ret = C.SDL_SetWindowMinimumSize(self.value, &@intCast(min_width), &@intCast(min_height));
+        const ret = c.SDL_SetWindowMinimumSize(self.value, &@intCast(min_width), &@intCast(min_height));
         try errors.wrapCallBool(ret);
     }
 
@@ -2319,7 +2304,7 @@ pub const Window = packed struct {
         self: Window,
         modal: bool,
     ) !void {
-        const ret = C.SDL_SetWindowModal(self.value, modal);
+        const ret = c.SDL_SetWindowModal(self.value, modal);
         try errors.wrapCallBool(ret);
     }
 
@@ -2337,7 +2322,7 @@ pub const Window = packed struct {
         self: Window,
         grabbed: bool,
     ) !void {
-        const ret = C.SDL_SetWindowMouseGrab(self.value, grabbed);
+        const ret = c.SDL_SetWindowMouseGrab(self.value, grabbed);
         try errors.wrapCallBool(ret);
     }
 
@@ -2355,8 +2340,8 @@ pub const Window = packed struct {
         self: Window,
         area: ?rect.IRect,
     ) !void {
-        const area_sdl: ?C.SDL_Rect = if (area == null) null else area.?.toSdl();
-        const ret = C.SDL_SetWindowMouseRect(
+        const area_sdl: ?c.SDL_Rect = if (area == null) null else area.?.toSdl();
+        const ret = c.SDL_SetWindowMouseRect(
             self.value,
             if (area_sdl == null) null else &(area_sdl.?),
         );
@@ -2379,7 +2364,7 @@ pub const Window = packed struct {
         self: Window,
         opacity: f32,
     ) !void {
-        const ret = C.SDL_SetWindowOpacity(self.value, opacity);
+        const ret = c.SDL_SetWindowOpacity(self.value, opacity);
         try errors.wrapCallBool(ret);
     }
 
@@ -2408,7 +2393,7 @@ pub const Window = packed struct {
         self: Window,
         parent: ?Window,
     ) !void {
-        const ret = C.SDL_SetWindowParent(
+        const ret = c.SDL_SetWindowParent(
             self.value,
             if (parent == null) null or parent.?.value,
         );
@@ -2440,7 +2425,7 @@ pub const Window = packed struct {
         x: i32,
         y: i32,
     ) !void {
-        const ret = C.SDL_SetWindowPosition(
+        const ret = c.SDL_SetWindowPosition(
             self.value,
             @intCast(x),
             @intCast(y),
@@ -2465,7 +2450,7 @@ pub const Window = packed struct {
         self: Window,
         resizable: bool,
     ) !void {
-        const ret = C.SDL_SetWindowResizable(self.value, resizable);
+        const ret = c.SDL_SetWindowResizable(self.value, resizable);
         try errors.wrapCallBool(ret);
     }
 
@@ -2490,7 +2475,7 @@ pub const Window = packed struct {
         self: Window,
         shape: surface.Surface,
     ) !void {
-        const ret = C.SDL_SetWindowShape(self.value, shape.value);
+        const ret = c.SDL_SetWindowShape(self.value, shape.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2518,7 +2503,7 @@ pub const Window = packed struct {
         width: u32,
         height: u32,
     ) !void {
-        const ret = C.SDL_SetWindowSize(
+        const ret = c.SDL_SetWindowSize(
             self.value,
             @intCast(width),
             @intCast(height),
@@ -2540,7 +2525,7 @@ pub const Window = packed struct {
         self: Window,
         title: [:0]const u8,
     ) !void {
-        const ret = C.SDL_SetWindowTitle(self.value, title);
+        const ret = c.SDL_SetWindowTitle(self.value, title);
         try errors.wrapCallBool(ret);
     }
 
@@ -2554,7 +2539,7 @@ pub const Window = packed struct {
     pub fn show(
         self: Window,
     ) !void {
-        const ret = C.SDL_ShowWindow(self.value);
+        const ret = c.SDL_ShowWindow(self.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2576,7 +2561,7 @@ pub const Window = packed struct {
     pub fn sync(
         self: Window,
     ) !void {
-        const ret = C.SDL_SyncWindow(self.value);
+        const ret = c.SDL_SyncWindow(self.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2595,7 +2580,7 @@ pub const Window = packed struct {
     pub fn updateSurface(
         self: Window,
     ) !void {
-        const ret = C.SDL_UpdateWindowSurface(self.value);
+        const ret = c.SDL_UpdateWindowSurface(self.value);
         try errors.wrapCallBool(ret);
     }
 
@@ -2612,7 +2597,7 @@ pub const Window = packed struct {
     pub fn hasSurface(
         self: Window,
     ) bool {
-        return C.SDL_WindowHasSurface(self.value);
+        return c.SDL_WindowHasSurface(self.value);
     }
 };
 
@@ -2680,63 +2665,63 @@ pub const WindowFlags = struct {
     not_focusable: bool = false,
 
     /// Convert from an SDL value.
-    pub fn fromSdl(flags: C.SDL_WindowFlags) WindowFlags {
+    pub fn fromSdl(flags: c.SDL_WindowFlags) WindowFlags {
         return .{
-            .fullscreen = (flags & C.SDL_WINDOW_FULLSCREEN) != 0,
-            .open_gl = (flags & C.SDL_WINDOW_OPENGL) != 0,
-            .occluded = (flags & C.SDL_WINDOW_OCCLUDED) != 0,
-            .hidden = (flags & C.SDL_WINDOW_HIDDEN) != 0,
-            .borderless = (flags & C.SDL_WINDOW_BORDERLESS) != 0,
-            .resizable = (flags & C.SDL_WINDOW_RESIZABLE) != 0,
-            .minimized = (flags & C.SDL_WINDOW_MINIMIZED) != 0,
-            .maximized = (flags & C.SDL_WINDOW_MAXIMIZED) != 0,
-            .mouse_grabbed = (flags & C.SDL_WINDOW_MOUSE_GRABBED) != 0,
-            .input_focus = (flags & C.SDL_WINDOW_INPUT_FOCUS) != 0,
-            .mouse_focus = (flags & C.SDL_WINDOW_MOUSE_FOCUS) != 0,
-            .external = (flags & C.SDL_WINDOW_EXTERNAL) != 0,
-            .modal = (flags & C.SDL_WINDOW_MODAL) != 0,
-            .high_pixel_density = (flags & C.SDL_WINDOW_HIGH_PIXEL_DENSITY) != 0,
-            .mouse_capture = (flags & C.SDL_WINDOW_MOUSE_CAPTURE) != 0,
-            .mouse_relative_mode = (flags & C.SDL_WINDOW_MOUSE_RELATIVE_MODE) != 0,
-            .always_on_top = (flags & C.SDL_WINDOW_ALWAYS_ON_TOP) != 0,
-            .utility = (flags & C.SDL_WINDOW_UTILITY) != 0,
-            .tooltip = (flags & C.SDL_WINDOW_TOOLTIP) != 0,
-            .popup_menu = (flags & C.SDL_WINDOW_POPUP_MENU) != 0,
-            .keyboard_grabbed = (flags & C.SDL_WINDOW_KEYBOARD_GRABBED) != 0,
-            .vulkan = (flags & C.SDL_WINDOW_VULKAN) != 0,
-            .metal = (flags & C.SDL_WINDOW_METAL) != 0,
-            .transparent = (flags & C.SDL_WINDOW_TRANSPARENT) != 0,
-            .not_focusable = (flags & C.SDL_WINDOW_NOT_FOCUSABLE) != 0,
+            .fullscreen = (flags & c.SDL_WINDOW_FULLSCREEN) != 0,
+            .open_gl = (flags & c.SDL_WINDOW_OPENGL) != 0,
+            .occluded = (flags & c.SDL_WINDOW_OCCLUDED) != 0,
+            .hidden = (flags & c.SDL_WINDOW_HIDDEN) != 0,
+            .borderless = (flags & c.SDL_WINDOW_BORDERLESS) != 0,
+            .resizable = (flags & c.SDL_WINDOW_RESIZABLE) != 0,
+            .minimized = (flags & c.SDL_WINDOW_MINIMIZED) != 0,
+            .maximized = (flags & c.SDL_WINDOW_MAXIMIZED) != 0,
+            .mouse_grabbed = (flags & c.SDL_WINDOW_MOUSE_GRABBED) != 0,
+            .input_focus = (flags & c.SDL_WINDOW_INPUT_FOCUS) != 0,
+            .mouse_focus = (flags & c.SDL_WINDOW_MOUSE_FOCUS) != 0,
+            .external = (flags & c.SDL_WINDOW_EXTERNAL) != 0,
+            .modal = (flags & c.SDL_WINDOW_MODAL) != 0,
+            .high_pixel_density = (flags & c.SDL_WINDOW_HIGH_PIXEL_DENSITY) != 0,
+            .mouse_capture = (flags & c.SDL_WINDOW_MOUSE_CAPTURE) != 0,
+            .mouse_relative_mode = (flags & c.SDL_WINDOW_MOUSE_RELATIVE_MODE) != 0,
+            .always_on_top = (flags & c.SDL_WINDOW_ALWAYS_ON_TOP) != 0,
+            .utility = (flags & c.SDL_WINDOW_UTILITY) != 0,
+            .tooltip = (flags & c.SDL_WINDOW_TOOLTIP) != 0,
+            .popup_menu = (flags & c.SDL_WINDOW_POPUP_MENU) != 0,
+            .keyboard_grabbed = (flags & c.SDL_WINDOW_KEYBOARD_GRABBED) != 0,
+            .vulkan = (flags & c.SDL_WINDOW_VULKAN) != 0,
+            .metal = (flags & c.SDL_WINDOW_METAL) != 0,
+            .transparent = (flags & c.SDL_WINDOW_TRANSPARENT) != 0,
+            .not_focusable = (flags & c.SDL_WINDOW_NOT_FOCUSABLE) != 0,
         };
     }
 
     /// Convert to an SDL value.
-    pub fn toSdl(self: WindowFlags) C.SDL_WindowFlags {
-        return (if (self.fullscreen) @as(C.SDL_WindowFlags, C.SDL_WINDOW_FULLSCREEN) else 0) |
-            (if (self.open_gl) @as(C.SDL_WindowFlags, C.SDL_WINDOW_OPENGL) else 0) |
-            (if (self.occluded) @as(C.SDL_WindowFlags, C.SDL_WINDOW_OCCLUDED) else 0) |
-            (if (self.hidden) @as(C.SDL_WindowFlags, C.SDL_WINDOW_HIDDEN) else 0) |
-            (if (self.borderless) @as(C.SDL_WindowFlags, C.SDL_WINDOW_BORDERLESS) else 0) |
-            (if (self.resizable) @as(C.SDL_WindowFlags, C.SDL_WINDOW_RESIZABLE) else 0) |
-            (if (self.minimized) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MINIMIZED) else 0) |
-            (if (self.maximized) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MAXIMIZED) else 0) |
-            (if (self.mouse_grabbed) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MOUSE_GRABBED) else 0) |
-            (if (self.input_focus) @as(C.SDL_WindowFlags, C.SDL_WINDOW_INPUT_FOCUS) else 0) |
-            (if (self.mouse_focus) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MOUSE_FOCUS) else 0) |
-            (if (self.external) @as(C.SDL_WindowFlags, C.SDL_WINDOW_EXTERNAL) else 0) |
-            (if (self.modal) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MODAL) else 0) |
-            (if (self.high_pixel_density) @as(C.SDL_WindowFlags, C.SDL_WINDOW_HIGH_PIXEL_DENSITY) else 0) |
-            (if (self.mouse_capture) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MOUSE_CAPTURE) else 0) |
-            (if (self.mouse_relative_mode) @as(C.SDL_WindowFlags, C.SDL_WINDOW_MOUSE_RELATIVE_MODE) else 0) |
-            (if (self.always_on_top) @as(C.SDL_WindowFlags, C.SDL_WINDOW_ALWAYS_ON_TOP) else 0) |
-            (if (self.utility) @as(C.SDL_WindowFlags, C.SDL_WINDOW_UTILITY) else 0) |
-            (if (self.tooltip) @as(C.SDL_WindowFlags, C.SDL_WINDOW_TOOLTIP) else 0) |
-            (if (self.popup_menu) @as(C.SDL_WindowFlags, C.SDL_WINDOW_POPUP_MENU) else 0) |
-            (if (self.keyboard_grabbed) @as(C.SDL_WindowFlags, C.SDL_WINDOW_KEYBOARD_GRABBED) else 0) |
-            (if (self.vulkan) @as(C.SDL_WindowFlags, C.SDL_WINDOW_VULKAN) else 0) |
-            (if (self.metal) @as(C.SDL_WindowFlags, C.SDL_WINDOW_METAL) else 0) |
-            (if (self.transparent) @as(C.SDL_WindowFlags, C.SDL_WINDOW_TRANSPARENT) else 0) |
-            (if (self.not_focusable) @as(C.SDL_WindowFlags, C.SDL_WINDOW_NOT_FOCUSABLE) else 0) |
+    pub fn toSdl(self: WindowFlags) c.SDL_WindowFlags {
+        return (if (self.fullscreen) @as(c.SDL_WindowFlags, c.SDL_WINDOW_FULLSCREEN) else 0) |
+            (if (self.open_gl) @as(c.SDL_WindowFlags, c.SDL_WINDOW_OPENGL) else 0) |
+            (if (self.occluded) @as(c.SDL_WindowFlags, c.SDL_WINDOW_OCCLUDED) else 0) |
+            (if (self.hidden) @as(c.SDL_WindowFlags, c.SDL_WINDOW_HIDDEN) else 0) |
+            (if (self.borderless) @as(c.SDL_WindowFlags, c.SDL_WINDOW_BORDERLESS) else 0) |
+            (if (self.resizable) @as(c.SDL_WindowFlags, c.SDL_WINDOW_RESIZABLE) else 0) |
+            (if (self.minimized) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MINIMIZED) else 0) |
+            (if (self.maximized) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MAXIMIZED) else 0) |
+            (if (self.mouse_grabbed) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MOUSE_GRABBED) else 0) |
+            (if (self.input_focus) @as(c.SDL_WindowFlags, c.SDL_WINDOW_INPUT_FOCUS) else 0) |
+            (if (self.mouse_focus) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MOUSE_FOCUS) else 0) |
+            (if (self.external) @as(c.SDL_WindowFlags, c.SDL_WINDOW_EXTERNAL) else 0) |
+            (if (self.modal) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MODAL) else 0) |
+            (if (self.high_pixel_density) @as(c.SDL_WindowFlags, c.SDL_WINDOW_HIGH_PIXEL_DENSITY) else 0) |
+            (if (self.mouse_capture) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MOUSE_CAPTURE) else 0) |
+            (if (self.mouse_relative_mode) @as(c.SDL_WindowFlags, c.SDL_WINDOW_MOUSE_RELATIVE_MODE) else 0) |
+            (if (self.always_on_top) @as(c.SDL_WindowFlags, c.SDL_WINDOW_ALWAYS_ON_TOP) else 0) |
+            (if (self.utility) @as(c.SDL_WindowFlags, c.SDL_WINDOW_UTILITY) else 0) |
+            (if (self.tooltip) @as(c.SDL_WindowFlags, c.SDL_WINDOW_TOOLTIP) else 0) |
+            (if (self.popup_menu) @as(c.SDL_WindowFlags, c.SDL_WINDOW_POPUP_MENU) else 0) |
+            (if (self.keyboard_grabbed) @as(c.SDL_WindowFlags, c.SDL_WINDOW_KEYBOARD_GRABBED) else 0) |
+            (if (self.vulkan) @as(c.SDL_WindowFlags, c.SDL_WINDOW_VULKAN) else 0) |
+            (if (self.metal) @as(c.SDL_WindowFlags, c.SDL_WINDOW_METAL) else 0) |
+            (if (self.transparent) @as(c.SDL_WindowFlags, c.SDL_WINDOW_TRANSPARENT) else 0) |
+            (if (self.not_focusable) @as(c.SDL_WindowFlags, c.SDL_WINDOW_NOT_FOCUSABLE) else 0) |
             0;
     }
 };
@@ -2754,7 +2739,7 @@ pub const WindowFlags = struct {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn disableScreenSaver() !void {
-    const ret = C.SDL_DisableScreenSaver();
+    const ret = c.SDL_DisableScreenSaver();
     return errors.wrapCallBool(ret);
 }
 
@@ -2766,7 +2751,7 @@ pub fn disableScreenSaver() !void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn enableScreenSaver() !void {
-    const ret = C.SDL_EnableScreenSaver();
+    const ret = c.SDL_EnableScreenSaver();
     return errors.wrapCallBool(ret);
 }
 
@@ -2785,7 +2770,7 @@ pub fn enableScreenSaver() !void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getCurrentDriverName() ?[:0]const u8 {
-    const ret = C.SDL_GetCurrentVideoDriver();
+    const ret = c.SDL_GetCurrentVideoDriver();
     if (ret) |val|
         return std.mem.span(val);
     return null;
@@ -2806,8 +2791,8 @@ pub fn getCurrentDriverName() ?[:0]const u8 {
 /// This function is available since SDL 3.2.0.
 pub fn getDisplayForPoint(point: rect.IPoint) !Display {
     const c_point = point.toSdl();
-    const ret = C.SDL_GetDisplayForPoint(&c_point);
-    return .{ .value = try errors.wrapCall(C.SDL_DisplayID, ret, 0) };
+    const ret = c.SDL_GetDisplayForPoint(&c_point);
+    return .{ .value = try errors.wrapCall(c.SDL_DisplayID, ret, 0) };
 }
 
 /// Get the display primarily containing a rect.
@@ -2825,8 +2810,8 @@ pub fn getDisplayForPoint(point: rect.IPoint) !Display {
 /// This function is available since SDL 3.2.0.
 pub fn getDisplayForRect(space: rect.IRect) !Display {
     const c_rect = space.toSdl();
-    const ret = C.SDL_GetDisplayForRect(&c_rect);
-    return .{ .value = try errors.wrapCall(C.SDL_DisplayID, ret, 0) };
+    const ret = c.SDL_GetDisplayForRect(&c_rect);
+    return .{ .value = try errors.wrapCall(c.SDL_DisplayID, ret, 0) };
 }
 
 /// Get the display associated with a window.
@@ -2846,8 +2831,8 @@ pub fn getDisplayForRect(space: rect.IRect) !Display {
 /// ## Code Examples
 /// TODO!!!
 pub fn getDisplayForWindow(window: Window) !Display {
-    const ret = C.SDL_GetDisplayForWindow(window.value);
-    return .{ .value = try errors.wrapCall(C.SDL_DisplayID, ret, 0) };
+    const ret = c.SDL_GetDisplayForWindow(window.value);
+    return .{ .value = try errors.wrapCall(c.SDL_DisplayID, ret, 0) };
 }
 
 /// Get the number of video drivers compiled into SDL.
@@ -2861,7 +2846,7 @@ pub fn getDisplayForWindow(window: Window) !Display {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getNumDrivers() usize {
-    const ret = C.SDL_GetNumVideoDrivers();
+    const ret = c.SDL_GetNumVideoDrivers();
     return @intCast(ret);
 }
 
@@ -2876,8 +2861,8 @@ pub fn getNumDrivers() usize {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getSystemTheme() ?SystemTheme {
-    const ret = C.SDL_GetSystemTheme();
-    if (ret == C.SDL_SYSTEM_THEME_UNKNOWN)
+    const ret = c.SDL_GetSystemTheme();
+    if (ret == c.SDL_SYSTEM_THEME_UNKNOWN)
         return null;
     return @enumFromInt(ret);
 }
@@ -2904,7 +2889,7 @@ pub fn getSystemTheme() ?SystemTheme {
 pub fn getDriverName(
     index: usize,
 ) ?[:0]const u8 {
-    const ret = C.SDL_GetVideoDriver(
+    const ret = c.SDL_GetVideoDriver(
         @intCast(index),
     );
     if (ret == null)

--- a/src/video.zig
+++ b/src/video.zig
@@ -518,7 +518,7 @@ pub const egl = struct {
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const EglAttribArrayCallback = *const fn (user_data: ?*anyopaque) callconv(.C) [*c]EglAttrib;
+    pub const EglAttribArrayCallback = *const fn (user_data: ?*anyopaque) callconv(.c) [*c]EglAttrib;
 
     /// Opaque type for an EGL config.
     ///
@@ -562,7 +562,7 @@ pub const egl = struct {
     ///
     /// ## Version
     /// This datatype is available since SDL 3.2.0.
-    pub const EglIntArrayCallback = *const fn (user_data: ?*anyopaque, display: c.SDL_EGLDisplay, config: c.SDL_EGLConfig) callconv(.C) [*c]EglInt;
+    pub const EglIntArrayCallback = *const fn (user_data: ?*anyopaque, display: c.SDL_EGLDisplay, config: c.SDL_EGLConfig) callconv(.c) [*c]EglInt;
 
     /// Opaque type for an EGL surface.
     ///

--- a/src/vulkan.zig
+++ b/src/vulkan.zig
@@ -1,20 +1,20 @@
-const C = @import("c.zig").C;
+const c = @import("c.zig").c;
 const init = @import("init.zig");
 const errors = @import("errors.zig");
 const std = @import("std");
 const video = @import("video.zig");
 
 /// Allocation callbacks.
-pub const AllocationCallbacks = *const C.VkAllocationCallbacks;
+pub const AllocationCallbacks = *const c.VkAllocationCallbacks;
 
 /// Vulkan instance handle.
-pub const Instance = C.VkInstance;
+pub const Instance = c.VkInstance;
 
 /// Vulkan physical device handle.
-pub const PhysicalDevice = C.VkPhysicalDevice;
+pub const PhysicalDevice = c.VkPhysicalDevice;
 
 /// Vulkan surface handle.
-pub const SurfaceKHR = C.VkSurfaceKHR;
+pub const SurfaceKHR = c.VkSurfaceKHR;
 
 /// Vulkan surface.
 pub const Surface = struct {
@@ -39,7 +39,7 @@ pub const Surface = struct {
     /// ## Version
     /// This function is available since SDL 3.2.0.
     pub fn deinit(self: Surface) void {
-        C.SDL_Vulkan_DestroySurface(
+        c.SDL_Vulkan_DestroySurface(
             self.instance,
             self.surface,
             self.allocator,
@@ -73,8 +73,8 @@ pub const Surface = struct {
         instance: Instance,
         allocator: ?AllocationCallbacks,
     ) !Surface {
-        var surface: C.VkSurfaceKHR = undefined;
-        const ret = C.SDL_Vulkan_CreateSurface(
+        var surface: c.VkSurfaceKHR = undefined;
+        const ret = c.SDL_Vulkan_CreateSurface(
             window.value,
             instance,
             allocator,
@@ -110,7 +110,7 @@ pub const Surface = struct {
 /// TODO!!!
 pub fn getInstanceExtensions() ![]const [*:0]const u8 {
     var count: u32 = undefined;
-    const val = C.SDL_Vulkan_GetInstanceExtensions(&count);
+    const val = c.SDL_Vulkan_GetInstanceExtensions(&count);
     const ret = try errors.wrapCallCPtrConst([*c]const u8, val);
     return @as([*]const [*:0]const u8, @ptrCast(ret))[0..count];
 }
@@ -135,7 +135,7 @@ pub fn getPresentationSupport(
     physical_device: PhysicalDevice,
     queue_family_index: u32,
 ) bool {
-    return C.SDL_Vulkan_GetPresentationSupport(
+    return c.SDL_Vulkan_GetPresentationSupport(
         instance,
         physical_device,
         queue_family_index,
@@ -156,7 +156,7 @@ pub fn getPresentationSupport(
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn getVkGetInstanceProcAddr() !*const anyopaque {
-    const ret = C.SDL_Vulkan_GetVkGetInstanceProcAddr();
+    const ret = c.SDL_Vulkan_GetVkGetInstanceProcAddr();
     return errors.wrapNull(*const anyopaque, @ptrCast(ret));
 }
 
@@ -196,7 +196,7 @@ pub fn getVkGetInstanceProcAddr() !*const anyopaque {
 /// This function is available since SDL 3.2.0.
 pub fn loadLibrary(path: ?[:0]const u8) !void {
     const lib: [*c]const u8 = if (path) |val| val.ptr else null;
-    return errors.wrapCallBool(C.SDL_Vulkan_LoadLibrary(lib));
+    return errors.wrapCallBool(c.SDL_Vulkan_LoadLibrary(lib));
 }
 
 /// Unload the Vulkan library previously loaded by `vulkan.loadLibrary()`.
@@ -215,7 +215,7 @@ pub fn loadLibrary(path: ?[:0]const u8) !void {
 /// ## Version
 /// This function is available since SDL 3.2.0.
 pub fn unloadLibrary() void {
-    C.SDL_Vulkan_UnloadLibrary();
+    c.SDL_Vulkan_UnloadLibrary();
 }
 
 // Vulkan related testing.

--- a/template/src/main.zig
+++ b/template/src/main.zig
@@ -51,7 +51,7 @@ pub export fn SDL_AppInit(
     app_state: *?*anyopaque,
     arg_count: c_int,
     arg_values: [*][*:0]u8,
-) callconv(.C) sdl3.AppResult {
+) callconv(.c) sdl3.AppResult {
     return init(@ptrCast(app_state), arg_values[0..@intCast(arg_count)]) catch return .failure;
 }
 
@@ -107,7 +107,7 @@ pub export fn SDL_AppInit(
 /// This function is available since SDL 3.2.0.
 pub export fn SDL_AppIterate(
     app_state: ?*anyopaque,
-) callconv(.C) sdl3.AppResult {
+) callconv(.c) sdl3.AppResult {
     return iterate(@alignCast(@ptrCast(app_state))) catch return .failure;
 }
 
@@ -155,7 +155,7 @@ pub export fn SDL_AppIterate(
 pub export fn SDL_AppEvent(
     app_state: ?*anyopaque,
     event: *sdl3.c.SDL_Event,
-) callconv(.C) sdl3.AppResult {
+) callconv(.c) sdl3.AppResult {
     return eventHandler(@alignCast(@ptrCast(app_state)), sdl3.events.Event.fromSdl(event.*)) catch return .failure;
 }
 
@@ -200,7 +200,7 @@ pub export fn SDL_AppEvent(
 pub export fn SDL_AppQuit(
     app_state: ?*anyopaque,
     result: sdl3.AppResult,
-) callconv(.C) void {
+) callconv(.c) void {
     quit(@alignCast(@ptrCast(app_state)), result);
 }
 
@@ -264,7 +264,7 @@ fn sdlLog(
     category: c_int,
     priority: sdl3.c.SDL_LogPriority,
     message: [*c]const u8,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = user_data;
     const category_managed = sdl3.log.Category.fromSdl(category);
     const category_str: ?[]const u8 = if (category_managed) |val| switch (val.value) {


### PR DESCRIPTION
This PR if for closing [C Calling Convention #51](https://github.com/Gota7/zig-sdl3/issues/51).

Replacement was simple the only issue was in `src/pixels.zig` in the method `fn define4CC` as it the third parameter of the function has the name `c` conflicting with the namespace.
As such I changed the parameter names from `a`, `b`, `c`, and `d` to `c1`, `c2`, `c3`, and `c4` (short for character 1, character 2, etc. as specified in the method documentation).
