### PR TITLE
Fix spelling of "acquire" in method namese

### DIFF
--- a/gpu_examples/src/examples/basic_triangle.zig
+++ b/gpu_examples/src/examples/basic_triangle.zig
@@ -80,8 +80,8 @@ pub fn update(ctx: common.Context) !void {
 pub fn draw(ctx: common.Context) !void {
 
     // Get command buffer and swapchain texture.
-    const cmd_buf = try ctx.device.aquireCommandBuffer();
-    const swapchain_texture = try cmd_buf.waitAndAquireSwapchainTexture(ctx.window);
+    const cmd_buf = try ctx.device.acquireCommandBuffer();
+    const swapchain_texture = try cmd_buf.waitAndAcquireSwapchainTexture(ctx.window);
     if (swapchain_texture.texture) |texture| {
 
         // Start a render pass if the swapchain texture is available. Make sure to clear it.

--- a/gpu_examples/src/examples/basic_vertex_buffer.zig
+++ b/gpu_examples/src/examples/basic_vertex_buffer.zig
@@ -107,7 +107,7 @@ pub fn init() !common.Context {
     ctx.device.unmapTransferBuffer(transfer_buffer);
 
     // Upload transfer data to the vertex buffer.
-    const upload_cmd_buf = try ctx.device.aquireCommandBuffer();
+    const upload_cmd_buf = try ctx.device.acquireCommandBuffer();
     const copy_pass = upload_cmd_buf.beginCopyPass();
     copy_pass.uploadToBuffer(.{
         .transfer_buffer = transfer_buffer,
@@ -131,8 +131,8 @@ pub fn update(ctx: common.Context) !void {
 pub fn draw(ctx: common.Context) !void {
 
     // Get command buffer and swapchain texture.
-    const cmd_buf = try ctx.device.aquireCommandBuffer();
-    const swapchain_texture = try cmd_buf.waitAndAquireSwapchainTexture(ctx.window);
+    const cmd_buf = try ctx.device.acquireCommandBuffer();
+    const swapchain_texture = try cmd_buf.waitAndAcquireSwapchainTexture(ctx.window);
     if (swapchain_texture.texture) |texture| {
 
         // Start a render pass if the swapchain texture is available. Make sure to clear it.

--- a/gpu_examples/src/examples/clear_screen.zig
+++ b/gpu_examples/src/examples/clear_screen.zig
@@ -15,8 +15,8 @@ pub fn update(ctx: common.Context) !void {
 pub fn draw(ctx: common.Context) !void {
 
     // Get command buffer and swapchain texture.
-    const cmd_buf = try ctx.device.aquireCommandBuffer();
-    const swapchain_texture = try cmd_buf.waitAndAquireSwapchainTexture(ctx.window);
+    const cmd_buf = try ctx.device.acquireCommandBuffer();
+    const swapchain_texture = try cmd_buf.waitAndAcquireSwapchainTexture(ctx.window);
     if (swapchain_texture.texture) |texture| {
 
         // Start a render pass if the swapchain texture is available. Make sure to clear it.

--- a/gpu_examples/src/examples/clear_screen_multi.zig
+++ b/gpu_examples/src/examples/clear_screen_multi.zig
@@ -18,8 +18,8 @@ pub fn update(ctx: common.Context) !void {
 pub fn draw(ctx: common.Context) !void {
 
     // Get command buffer and swapchain texture.
-    const cmd_buf = try ctx.device.aquireCommandBuffer();
-    var swapchain_texture = try cmd_buf.waitAndAquireSwapchainTexture(ctx.window);
+    const cmd_buf = try ctx.device.acquireCommandBuffer();
+    var swapchain_texture = try cmd_buf.waitAndAcquireSwapchainTexture(ctx.window);
     if (swapchain_texture.texture) |texture| {
 
         // Start a render pass if the swapchain texture is available. Make sure to clear it.
@@ -32,7 +32,7 @@ pub fn draw(ctx: common.Context) !void {
         }, null);
         defer render_pass.end();
     }
-    swapchain_texture = try cmd_buf.waitAndAquireSwapchainTexture(window);
+    swapchain_texture = try cmd_buf.waitAndAcquireSwapchainTexture(window);
     if (swapchain_texture.texture) |texture| {
 
         // Start a render pass if the swapchain texture is available. Make sure to clear it.

--- a/src/camera.zig
+++ b/src/camera.zig
@@ -401,7 +401,7 @@ pub const Camera = packed struct {
     /// ## Remarks
     /// Let the back-end re-use the internal buffer for camera.
     ///
-    /// This function must be called only on surface objects returned by `camera.Camera.aquireFrame()`.
+    /// This function must be called only on surface objects returned by `camera.Camera.acquireFrame()`.
     /// This function should be called as quickly as possible after acquisition, as SDL keeps a small FIFO queue of surfaces for video frames;
     /// if surfaces aren't released in a timely manner, SDL may drop upcoming video frames from the camera.
     ///

--- a/src/gpu.zig
+++ b/src/gpu.zig
@@ -989,7 +989,7 @@ pub const CommandBuffer = packed struct {
     ///
     /// ## Version
     /// This function is available since SDL 3.2.0.
-    pub fn waitAndAquireSwapchainTexture(
+    pub fn waitAndAcquireSwapchainTexture(
         self: CommandBuffer,
         window: video.Window,
     ) !struct { texture: ?Texture, width: u32, height: u32 } {
@@ -1707,7 +1707,7 @@ pub const Device = packed struct {
     ///
     /// ## Version
     /// This function is available since SDL 3.2.0.
-    pub fn aquireCommandBuffer(
+    pub fn acquireCommandBuffer(
         self: Device,
     ) !CommandBuffer {
         return .{
@@ -1722,7 +1722,7 @@ pub const Device = packed struct {
     /// * `window`: An SDL window.
     ///
     /// ## Remarks
-    /// This must be called before `gpu.CommandBuffer.aquireSwapchainTexture()` is called using the window.
+    /// This must be called before `gpu.CommandBuffer.acquireSwapchainTexture()` is called using the window.
     /// You should only call this function from the thread that created the window.
     ///
     /// The swapchain will be created with `gpu.SwapChainComposition.sdr` and `gpu.PresentMode.vsync`.
@@ -2000,7 +2000,7 @@ pub const Device = packed struct {
     /// * `create_info`: A struct describing the state of the transfer buffer to create.
     ///
     /// ## Return Value
-    /// Returns a texture object.
+    /// Returns a transfer buffer on success.
     ///
     /// ## Remarks
     /// Download buffers can be particularly expensive to create, so it is good practice to reuse them if data will be downloaded regularly.


### PR DESCRIPTION
Just a simple PR to fix the verb "acquire" being spelt as "aquire" :)

Thanks for making the library!