### PR TITLE
Fix getFullscreenModes memory leak

### DIFF
--- a/src/video.zig
+++ b/src/video.zig
@@ -352,6 +352,7 @@ pub const Display = packed struct {
     ) ![]DisplayMode {
         var count: c_int = undefined;
         const val = try errors.wrapCallCPtr([*c]c.SDL_DisplayMode, c.SDL_GetFullscreenDisplayModes(self.value, &count));
+        defer c.SDL_free(@ptrCast(val));
         var ret = try allocator.alloc(DisplayMode, @intCast(count));
         for (0..count) |ind| {
             ret[ind] = DisplayMode.fromSdl(val[ind].*);


### PR DESCRIPTION
In the `getFullscreenModes` method the pointer for the display modes, returned by the C SDL function, was not cleaned up after using it to create the equivalent zig structure, leading to a memory leak.