### PR TITLE
Passing flags to catholm/SDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ const sdl3 = b.dependency("sdl3", .{
     //.preferred_linkage = .static,
     //.strip = false,
     //.sanitize_c = .off,
-    //.pic = true,
-    //.lto = .false,
+    //.lto = .none,
     //.emscripten_pthreads = false,
     //.install_build_config_h = false,
 });

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ const sdl3 = b.dependency("sdl3", .{
     .optimize = optimize,
     .callbacks = false,
     .ext_image = true,
+
+    // Options passed directly to https://github.com/castholm/SDL (SDL3 C Bindings)
+    //.preferred_linkage = .static,
+    //.strip = false,
+    //.sanitize_c = .off,
+    //.pic = true,
+    //.lto = .false,
+    //.emscripten_pthreads = false,
+    //.install_build_config_h = false,
 });
 ```
 Now add the modules and artifact to your target as you would normally:

--- a/build.zig
+++ b/build.zig
@@ -26,22 +26,21 @@ pub fn build(b: *std.Build) !void {
         bool,
         "c_sdl_strip",
         "Strip debug symbols (default: varies)",
-    ) orelse (optimize != .Debug);
+    ) orelse (optimize == .ReleaseSmall);
     const c_sdl_sanitize_c = b.option(
         enum { off, trap, full }, // TODO: Change to std.zig.SanitizeC after 0.15
         "c_sdl_sanitize_c",
         "Detect C undefined behavior (default: varies)",
-    ) orelse .off;
-    const c_sdl_pic = b.option(
-        bool,
-        "c_sdl_pic",
-        "Produce position-independent code (default: varies)",
-    ) orelse true;
+    ) orelse switch (optimize) {
+        .Debug => .full,
+        .ReleaseSafe => .trap,
+        .ReleaseFast, .ReleaseSmall => .off,
+    };
     const c_sdl_lto = b.option(
-        enum { true, false, none, full, thin }, // TODO: Change to std.zig.LtoMode after 0.15
+        enum { none, full, thin }, // TODO: Change to std.zig.LtoMode after 0.15
         "lto",
         "Perform link time optimization (default: false)",
-    ) orelse .false;
+    ) orelse .none;
     const c_sdl_emscripten_pthreads = b.option(
         bool,
         "c_sdl_emscripten_pthreads",
@@ -59,7 +58,6 @@ pub fn build(b: *std.Build) !void {
         .preferred_linkage = c_sdl_preferred_linkage,
         .strip = c_sdl_strip,
         .sanitize_c = c_sdl_sanitize_c,
-        .pic = if (c_sdl_preferred_linkage == .dynamic) true else c_sdl_pic,
         .lto = c_sdl_lto,
         .emscripten_pthreads = c_sdl_emscripten_pthreads,
         .install_build_config_h = c_sdl_install_build_config_h,

--- a/build.zig
+++ b/build.zig
@@ -26,17 +26,22 @@ pub fn build(b: *std.Build) !void {
         bool,
         "c_sdl_strip",
         "Strip debug symbols (default: varies)",
-    ) orelse (optimize == .Debug);
+    ) orelse (optimize != .Debug);
+    const c_sdl_sanitize_c = b.option(
+        enum { off, trap, full }, // TODO: Change to std.zig.SanitizeC after 0.15
+        "c_sdl_sanitize_c",
+        "Detect C undefined behavior (default: varies)",
+    ) orelse .off;
     const c_sdl_pic = b.option(
         bool,
         "c_sdl_pic",
-        "Produce position-independent code (default: true)",
+        "Produce position-independent code (default: varies)",
     ) orelse true;
     const c_sdl_lto = b.option(
-        bool,
-        "c_sdl_lto",
+        enum { true, false, none, full, thin }, // TODO: Change to std.zig.LtoMode after 0.15
+        "lto",
         "Perform link time optimization (default: false)",
-    ) orelse false;
+    ) orelse .false;
     const c_sdl_emscripten_pthreads = b.option(
         bool,
         "c_sdl_emscripten_pthreads",
@@ -53,6 +58,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
         .preferred_linkage = c_sdl_preferred_linkage,
         .strip = c_sdl_strip,
+        .sanitize_c = c_sdl_sanitize_c,
         .pic = if (c_sdl_preferred_linkage == .dynamic) true else c_sdl_pic,
         .lto = c_sdl_lto,
         .emscripten_pthreads = c_sdl_emscripten_pthreads,

--- a/build.zig
+++ b/build.zig
@@ -17,10 +17,48 @@ pub fn build(b: *std.Build) !void {
         },
     };
 
+    const c_sdl_preferred_linkage = b.option(
+        std.builtin.LinkMode,
+        "c_sdl_preferred_linkage",
+        "Prefer building statically or dynamically linked libraries (default: static)",
+    ) orelse .static;
+    const c_sdl_strip = b.option(
+        bool,
+        "c_sdl_strip",
+        "Strip debug symbols (default: varies)",
+    ) orelse (optimize == .Debug);
+    const c_sdl_pic = b.option(
+        bool,
+        "c_sdl_pic",
+        "Produce position-independent code (default: true)",
+    ) orelse true;
+    const c_sdl_lto = b.option(
+        bool,
+        "c_sdl_lto",
+        "Perform link time optimization (default: false)",
+    ) orelse false;
+    const c_sdl_emscripten_pthreads = b.option(
+        bool,
+        "c_sdl_emscripten_pthreads",
+        "Build with pthreads support when targeting Emscripten (default: false)",
+    ) orelse false;
+    const c_sdl_install_build_config_h = b.option(
+        bool,
+        "c_sdl_install_build_config_h",
+        "Additionally install 'SDL_build_config.h' when installing SDL (default: false)",
+    ) orelse false;
+
     const sdl_dep = b.dependency("sdl", .{
         .target = target,
         .optimize = optimize,
+        .preferred_linkage = c_sdl_preferred_linkage,
+        .strip = c_sdl_strip,
+        .pic = if (c_sdl_preferred_linkage == .dynamic) true else c_sdl_pic,
+        .lto = c_sdl_lto,
+        .emscripten_pthreads = c_sdl_emscripten_pthreads,
+        .install_build_config_h = c_sdl_install_build_config_h,
     });
+
     const sdl_dep_lib = sdl_dep.artifact("SDL3");
 
     const sdl_image_dep = b.dependency("sdl_image", .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .sdl = .{
-            .url = "https://github.com/castholm/SDL/archive/refs/tags/v0.2.3+3.2.14.zip",
-            .hash = "sdl-0.2.3+3.2.14-7uIn9BR5fgHLSuR3NxLrwhUENvEQwoNBeV2-johgGda_",
+            .url = "git+https://github.com/castholm/SDL.git#3ed62e53aecd9ffb28e44b9d35b7c09a8739e823",
+            .hash = "sdl-0.2.4+3.2.16-7uIn9DPhfgH29yAIJqHLc69hNb4IW0q-AngtKCFoT92b",
         },
         .sdl_image = .{
             .url = "git+https://github.com/allyourcodebase/SDL_image.git#f6a7beaf014dbc3696f29513172cab498e527adc",


### PR DESCRIPTION
This is an attempt to pass compilation flags directly to [castholm/SDL](https://github.com/castholm/SDL) raw SDL bindings for https://github.com/Gota7/zig-sdl3/issues/70

> [!WARNING]
> I am not very familiar with the Zig build system.
> Check this thoroughly before merging!

Initially I wanted to pass a struct for all the flags but apparently zig only allows primitives for build options.

I tried used the same defaults as the original library, with the exception of [`strip`, `pic`, `lto`].
I keep getting an error of `has unsupported type: ?bool`. (Even though in the `build.zig` of the raw bindings it seems to work without a default value)

Any tips on improving this are welcome.